### PR TITLE
Resolve issue when RAJA is built with ENABLE_TESTS=Off

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,6 +77,8 @@ install(DIRECTORY
   DESTINATION
   include)
 
+if(ENABLE_TESTS)
 enable_testing()
 add_subdirectory(test)
+endif()
 


### PR DESCRIPTION
@trws when we make a tarfile for the release using the script make_release_tarball.sh in RAJA/scripts, the contents of the camp/extern/googletest directory are missing. As a result, when users try to configure RAJA with ENABLE_TESTS=Off, Cmake fails. See 
https://github.com/LLNL/RAJA/issues/684. This PR is one potential fix. If you see a better way to do this, or a way to modify the 'make tarball' script in RAJA, I'm amenable to that.