### PR TITLE
resource: fix copy construction bug

### DIFF
--- a/include/camp/resource.hpp
+++ b/include/camp/resource.hpp
@@ -14,13 +14,15 @@ http://github.com/llnl/camp
 #include <cstring>
 #include <memory>
 #include <mutex>
+#include <type_traits>
 
-#include "camp/resource/event.hpp"
-#include "camp/resource/platform.hpp"
-#include "camp/resource/host.hpp"
+#include "camp/helpers.hpp"
 #include "camp/resource/cuda.hpp"
+#include "camp/resource/event.hpp"
 #include "camp/resource/hip.hpp"
+#include "camp/resource/host.hpp"
 #include "camp/resource/omp_target.hpp"
+#include "camp/resource/platform.hpp"
 
 namespace camp
 {
@@ -32,13 +34,20 @@ namespace resources
     class Resource
     {
     public:
-      template <typename T>
+      Resource(Resource &&) = default;
+      Resource(Resource const &) = default;
+      Resource &operator=(Resource &&) = default;
+      Resource &operator=(Resource const &) = default;
+      template <typename T,
+                typename = typename std::enable_if<
+                    !std::is_same<typename std::decay<T>::type,
+                                  Resource>::value>::type>
       Resource(T &&value)
       {
-        m_value.reset(new ContextModel<T>(value));
+        m_value.reset(new ContextModel<type::ref::rem<T>>(forward<T>(value)));
       }
       template <typename T>
-      T* try_get()
+      T *try_get()
       {
         auto result = dynamic_cast<ContextModel<T> *>(m_value.get());
         return result ? result->get() : nullptr;
@@ -103,7 +112,7 @@ namespace resources
         }
         Event get_event() override { return m_modelVal.get_event_erased(); }
         void wait_for(Event *e) override { m_modelVal.wait_for(e); }
-        T* get() { return &m_modelVal; }
+        T *get() { return &m_modelVal; }
 
       private:
         T m_modelVal;
@@ -112,32 +121,32 @@ namespace resources
       std::shared_ptr<ContextInterface> m_value;
     };
 
-    template<Platform p>
+    template <Platform p>
     struct resource_from_platform;
-    template<>
-    struct resource_from_platform<Platform::host>{
+    template <>
+    struct resource_from_platform<Platform::host> {
       using type = ::camp::resources::Host;
     };
 #if defined(CAMP_HAVE_CUDA)
-    template<>
-    struct resource_from_platform<Platform::cuda>{
+    template <>
+    struct resource_from_platform<Platform::cuda> {
       using type = ::camp::resources::Cuda;
     };
 #endif
 #if defined(CAMP_HAVE_HIP)
-    template<>
-    struct resource_from_platform<Platform::hip>{
+    template <>
+    struct resource_from_platform<Platform::hip> {
       using type = ::camp::resources::Hip;
     };
 #endif
 #if defined(CAMP_HAVE_OMP_OFFLOAD)
-template<>
-    struct resource_from_platform<Platform::omp_target>{
+    template <>
+    struct resource_from_platform<Platform::omp_target> {
       using type = ::camp::resources::Omp;
     };
 #endif
 
-}  // namespace v1
+  }  // namespace v1
 }  // namespace resources
 }  // namespace camp
 #endif /* __CAMP_RESOURCE_HPP */

--- a/test/resource.cpp
+++ b/test/resource.cpp
@@ -14,6 +14,7 @@
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 
 #include "camp/resource.hpp"
+
 #include "camp/camp.hpp"
 #include "gtest/gtest.h"
 
@@ -24,6 +25,12 @@ struct Host2 : Host {
 };
 
 TEST(CampResource, Construct) { Resource h1{Host()}; }
+TEST(CampResource, Copy)
+{
+  Resource h1{Host()};
+  auto h2 = h1;
+  Resource h3 = h1;
+}
 TEST(CampResource, ConvertFails)
 {
   Resource h1{Host()};


### PR DESCRIPTION
We apparently had two bugs here, both caught by @rhornung67 with a new
case we somehow hadn't hit before.

1. The internal context was sometimes being constructed with a reference
   type when it should have been the bare type
2. The rvalue-reference constructor was being used even for copy
   construction, which made Resource try and wrap an already erased
   Resource.

Both of these were preventing copying and storing a Resource by value.
This should fix both issues, and adds a minimal test to ensure we don't
regress.

@rhornung67, any chance you could test this and see if it lets you work the way you want? The intention is these should be (relatively) cheaply copyable.  We may optimize out the shared_ptr to help that at some point but it's a convenient way to start out.