### PR TITLE
Resource preparation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,11 +4,11 @@ project (camp
   LANGUAGES CXX
   VERSION 0.1.0)
 
-option(ENABLE_CUDA "whether to build with cuda" Off CACHE BOOL)
-option(ENABLE_CLANG_CUDA "use clang cuda support rather than nvcc" Off CACHE BOOL)
-option(ENABLE_HIP "whether to build with hip" Off CACHE BOOL)
-option(ENABLE_TARGET_OPENMP "whether to build with OpenMP offload" Off CACHE BOOL)
-option(ENABLE_TESTS "whether to configure and build tests" On CACHE BOOL)
+option(ENABLE_CUDA "whether to build with cuda" Off)
+option(ENABLE_CLANG_CUDA "use clang cuda support rather than nvcc" Off)
+option(ENABLE_HIP "whether to build with hip" Off)
+option(ENABLE_TARGET_OPENMP "whether to build with OpenMP offload" Off)
+option(ENABLE_TESTS "whether to configure and build tests" On)
 
 if(ENABLE_CLANG_CUDA)
   if(NOT ${CMAKE_CXX_COMPILER_ID} STREQUAL Clang)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,8 +4,11 @@ project (camp
   LANGUAGES CXX
   VERSION 0.1.0)
 
-option(ENABLE_CUDA "whether to build with cuda" Off)
-option(ENABLE_CLANG_CUDA "use clang cuda support rather than nvcc" Off)
+option(ENABLE_CUDA "whether to build with cuda" Off CACHE BOOL)
+option(ENABLE_CLANG_CUDA "use clang cuda support rather than nvcc" Off CACHE BOOL)
+option(ENABLE_HIP "whether to build with hip" Off CACHE BOOL)
+option(ENABLE_TARGET_OPENMP "whether to build with OpenMP offload" Off CACHE BOOL)
+option(ENABLE_TESTS "whether to configure and build tests" On CACHE BOOL)
 
 if(ENABLE_CLANG_CUDA)
   if(NOT ${CMAKE_CXX_COMPILER_ID} STREQUAL Clang)

--- a/include/camp/defines.hpp
+++ b/include/camp/defines.hpp
@@ -74,7 +74,7 @@ namespace camp
 #endif
 
 #if _OPENMP >= 201307
-#define CAMP_HAVE_OMP_OFFLOAD
+#define CAMP_HAVE_OMP_OFFLOAD 1
 #endif
 
 #if defined(__has_builtin)

--- a/include/camp/defines.hpp
+++ b/include/camp/defines.hpp
@@ -50,7 +50,7 @@ namespace camp
 #if defined(__CUDACC__)
 #define CAMP_DEVICE __device__
 #define CAMP_HOST_DEVICE __host__ __device__
-#define CAMP_HAVE_CUDA
+#define CAMP_HAVE_CUDA 1
 
 #if defined(_WIN32)  // windows is non-compliant, yay
 #define CAMP_SUPPRESS_HD_WARN __pragma(nv_exec_check_disable)
@@ -63,12 +63,18 @@ namespace camp
 #define CAMP_HOST_DEVICE __host__ __device__
 #undef CAMP_HIP_HOST_DEVICE
 #define CAMP_HIP_HOST_DEVICE __host__ __device__
+#define CAMP_HAVE_HIP 1
+
 #define CAMP_SUPPRESS_HD_WARN
 
 #else
 #define CAMP_DEVICE
 #define CAMP_HOST_DEVICE
 #define CAMP_SUPPRESS_HD_WARN
+#endif
+
+#if _OPENMP >= 201307
+#define CAMP_HAVE_OMP_OFFLOAD
 #endif
 
 #if defined(__has_builtin)

--- a/include/camp/defines.hpp
+++ b/include/camp/defines.hpp
@@ -83,10 +83,6 @@ namespace camp
 #endif
 #endif
 
-#if defined(__HIPCC__)
-#define CAMP_HAVE_HIP
-#endif
-
 // Types
 using idx_t = std::ptrdiff_t;
 using nullptr_t = decltype(nullptr);

--- a/include/camp/resource.hpp
+++ b/include/camp/resource.hpp
@@ -20,6 +20,7 @@ http://github.com/llnl/camp
 #include "camp/resource/host.hpp"
 #include "camp/resource/cuda.hpp"
 #include "camp/resource/hip.hpp"
