### PR TITLE
Detecting OMP 4.5 for CAMP_HAVE_OMP_OFFLOAD def

### DIFF
--- a/include/camp/defines.hpp
+++ b/include/camp/defines.hpp
@@ -74,7 +74,7 @@ namespace camp
 #define CAMP_SUPPRESS_HD_WARN
 #endif
 
-#if _OPENMP >= 201307
+#if _OPENMP >= 201511
 #define CAMP_HAVE_OMP_OFFLOAD 1
 #endif
 


### PR DESCRIPTION
Some builds (gcc <= 5?) in CHAI are failing because of the 'depend' and 'nowait' clauses in omp_targets.hpp . I think those are 4.5 features? Updating to this seems to fix those builds.