### PR TITLE
Feature/hip

### DIFF
--- a/include/camp/defines.hpp
+++ b/include/camp/defines.hpp
@@ -14,6 +14,10 @@ http://github.com/llnl/camp
 #include <cstddef>
 #include <cstdint>
 
+#if defined(__HIPCC__)
+#include <hip/hip_runtime.h>
+#endif
+
 namespace camp
 {
 
@@ -49,6 +53,11 @@ namespace camp
 #else
 #define CAMP_SUPPRESS_HD_WARN _Pragma("nv_exec_check_disable")
 #endif
+
+#elif defined(__HIPCC__)
+#define CAMP_DEVICE __device__
+#define CAMP_HOST_DEVICE __host__ __device__
+#define CAMP_SUPPRESS_HD_WARN
 
 #else
 #define CAMP_DEVICE

--- a/include/camp/helpers.hpp
+++ b/include/camp/helpers.hpp
@@ -178,7 +178,7 @@ CAMP_HOST_DEVICE constexpr type::ref::rem<T>&& move(T&& t) noexcept
 template <typename T>
 CAMP_HOST_DEVICE void safe_swap(T& t1, T& t2)
 {
-#if defined(__CUDA_ARCH__)
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
   T temp{std::move(t1)};
   t1 = std::move(t2);
   t2 = std::move(temp);

--- a/include/camp/tuple.hpp
+++ b/include/camp/tuple.hpp
@@ -90,8 +90,11 @@ namespace internal
   struct tuple_storage {
     CAMP_HOST_DEVICE constexpr tuple_storage() : val(){};
 
-#if defined(__HIPCC__)
-    CAMP_HOST_DEVICE constexpr tuple_storage(Type v) : val(v) {}
+    /* Workaround for bug in hipcc compiler */
+    //  This likely causes issues when building with hip
+    //  and using tuples in host code. Will be patched in the future
+#if defined(__HIPCC__) && !defined(__HIP_DEVICE_COMPILE__)
+    CAMP_HOST_DEVICE constexpr tuple_storage(Type v) : val{v} {}
 #endif
 
     CAMP_SUPPRESS_HD_WARN
@@ -138,7 +141,10 @@ namespace internal
     {
     }
 
-#if defined(__HIPCC__)
+    /* Workaround for bug in hipcc compiler */
+    //  This likely causes issues when building with hip
+    //  and using tuples in host code. Will be patched in the future
+#if defined(__HIPCC__) && !defined(__HIP_DEVICE_COMPILE__)
     CAMP_HOST_DEVICE constexpr tuple_helper(Types... args)
         : tuple_storage<Indices, Types>(args)...
     {
@@ -224,8 +230,11 @@ public:
   {
   }
 
-#if defined(__HIPCC__)
-  CAMP_HOST_DEVICE constexpr tuple(Elements... vals) : base(vals...)
+  /* Workaround for bug in hipcc compiler */
+  //  This likely causes issues when building with hip
+  //  and using tuples in host code. Will be patched in the future
+#if defined(__HIPCC__) && !defined(__HIP_DEVICE_COMPILE__)
+  CAMP_HOST_DEVICE constexpr explicit tuple(Elements... vals) : base(vals...)
   {
   }
 #endif

--- a/include/camp/tuple.hpp
+++ b/include/camp/tuple.hpp
@@ -90,6 +90,10 @@ namespace internal
   struct tuple_storage {
     CAMP_HOST_DEVICE constexpr tuple_storage() : val(){};
 
+#if defined(__HIPCC__)
+    CAMP_HOST_DEVICE constexpr tuple_storage(Type v) : val(v) {}
+#endif
+
     CAMP_SUPPRESS_HD_WARN
     template <typename T>
     CAMP_HOST_DEVICE constexpr tuple_storage(T&& v)
@@ -134,12 +138,20 @@ namespace internal
     {
     }
 
+#if defined(__HIPCC__)
+    CAMP_HOST_DEVICE constexpr tuple_helper(Types... args)
+        : tuple_storage<Indices, Types>(args)...
+    {
+    }
+#endif
+
     template <typename... Args>
     CAMP_HOST_DEVICE constexpr tuple_helper(Args&&... args)
         : tuple_storage<Indices, Types>(std::forward<Args>(args))...
     {
     }
 
+    CAMP_HOST_DEVICE 
     tuple_helper& operator=(const tuple_helper& rhs) = default;
 
     template <typename RTuple>
@@ -211,6 +223,12 @@ public:
   CAMP_HOST_DEVICE constexpr tuple() : base()
   {
   }
+
+#if defined(__HIPCC__)
+  CAMP_HOST_DEVICE constexpr tuple(Elements... vals) : base(vals...)
+  {
+  }
+#endif
 
   CAMP_HOST_DEVICE constexpr tuple(tuple const& o) : base(o.base) {}
 


### PR DESCRIPTION
Adding support for AMD's HIP in camp. 

There is currently a compiler bug which causes link time errors when using camp::tuples. There is an imperfect work around in place, but it will likely cause issues using host-side reductions in RAJA. We're tracking this issue and will update when a fix has been implemented. 

