### PR TITLE
Fix clang-cuda warnings from CAMP_SUPPRESS_HD_WARN

### DIFF
--- a/include/camp/defines.hpp
+++ b/include/camp/defines.hpp
@@ -52,10 +52,14 @@ namespace camp
 #define CAMP_HOST_DEVICE __host__ __device__
 #define CAMP_HAVE_CUDA 1
 
+#if defined(__NVCC__)
 #if defined(_WIN32)  // windows is non-compliant, yay
 #define CAMP_SUPPRESS_HD_WARN __pragma(nv_exec_check_disable)
 #else
 #define CAMP_SUPPRESS_HD_WARN _Pragma("nv_exec_check_disable")
+#endif
+#else // only nvcc supports this pragma
+#define CAMP_SUPPRESS_HD_WARN
 #endif
 
 #elif defined(__HIPCC__)


### PR DESCRIPTION
Clang-cuda does not support the pragma used by nvcc to suppress host device warnings, don't use it with clang-cuda.