### PR TITLE
add __host__ __device__ to defaulted hip constructors

### DIFF
--- a/include/camp/defines.hpp
+++ b/include/camp/defines.hpp
@@ -58,11 +58,13 @@ namespace camp
 #elif defined(__HIPCC__)
 #define CAMP_DEVICE __device__
 #define CAMP_HOST_DEVICE __host__ __device__
+#define CAMP_HIP_HOST_DEVICE __host__ __device__
 #define CAMP_SUPPRESS_HD_WARN
 
 #else
 #define CAMP_DEVICE
 #define CAMP_HOST_DEVICE
+#define CAMP_HIP_HOST_DEVICE
 #define CAMP_SUPPRESS_HD_WARN
 #endif
 

--- a/include/camp/defines.hpp
+++ b/include/camp/defines.hpp
@@ -44,6 +44,9 @@ namespace camp
 #define CAMP_CONSTEXPR14
 #endif
 
+// define host device macros
+#define CAMP_HIP_HOST_DEVICE
+
 #if defined(__CUDACC__)
 #define CAMP_DEVICE __device__
 #define CAMP_HOST_DEVICE __host__ __device__
@@ -58,13 +61,13 @@ namespace camp
 #elif defined(__HIPCC__)
 #define CAMP_DEVICE __device__
 #define CAMP_HOST_DEVICE __host__ __device__
+#undef CAMP_HIP_HOST_DEVICE
 #define CAMP_HIP_HOST_DEVICE __host__ __device__
 #define CAMP_SUPPRESS_HD_WARN
 
 #else
 #define CAMP_DEVICE
 #define CAMP_HOST_DEVICE
-#define CAMP_HIP_HOST_DEVICE
 #define CAMP_SUPPRESS_HD_WARN
 #endif
 

--- a/include/camp/tuple.hpp
+++ b/include/camp/tuple.hpp
@@ -125,12 +125,16 @@ namespace internal
   struct tuple_helper<camp::idx_seq<Indices...>, camp::list<Types...>>
       : public internal::tuple_storage<Indices, Types>... {
 
+    CAMP_HIP_HOST_DEVICE
     tuple_helper& operator=(const tuple_helper& rhs) = default;
 #if (!defined(__NVCC__))            \
-    || (__CUDACC_VER_MAJOR____ > 10 \
+    || (__CUDACC_VER_MAJOR__ > 10 \
         || (__CUDACC_VER_MAJOR__ == 10 && __CUDACC_VER_MINOR__ >= 1))
+    CAMP_HIP_HOST_DEVICE
     constexpr tuple_helper() = default;
+    CAMP_HIP_HOST_DEVICE
     constexpr tuple_helper(tuple_helper const&) = default;
+    CAMP_HIP_HOST_DEVICE
     constexpr tuple_helper(tuple_helper&&) = default;
 #else
     // NOTE: this is to work around nvcc 9 series issues with incorrect


### PR DESCRIPTION
The cuda model requires you not to have host/device notations on
defaulted constructors.  Apparently hip requires them to generate the
constructors on the device.  This commit adds a new macro so we can get
host/device only for HIP, and uses it to annotate defaulted constructors
on tuple_helper.