### PR TITLE
fix windows warning by changing heterogeneous tuple assignment test t…

### DIFF
--- a/test/tuple.cpp
+++ b/test/tuple.cpp
@@ -19,11 +19,11 @@
 TEST(CampTuple, AssignCompat)
 {
   // Compatible, though different, tuples are assignable
-  const camp::tuple<long long, char> t(5, 'a');
+  const camp::tuple<int, char> t(5, 'a');
   ASSERT_EQ(camp::get<0>(t), 5);
   ASSERT_EQ(camp::get<1>(t), 'a');
 
-  camp::tagged_tuple<camp::list<int, char>, int, char> t2;
+  camp::tagged_tuple<camp::list<int, char>, long long, char> t2;
   t2 = t;
   ASSERT_EQ(camp::get<0>(t2), 5);
   ASSERT_EQ(camp::get<1>(t2), 'a');


### PR DESCRIPTION
…o assign from int to long long rather than the other way around.

This should take care of the warning that's killing your build @davidbeckingsale.