### PR TITLE
Renaming context.hpp to resource.hpp

### DIFF
--- a/include/camp/resource.hpp
+++ b/include/camp/resource.hpp
@@ -1,5 +1,15 @@
-#ifndef __CAMP_CONTEXT_HPP
-#define __CAMP_CONTEXT_HPP
+/*
+Copyright (c) 2016-18, Lawrence Livermore National Security, LLC.
+Produced at the Lawrence Livermore National Laboratory
+Maintained by Tom Scogland <scogland1@llnl.gov>
+CODE-756261, All rights reserved.
+This file is part of camp.
+For details about use and distribution, please read LICENSE and NOTICE from
+http://github.com/llnl/camp
+*/
+
+#ifndef __CAMP_RESOURCE_HPP
+#define __CAMP_RESOURCE_HPP
 
 #include <cstring>
 #include <memory>
@@ -104,4 +114,4 @@ namespace resources
   }  // namespace v1
 }  // namespace resources
 }  // namespace camp
-#endif /* __CAMP_CONTEXT_HPP */
+#endif /* __CAMP_RESOURCE_HPP */

--- a/include/camp/resource/cuda.hpp
+++ b/include/camp/resource/cuda.hpp
@@ -1,3 +1,13 @@
+/*
+Copyright (c) 2016-18, Lawrence Livermore National Security, LLC.
+Produced at the Lawrence Livermore National Laboratory
+Maintained by Tom Scogland <scogland1@llnl.gov>
+CODE-756261, All rights reserved.
+This file is part of camp.
+For details about use and distribution, please read LICENSE and NOTICE from
+http://github.com/llnl/camp
+*/
+
 #ifndef __CAMP_CUDA_HPP
 #define __CAMP_CUDA_HPP
 

--- a/include/camp/resource/event.hpp
+++ b/include/camp/resource/event.hpp
@@ -1,3 +1,13 @@
+/*
+Copyright (c) 2016-18, Lawrence Livermore National Security, LLC.
+Produced at the Lawrence Livermore National Laboratory
+Maintained by Tom Scogland <scogland1@llnl.gov>
+CODE-756261, All rights reserved.
+This file is part of camp.
+For details about use and distribution, please read LICENSE and NOTICE from
+http://github.com/llnl/camp
+*/
+
 #ifndef __CAMP_EVENT_HPP
 #define __CAMP_EVENT_HPP
 

--- a/include/camp/resource/hip.hpp
+++ b/include/camp/resource/hip.hpp
@@ -1,3 +1,13 @@
+/*
+Copyright (c) 2016-18, Lawrence Livermore National Security, LLC.
+Produced at the Lawrence Livermore National Laboratory
+Maintained by Tom Scogland <scogland1@llnl.gov>
+CODE-756261, All rights reserved.
+This file is part of camp.
+For details about use and distribution, please read LICENSE and NOTICE from
+http://github.com/llnl/camp
+*/
+
 #ifndef __CAMP_HIP_HPP
 #define __CAMP_HIP_HPP
 

--- a/include/camp/resource/host.hpp
+++ b/include/camp/resource/host.hpp
@@ -1,3 +1,13 @@
+/*
+Copyright (c) 2016-18, Lawrence Livermore National Security, LLC.
+Produced at the Lawrence Livermore National Laboratory
+Maintained by Tom Scogland <scogland1@llnl.gov>
+CODE-756261, All rights reserved.
+This file is part of camp.
+For details about use and distribution, please read LICENSE and NOTICE from
+http://github.com/llnl/camp
+*/
+
 #ifndef __CAMP_HOST_HPP
 #define __CAMP_HOST_HPP
 

--- a/include/camp/resource/platform.hpp
+++ b/include/camp/resource/platform.hpp
@@ -1,3 +1,13 @@
+/*
+Copyright (c) 2016-18, Lawrence Livermore National Security, LLC.
+Produced at the Lawrence Livermore National Laboratory
+Maintained by Tom Scogland <scogland1@llnl.gov>
+CODE-756261, All rights reserved.
+This file is part of camp.
+For details about use and distribution, please read LICENSE and NOTICE from
+http://github.com/llnl/camp
+*/
+
 #ifndef __CAMP_PLATFORM_HPP
 #define __CAMP_PLATFORM_HPP
 


### PR DESCRIPTION
Renaming context.hpp to resource.hpp to match namespace name.

Adds the copyright information to all of the resource files.