+#include "camp/resource/omp_target.hpp"
 
 namespace camp
 {
@@ -129,8 +130,14 @@ namespace resources
       using type = ::camp::resources::Hip;
     };
 #endif
+#if defined(CAMP_HAVE_OMP_OFFLOAD)
+template<>
+    struct resource_from_platform<Platform::omp_target>{
+      using type = ::camp::resources::Omp;
+    };
+#endif
 
-  }  // namespace v1
+}  // namespace v1
 }  // namespace resources
 }  // namespace camp
 #endif /* __CAMP_RESOURCE_HPP */

--- a/include/camp/resource.hpp
+++ b/include/camp/resource.hpp
@@ -111,6 +111,25 @@ namespace resources
       std::shared_ptr<ContextInterface> m_value;
     };
 
+    template<Platform p>
+    struct resource_from_platform;
+    template<>
+    struct resource_from_platform<Platform::host>{
+      using type = ::camp::resources::Host;
+    };
+#if defined(CAMP_HAVE_CUDA)
+    template<>
+    struct resource_from_platform<Platform::cuda>{
+      using type = ::camp::resources::Cuda;
+    };
+#endif
+#if defined(CAMP_HAVE_HIP)
+    template<>
+    struct resource_from_platform<Platform::hip>{
+      using type = ::camp::resources::Hip;
+    };
+#endif
+
   }  // namespace v1
 }  // namespace resources
 }  // namespace camp

--- a/include/camp/resource.hpp
+++ b/include/camp/resource.hpp
@@ -69,7 +69,7 @@ namespace resources
         m_value->memset(p, val, size);
       }
       Event get_event() { return m_value->get_event(); }
-      void wait_on(Event *e) { m_value->wait_on(e); }
+      void wait_for(Event *e) { m_value->wait_for(e); }
 
     private:
       class ContextInterface
@@ -82,7 +82,7 @@ namespace resources
         virtual void memcpy(void *dst, const void *src, size_t size) = 0;
         virtual void memset(void *p, int val, size_t size) = 0;
         virtual Event get_event() = 0;
-        virtual void wait_on(Event *e) = 0;
+        virtual void wait_for(Event *e) = 0;
       };
 
       template <typename T>
@@ -102,7 +102,7 @@ namespace resources
           m_modelVal.memset(p, val, size);
         }
         Event get_event() { return m_modelVal.get_event_erased(); }
-        void wait_on(Event *e) { m_modelVal.wait_on(e); }
+        void wait_for(Event *e) { m_modelVal.wait_for(e); }
         T* get() { return &m_modelVal; }
 
       private:

--- a/include/camp/resource/cuda.hpp
+++ b/include/camp/resource/cuda.hpp
@@ -82,11 +82,12 @@ namespace resources
       CudaEvent get_event() { return CudaEvent(get_stream()); }
       Event get_event_erased() { return Event{CudaEvent(get_stream())}; }
       void wait() { cudaStreamSynchronize(stream); }
