### PR TITLE
Fixing unused var warning on nvcc

### DIFF
--- a/include/camp/defines.hpp
+++ b/include/camp/defines.hpp
@@ -21,7 +21,11 @@ http://github.com/llnl/camp
 namespace camp
 {
 
-#define CAMP_ALLOW_UNUSED_LOCAL(X) [&X]{}()
+#if defined(__NVCC__)
+#define CAMP_ALLOW_UNUSED_LOCAL(X) sink(X)
+#else
+#define CAMP_ALLOW_UNUSED_LOCAL(X) (void)(X)
+#endif
 
 #if defined(__clang__)
 #define CAMP_COMPILER_CLANG

--- a/include/camp/defines.hpp
+++ b/include/camp/defines.hpp
@@ -25,7 +25,6 @@ namespace camp
 #define CAMP_ALLOW_UNUSED_LOCAL(X) sink(X)
 #else
 #define CAMP_ALLOW_UNUSED_LOCAL(X) (void)(X)
-
 #endif
 
 #if defined(__clang__)

--- a/include/camp/defines.hpp
+++ b/include/camp/defines.hpp
@@ -25,6 +25,7 @@ namespace camp
 #define CAMP_ALLOW_UNUSED_LOCAL(X) sink(X)
 #else
 #define CAMP_ALLOW_UNUSED_LOCAL(X) (void)(X)
+
 #endif
 
 #if defined(__clang__)

--- a/include/camp/defines.hpp
+++ b/include/camp/defines.hpp
@@ -21,7 +21,7 @@ http://github.com/llnl/camp
 namespace camp
 {
 
-#define CAMP_ALLOW_UNUSED_LOCAL(X) (void)X
+#define CAMP_ALLOW_UNUSED_LOCAL(X) [&X]{}()
 
 #if defined(__clang__)
 #define CAMP_COMPILER_CLANG

--- a/include/camp/helpers.hpp
+++ b/include/camp/helpers.hpp
@@ -34,7 +34,7 @@ auto cval() noexcept -> decltype(std::declval<T const>());
 
 /// metafunction to expand a parameter pack and ignore result
 template <typename... Ts>
-CAMP_HOST_DEVICE void sink(Ts...)
+CAMP_HOST_DEVICE inline void sink(Ts const& ...)
 {
 }
 

--- a/include/camp/helpers.hpp
+++ b/include/camp/helpers.hpp
@@ -34,7 +34,11 @@ auto cval() noexcept -> decltype(std::declval<T const>());
 
 /// metafunction to expand a parameter pack and ignore result
 template <typename... Ts>
-CAMP_HOST_DEVICE inline void sink(Ts const& ...)
+CAMP_HOST_DEVICE
+#if (__cplusplus >= 201402L)
+constexpr
+#endif
+inline void sink(Ts const& ...)
 {
 }
 


### PR DESCRIPTION
CAMP_ALLOW_UNUSED_LOCAL was still returning unused variable warnings when compiling with cuda, this seems to hush nvcc up.