### PR TITLE
suppress unused warnings and only include omp_target and others if bu…

### DIFF
--- a/include/camp/defines.hpp
+++ b/include/camp/defines.hpp
@@ -21,6 +21,8 @@ http://github.com/llnl/camp
 namespace camp
 {
 
+#define CAMP_ALLOW_UNUSED_LOCAL(X) (void)X
+
 #if defined(__clang__)
 #define CAMP_COMPILER_CLANG
 #elif defined(__INTEL_COMPILER)

--- a/include/camp/resource.hpp
+++ b/include/camp/resource.hpp
@@ -17,11 +17,20 @@ http://github.com/llnl/camp
 #include <type_traits>
 
 #include "camp/helpers.hpp"
-#include "camp/resource/cuda.hpp"
 #include "camp/resource/event.hpp"
-#include "camp/resource/hip.hpp"
 #include "camp/resource/host.hpp"
+
+#if defined(CAMP_HAVE_CUDA)
+#include "camp/resource/cuda.hpp"
+#endif
+#if defined(CAMP_HAVE_HIP)
+#include "camp/resource/hip.hpp"
+#endif
+#if defined(CAMP_HAVE_OMP_OFFLOAD)
 #include "camp/resource/omp_target.hpp"
+#endif
+
+// last to ensure we don't hide breakage in the others
 #include "camp/resource/platform.hpp"
 
 namespace camp

--- a/include/camp/resource/omp_target.hpp
+++ b/include/camp/resource/omp_target.hpp
@@ -16,6 +16,7 @@ http://github.com/llnl/camp
 
 #ifdef CAMP_HAVE_OMP_OFFLOAD
 #include <omp.h>
+
 #include <map>
 #include <memory>
 
@@ -44,6 +45,7 @@ namespace resources
       void wait() const
       {
         char *local_addr = addr;
+        CAMP_ALLOW_UNUSED_LOCAL(local_addr);
         // if only we could use taskwait depend portably...
 #pragma omp task if (0) depend(inout : local_addr[0])
         {
@@ -93,6 +95,7 @@ namespace resources
       void wait()
       {
         char *local_addr = addr;
+        CAMP_ALLOW_UNUSED_LOCAL(local_addr);
 #pragma omp target device(dev) depend(inout : local_addr[0])
         {
         }
@@ -103,6 +106,8 @@ namespace resources
         if (oe) {
           char *local_addr = addr;
           char *other_addr = (char *)oe->getEventAddr();
+          CAMP_ALLOW_UNUSED_LOCAL(local_addr);
+          CAMP_ALLOW_UNUSED_LOCAL(other_addr);
 #pragma omp target depend(inout                      \
                           : local_addr[0]) depend(in \
                                                   : other_addr[0]) nowait
@@ -144,6 +149,7 @@ namespace resources
       void memset(void *p, int val, size_t size)
       {
         char *local_addr = addr;
+        CAMP_ALLOW_UNUSED_LOCAL(local_addr);
         char *pc = (char *)p;
 #pragma omp target teams distribute parallel for device(dev) \
     depend(inout                                             \


### PR DESCRIPTION
…ilding with them

This should fix the warnings you’ve been seeing two different ways @rhornung67.