-      void wait_on(Event *e)
+      void wait_for(Event *e)
       {
-        if (e->test_get<CudaEvent>()) {
+        auto *cuda_event = e->try_get<CudaEvent>();
+        if (cuda_event) {
           cudaStreamWaitEvent(get_stream(),
-                              e->get<CudaEvent>().getCudaEvent_t(),
+                              cuda_event->getCudaEvent_t(),
                               0);
         } else {
           e->wait();

--- a/include/camp/resource/cuda.hpp
+++ b/include/camp/resource/cuda.hpp
@@ -106,7 +106,7 @@ namespace resources
         this->memset(p, 0, size);
         return p;
       }
-      void free(void *p) { cudaFree(p); }
+      void deallocate(void *p) { cudaFree(p); }
       void memcpy(void *dst, const void *src, size_t size)
       {
         cudaMemcpyAsync(dst, src, size, cudaMemcpyDefault, stream);

--- a/include/camp/resource/cuda.hpp
+++ b/include/camp/resource/cuda.hpp
@@ -11,6 +11,7 @@ http://github.com/llnl/camp
 #ifndef __CAMP_CUDA_HPP
 #define __CAMP_CUDA_HPP
 
+#include "camp/defines.hpp"
 #include "camp/resource/event.hpp"
 #include "camp/resource/platform.hpp"
 

--- a/include/camp/resource/event.hpp
+++ b/include/camp/resource/event.hpp
@@ -32,19 +32,19 @@ namespace resources
       void wait() const { m_value->wait(); }
 
       template <typename T>
-      bool test_get()
+      T *try_get()
       {
         auto result = dynamic_cast<EventModel<T> *>(m_value.get());
-        return (result != nullptr);
+        return result->get();
       }
       template <typename T>
       T get()
       {
         auto result = dynamic_cast<EventModel<T> *>(m_value.get());
         if (result == nullptr) {
-          std::runtime_error("Incompatible Event type get cast.");
+          throw std::runtime_error("Incompatible Event type get cast.");
         }
-        return result->get();
+        return *result->get();
       }
 
     private:
@@ -63,7 +63,7 @@ namespace resources
         EventModel(T const &modelVal) : m_modelVal(modelVal) {}
         bool check() const override { return m_modelVal.check(); }
         void wait() const override { m_modelVal.wait(); }
-        T get() { return m_modelVal; }
+        T *get() { return &m_modelVal; }
 
       private:
         T m_modelVal;

--- a/include/camp/resource/hip.hpp
+++ b/include/camp/resource/hip.hpp
@@ -81,11 +81,12 @@ namespace resources
       HipEvent get_event() { return HipEvent(get_stream()); }
       Event get_event_erased() { return Event{HipEvent(get_stream())}; }
       void wait() { hipStreamSynchronize(stream); }
-      void wait_on(Event *e)
+      void wait_for(Event *e)
       {
-        if (e->test_get<HipEvent>()) {
+        auto *hip_event = e->try_get<HipEvent>();
+        if (hip_event) {
           hipStreamWaitEvent(get_stream(),
-                              e->get<HipEvent>().getHipEvent_t(),
+                              hip_event.getHipEvent_t(),
                               0);
         } else {
           e->wait();

--- a/include/camp/resource/hip.hpp
+++ b/include/camp/resource/hip.hpp
@@ -15,7 +15,7 @@ http://github.com/llnl/camp
 #include "camp/resource/platform.hpp"
 
 #ifdef CAMP_HAVE_HIP
-#include <hip/hip_runtime.hpp>
+#include <hip/hip_runtime.h>
 
 namespace camp
 {

--- a/include/camp/resource/hip.hpp
+++ b/include/camp/resource/hip.hpp
@@ -106,7 +106,7 @@ namespace resources
         this->memset(p, 0, size);
         return p;
       }
-      void free(void *p) { hipFree(p); }
+      void deallocate(void *p) { hipFree(p); }
       void memcpy(void *dst, const void *src, size_t size)
       {
         hipMemcpyAsync(dst, src, size, hipMemcpyDefault, stream);

--- a/include/camp/resource/host.hpp
+++ b/include/camp/resource/host.hpp
@@ -48,7 +48,7 @@ namespace resources
         return e;
       }
       void wait() {}
-      void wait_on(Event *e) { e->wait(); }
+      void wait_for(Event *e) { e->wait(); }
 
       // Memory
       template <typename T>

--- a/include/camp/resource/host.hpp
+++ b/include/camp/resource/host.hpp
@@ -32,7 +32,7 @@ namespace resources
     class Host
     {
     public:
-      Host() {}
+      Host(int /* group */ = -1) {}
 
       // Methods
       Platform get_platform() { return Platform::host; }

--- a/include/camp/resource/host.hpp
+++ b/include/camp/resource/host.hpp
@@ -62,7 +62,7 @@ namespace resources
         this->memset(p, 0, size);
         return p;
       }
-      void free(void *p) { free(p); }
+      void deallocate(void *p) { free(p); }
       void memcpy(void *dst, const void *src, size_t size) { memcpy(dst, src, size); }
       void memset(void *p, int val, size_t size) { std::memset(p, val, size); }
     };

--- a/include/camp/resource/omp_target.hpp
+++ b/include/camp/resource/omp_target.hpp
@@ -1,0 +1,186 @@
+/*
+Copyright (c) 2016-18, Lawrence Livermore National Security, LLC.
+Produced at the Lawrence Livermore National Laboratory
+Maintained by Tom Scogland <scogland1@llnl.gov>
+CODE-756261, All rights reserved.
+This file is part of camp.
+For details about use and distribution, please read LICENSE and NOTICE from
+http://github.com/llnl/camp
+*/
+
+#ifndef __CAMP_OMP_TARGET_HPP
+#define __CAMP_OMP_TARGET_HPP
+
+#include "camp/resource/event.hpp"
+#include "camp/resource/platform.hpp"
+
+#ifdef CAMP_HAVE_OMP_OFFLOAD
+#include <omp.h>
+#include <memory>
+#include <map>
+
+namespace camp
+{
+namespace resources
+{
+  inline namespace v1
+  {
+
+    class OmpEvent
+    {
+    public:
+      OmpEvent(char *addr_in, int device = omp_get_default_device())
+          : addr(addr_in), dev(device)
+      {
+#pragma omp target device(dev) depend(inout : addr_in[0]) nowait
+        {
+        }
+      }
+      bool check() const
+      {
+        // think up a way to do something better portably
+        return false;
+      }
+      void wait() const
+      {
+        char *local_addr = addr;
+        // if only we could use taskwait depend portably...
+#pragma omp task if (0) depend(inout : local_addr[0])
+        {
+        }
+      }
+      void *getEventAddr() const { return addr; }
+
+    private:
+      char *addr;
+      int dev;
+    };
+
+    class Omp
+    {
+      static char *get_addr(int num)
+      {
+        static char addrs[16] = {};
+        static int previous = 0;
+
+        static std::mutex m_mtx;
+
+        if (num < 0) {
+          m_mtx.lock();
+          previous = (previous + 1) % 16;
+          m_mtx.unlock();
+          return &addrs[previous];
+        }
+
+        return &addrs[num % 16];
+      }
+
+    public:
+      Omp(int group = -1, int device = omp_get_default_device())
+          : addr(get_addr(group)), dev(device)
+      {
+      }
+
+      // Methods
+      Platform get_platform() { return Platform::omp_target; }
+      static Omp &get_default()
+      {
+        static Omp o;
+        return o;
+      }
+      OmpEvent get_event() { return OmpEvent(addr, dev); }
+      Event get_event_erased() { return get_event(); }
+      void wait()
+      {
+        char *local_addr = addr;
+#pragma omp target device(dev) depend(inout : local_addr[0])
+        {
+        }
+      }
+      void wait_on(Event *e)
+      {
+        OmpEvent *oe = e->try_get<OmpEvent>();
+        if (oe) {
+          char *local_addr = addr;
+          char *other_addr = (char*)oe->getEventAddr();
+#pragma omp target depend(inout                \
+                          : local_addr[0]) depend(in: other_addr[0]) nowait
+          {
+          }
+        } else {
+          e->wait();
+        }
+      }
+
+      // Memory
+      template <typename T>
+      T *allocate(size_t size)
+      {
+        return static_cast<T*>(omp_target_alloc(sizeof(T) * size, dev));
+      }
+      void *calloc(size_t size)
+      {
+        void *p = allocate<char>(size);
+        this->memset(p, 0, size);
+        return p;
+      }
+      void deallocate(void *p)
+      {
+#pragma omp critical(camp_register_ptr)
+        {
+          dev_register.erase(p);
+        }
+        omp_target_free(p, dev);
+      }
+      void memcpy(void *dst, const void *src, size_t size)
+      {
+        // this is truly, insanely awful, need to think of something better
+        int dd = get_ptr_dev(dst);
+        int sd = get_ptr_dev(src);
+        // extra cast due to GCC openmp header bug
+        omp_target_memcpy(dst, (void*)src, size, 0, 0, dd, sd);
+      }
+      void memset(void *p, int val, size_t size)
+      {
+        char *local_addr = addr;
+        char *pc = (char*)p;
+#pragma omp target teams distribute parallel for device(dev) depend(inout      \
+                                                                    : local_addr[0]) \
+    nowait
+        for (size_t i = 0; i < size; ++i) {
+          pc[i] = val;
+        }
+      }
+
+      void register_ptr_dev(void *p, int device)
+      {
+#pragma omp critical(camp_register_ptr)
+        {
+          dev_register[p] = device;
+        }
+      }
+      int get_ptr_dev(void const *p)
+      {
+        int ret = omp_get_initial_device();
+#pragma omp critical(camp_register_ptr)
+        {
+          auto it = dev_register.find(p);
+          if (it != dev_register.end()) {
+            ret = it->second;
+          }
+        }
+        return ret;
+      }
+
+    private:
+      char *addr;
+      int dev;
+      static std::map<const void *, int> dev_register;
+    };
+
+  }  // namespace v1
+}  // namespace resources
+}  // namespace camp
+#endif  //#ifdef CAMP_HAVE_OMP_OFFLOAD
+
+#endif /* __CAMP_OMP_TARGET_HPP */

--- a/include/camp/resource/omp_target.hpp
+++ b/include/camp/resource/omp_target.hpp
@@ -97,7 +97,7 @@ namespace resources
         {
         }
       }
-      void wait_on(Event *e)
+      void wait_for(Event *e)
       {
         OmpEvent *oe = e->try_get<OmpEvent>();
         if (oe) {

--- a/include/camp/resource/platform.hpp
+++ b/include/camp/resource/platform.hpp
@@ -21,10 +21,9 @@ namespace resources
     enum class Platform {
       undefined = 0,
       host = 1,
-      omp = 2,
-      tbb = 4,
-      cuda = 8,
-      hip = 16
+      cuda = 2,
+      omp_target = 4,
+      hip = 8
     };
 
   }  // namespace v1

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -108,9 +108,7 @@ function(camp_add_test TESTNAME)
   endforeach()
 endfunction()
 
-if(ENABLE_CUDA)
-  camp_add_test(resource GTEST)
-endif()
+camp_add_test(resource GTEST)
 camp_add_test(tuple GTEST)
 
 camp_add_test(tuple_out_of_range RUN)

--- a/test/resource.cpp
+++ b/test/resource.cpp
@@ -19,6 +19,20 @@
 
 using namespace camp::resources;
 
+TEST(CampResource, Construct) { Resource h1{Host()}; }
+TEST(CampResource, ConvertFails)
+{
+  Resource h1{Host()};
+  ASSERT_THROW(h1.get<int>(), std::runtime_error);
+  ASSERT_FALSE(h1.try_get<int>());
+}
+TEST(CampResource, ConvertWorks)
+{
+  Resource h1{Host()};
+  ASSERT_TRUE(h1.try_get<Host>());
+  ASSERT_EQ(h1.get<Host>().get_platform(), Platform::host);
+}
+#if defined(CAMP_HAVE_CUDA)
 TEST(CampResource, Reassignment)
 {
   Context h1{Host()};
@@ -90,3 +104,4 @@ TEST(CampEvent, Get)
   ASSERT_EQ(typeid(host_event), typeid(pure_host_event));
   ASSERT_EQ(typeid(cuda_event), typeid(pure_cuda_event));
 }
+#endif

--- a/test/resource.cpp
+++ b/test/resource.cpp
@@ -13,31 +13,36 @@
 //
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 
+#include "camp/resource.hpp"
 #include "camp/camp.hpp"
 #include "gtest/gtest.h"
-#include "camp/resource.hpp"
 
 using namespace camp::resources;
+
+// compatible but different resource for conversion test
+struct Host2 : Host {
+};
 
 TEST(CampResource, Construct) { Resource h1{Host()}; }
 TEST(CampResource, ConvertFails)
 {
   Resource h1{Host()};
-  ASSERT_THROW(h1.get<int>(), std::runtime_error);
-  ASSERT_FALSE(h1.try_get<int>());
+  h1.get<Host>();
+  ASSERT_THROW(h1.get<Host2>(), std::runtime_error);
+  ASSERT_FALSE(h1.try_get<Host2>());
 }
 TEST(CampResource, GetPlatform)
 {
   ASSERT_EQ(Resource(Host()).get_platform(), Platform::host);
-  #ifdef CAMP_HAVE_CUDA
+#ifdef CAMP_HAVE_CUDA
   ASSERT_EQ(Resource(Cuda()).get_platform(), Platform::cuda);
-  #endif
-  #ifdef CAMP_HAVE_HIP
+#endif
+#ifdef CAMP_HAVE_HIP
   ASSERT_EQ(Resource(Hip()).get_platform(), Platform::hip);
-  #endif
-  #ifdef CAMP_HAVE_OMP_OFFLOAD
+#endif
+#ifdef CAMP_HAVE_OMP_OFFLOAD
   ASSERT_EQ(Resource(Omp()).get_platform(), Platform::omp_target);
-  #endif
+#endif
 }
 TEST(CampResource, ConvertWorks)
 {

--- a/test/resource.cpp
+++ b/test/resource.cpp
@@ -26,39 +26,42 @@ TEST(CampResource, ConvertFails)
   ASSERT_THROW(h1.get<int>(), std::runtime_error);
   ASSERT_FALSE(h1.try_get<int>());
 }
+TEST(CampResource, GetPlatform)
+{
+  ASSERT_EQ(Resource(Host()).get_platform(), Platform::host);
+  #ifdef CAMP_HAVE_CUDA
+  ASSERT_EQ(Resource(Cuda()).get_platform(), Platform::cuda);
+  #endif
+  #ifdef CAMP_HAVE_HIP
+  ASSERT_EQ(Resource(Hip()).get_platform(), Platform::cuda);
+  #endif
+}
 TEST(CampResource, ConvertWorks)
 {
   Resource h1{Host()};
   ASSERT_TRUE(h1.try_get<Host>());
   ASSERT_EQ(h1.get<Host>().get_platform(), Platform::host);
 }
+
 #if defined(CAMP_HAVE_CUDA)
 TEST(CampResource, Reassignment)
 {
-  Context h1{Host()};
-  Context c1{Cuda()};
+  Resource h1{Host()};
+  Resource c1{Cuda()};
   h1 = Cuda();
   ASSERT_EQ(typeid(c1), typeid(h1));
 
-  Context h2{Host()};
-  Context c2{Cuda()};
+  Resource h2{Host()};
+  Resource c2{Cuda()};
   c2 = Host();
   ASSERT_EQ(typeid(c2), typeid(h2));
 }
 
-TEST(CampResource, GetPlatform)
-{
-  Context dev_host{Host()};
-  Context dev_cuda{Cuda()};
-
-  ASSERT_EQ(dev_host.get_platform(), Platform::host);
-  ASSERT_EQ(dev_cuda.get_platform(), Platform::cuda);
-}
 
 TEST(CampResource, Get)
 {
-  Context dev_host{Host()};
-  Context dev_cuda{Cuda()};
+  Resource dev_host{Host()};
+  Resource dev_cuda{Cuda()};
 
   auto erased_host = dev_host.get<Host>();
   Host pure_host;
@@ -71,8 +74,8 @@ TEST(CampResource, Get)
 
 TEST(CampResource, GetEvent)
 {
-  Context h1{Host()};
-  Context c1{Cuda()};
+  Resource h1{Host()};
+  Resource c1{Cuda()};
 
   auto ev1 = h1.get_event();
   Event evh{HostEvent()};
@@ -87,8 +90,8 @@ TEST(CampResource, GetEvent)
 
 TEST(CampEvent, Get)
 {
-  Context h1{Host()};
-  Context c1{Cuda()};
+  Resource h1{Host()};
+  Resource c1{Cuda()};
 
   Event erased_host_event = h1.get_event();
   Event erased_cuda_event = c1.get_event();
@@ -100,6 +103,79 @@ TEST(CampEvent, Get)
   cudaStream_t s;
   cudaStreamCreate(&s);
   CudaEvent cuda_event(s);
+
+  ASSERT_EQ(typeid(host_event), typeid(pure_host_event));
+  ASSERT_EQ(typeid(cuda_event), typeid(pure_cuda_event));
+}
+#endif
+#if defined(CAMP_HAVE_HIP)
+TEST(CampResource, Reassignment)
+{
+  Resource h1{Host()};
+  Resource c1{Hip()};
+  h1 = Hip();
+  ASSERT_EQ(typeid(c1), typeid(h1));
+
+  Resource h2{Host()};
+  Resource c2{Hip()};
+  c2 = Host();
+  ASSERT_EQ(typeid(c2), typeid(h2));
+}
+
+TEST(CampResource, GetPlatform)
+{
+  Resource dev_host{Host()};
+  Resource dev_cuda{Hip()};
+
+  ASSERT_EQ(dev_host.get_platform(), Platform::host);
+  ASSERT_EQ(dev_cuda.get_platform(), Platform::hip);
+}
+
+TEST(CampResource, Get)
+{
+  Resource dev_host{Host()};
+  Resource dev_cuda{Hip()};
+
+  auto erased_host = dev_host.get<Host>();
+  Host pure_host;
+  ASSERT_EQ(typeid(erased_host), typeid(pure_host));
+
+  auto erased_cuda = dev_cuda.get<Hip>();
+  Hip pure_cuda;
+  ASSERT_EQ(typeid(erased_cuda), typeid(pure_cuda));
+}
+
+TEST(CampResource, GetEvent)
+{
+  Resource h1{Host()};
+  Resource c1{Hip()};
+
+  auto ev1 = h1.get_event();
+  Event evh{HostEvent()};
+  ASSERT_EQ(typeid(evh), typeid(ev1));
+
+  auto ev2 = c1.get_event();
+  hipStream_t s;
+  hipStreamCreate(&s);
+  Event evc{HipEvent(s)};
+  ASSERT_EQ(typeid(evc), typeid(ev2));
+}
+
+TEST(CampEvent, Get)
+{
+  Resource h1{Host()};
+  Resource c1{Hip()};
+
+  Event erased_host_event = h1.get_event();
+  Event erased_cuda_event = c1.get_event();
+
+  auto pure_host_event = erased_host_event.get<HostEvent>();
+  auto pure_cuda_event = erased_cuda_event.get<HipEvent>();
+
+  HostEvent host_event;
+  hipStream_t s;
+  hipStreamCreate(&s);
+  HipEvent cuda_event(s);
 
   ASSERT_EQ(typeid(host_event), typeid(pure_host_event));
   ASSERT_EQ(typeid(cuda_event), typeid(pure_cuda_event));

--- a/test/resource.cpp
+++ b/test/resource.cpp
@@ -33,7 +33,10 @@ TEST(CampResource, GetPlatform)
   ASSERT_EQ(Resource(Cuda()).get_platform(), Platform::cuda);
   #endif
   #ifdef CAMP_HAVE_HIP
-  ASSERT_EQ(Resource(Hip()).get_platform(), Platform::cuda);
+  ASSERT_EQ(Resource(Hip()).get_platform(), Platform::hip);
+  #endif
+  #ifdef CAMP_HAVE_OMP_OFFLOAD
+  ASSERT_EQ(Resource(Omp()).get_platform(), Platform::omp_target);
   #endif
 }
 TEST(CampResource, ConvertWorks)
@@ -120,15 +123,6 @@ TEST(CampResource, Reassignment)
   Resource c2{Hip()};
   c2 = Host();
   ASSERT_EQ(typeid(c2), typeid(h2));
-}
-
-TEST(CampResource, GetPlatform)
-{
-  Resource dev_host{Host()};
-  Resource dev_cuda{Hip()};
-
-  ASSERT_EQ(dev_host.get_platform(), Platform::host);
-  ASSERT_EQ(dev_cuda.get_platform(), Platform::hip);
 }
 
 TEST(CampResource, Get)


### PR DESCRIPTION
This is a collection of fixes to prepare the Resource types to be used as part of a generic allocation mechanism, and includes a helper (based heavily on what you were starting with @davidbeckingsale) for getting a resource type based on the platform value.

This should be enough to get going with to unify the cuda and hip paths of stuff.  There's some more to be done for me to consider this really "finished" though.

1. [ ] We don't have error handling or propagation on memcpy/memset in these, need a good way to handle it
2. [ ] Platform is weirding me out, we have enough to differentiate for the memory platforms for host cuda and hip, but resources need to work for TBB and openmp, and openmp offload too for that matter.  I think we may need to be able to differentiate between execution and memory space as a next-step, and would be interested in thoughts on this.

@rhornung67, @artv3, take a look here if you would.  @artv3, I think this solves all the external interface issues we talked about, let me know if I missed something.