### PR TITLE
add list join and product helpers

### DIFF
--- a/include/camp/camp.hpp
+++ b/include/camp/camp.hpp
@@ -97,6 +97,21 @@ struct flatten<list<Elements...>>
     : detail::flatten_impl<list<>, sizeof...(Elements), Elements...> {
 };
 
+template <typename... Seqs>
+struct join;
+template <typename Seq1, typename Seq2, typename... Rest>
+struct join<Seq1, Seq2, Rest...> {
+      using type = typename join<typename extend<Seq1, Seq2>::type, Rest...>::type;
+};
+template <typename Seq1>
+struct join<Seq1> {
+      using type = Seq1;
+};
+template <>
+struct join<> {
+  using type = list<>;
+};
+
 template <template <typename...> class Op, typename T>
 struct transform;
 template <template <typename...> class Op, typename... Elements>
@@ -130,6 +145,25 @@ template <template <typename...> class Op,
 struct accumulate<Op, Initial, list<Elements...>> {
   using type = typename detail::accumulate_impl<Op, Initial, Elements...>::type;
 };
+
+
+namespace detail
+{
+  template<class, class>
+  struct product_impl{};
+  template<class... Xs, class... Ys>
+    struct product_impl<list<Xs...>, list<Ys...>> {
+      using type = list<list<Xs..., Ys>...>;
+    };
+  template<class, class>
+  struct product{};
+  template<class... Seqs, class... vals>
+    struct product<list<Seqs...>, list<vals...>> {
+      using type = typename join<typename product_impl<Seqs, list<vals...>>::type...>::type;
+    };
+} /* detail */ 
+template<class ... Seqs>
+using cartesian_product = typename accumulate<detail::product, list<list<>>, list<Seqs...>>::type;
 
 CAMP_MAKE_L(accumulate);
 

--- a/test/accumulate.cpp
+++ b/test/accumulate.cpp
@@ -3,3 +3,32 @@
 using namespace camp;
 CAMP_CHECK_TSAME((accumulate<append, list<>, list<int, float, double>>),
                  (list<int, float, double>));
+CAMP_CHECK_TSAME((cartesian_product<list<int>, list<float>>),
+                 (list<list<int, float>>));
+struct a;
+struct b;
+struct c;
+struct d;
+struct e;
+struct f;
+struct g;
+CAMP_CHECK_TSAME((cartesian_product<list<a, b>, list<c, d, e>>),
+                 (list<list<a, c>,
+                       list<a, d>,
+                       list<a, e>,
+                       list<b, c>,
+                       list<b, d>,
+                       list<b, e>>));
+CAMP_CHECK_TSAME((cartesian_product<list<a, b>, list<c, d, e>, list<f, g>>),
+                 (camp::list<camp::list<a, c, f>,
+                             camp::list<a, c, g>,
+                             camp::list<a, d, f>,
+                             camp::list<a, d, g>,
+                             camp::list<a, e, f>,
+                             camp::list<a, e, g>,
+                             camp::list<b, c, f>,
+                             camp::list<b, c, g>,
+                             camp::list<b, d, f>,
+                             camp::list<b, d, g>,
+                             camp::list<b, e, f>,
+                             camp::list<b, e, g>>));


### PR DESCRIPTION
First cut at support for cartesian product operation on camp lists.  The join operation is likely to be rather slow right now, but the interface should be stable.