### PR TITLE
Add C++17 make_from_tuple for camp tuple

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,18 @@
+version: 1.0.{build}
+skip_branch_with_pr: true
+image: Visual Studio 2017
+build_script:
+- cmd: >-
+    git submodule init
+
+    git submodule update
+
+    mkdir build
+
+    cd build
+
+    cmake ../
+
+    cmake --build . --config Release
+test_script:
+- cmd: ctest -VV -C Release

--- a/include/camp/camp.hpp
+++ b/include/camp/camp.hpp
@@ -161,7 +161,7 @@ namespace detail
     struct product<list<Seqs...>, list<vals...>> {
       using type = typename join<typename product_impl<Seqs, list<vals...>>::type...>::type;
     };
-} /* detail */ 
+} /* detail */
 template<class ... Seqs>
 using cartesian_product = typename accumulate<detail::product, list<list<>>, list<Seqs...>>::type;
 

--- a/include/camp/defines.hpp
+++ b/include/camp/defines.hpp
@@ -104,6 +104,13 @@ namespace camp
 #endif
 #endif
 
+// libstdc++ from GCC below version 5 lacks the type trait
+#if defined(__GLIBCXX__) && __GLIBCXX__ < 20150422
+#define CAMP_HAS_IS_TRIVIALLY_COPY_CONSTRUCTIBLE 0
+#else
+#define CAMP_HAS_IS_TRIVIALLY_COPY_CONSTRUCTIBLE 1
+#endif
+
 // Types
 using idx_t = std::ptrdiff_t;
 using nullptr_t = decltype(nullptr);

--- a/include/camp/defines.hpp
+++ b/include/camp/defines.hpp
@@ -43,6 +43,16 @@ namespace camp
 #pragma warn("Unknown compiler!")
 #endif
 
+// detect empty_bases for MSVC
+#ifndef __has_declspec_attribute
+#define __has_declspec_attribute(__x) 0
+#endif
+#if defined(CAMP_COMPILER_MSVC) || __has_declspec_attribute(empty_bases)
+#define CAMP_EMPTY_BASES __declspec(empty_bases)
+#else
+#define CAMP_EMPTY_BASES
+#endif
+
 #if defined(__cpp_constexpr) && __cpp_constexpr >= 201304
 #define CAMP_HAS_CONSTEXPR14
 #define CAMP_CONSTEXPR14 constexpr

--- a/include/camp/helpers.hpp
+++ b/include/camp/helpers.hpp
@@ -25,10 +25,12 @@ template <typename T>
 T* declptr();
 
 /// metafunction to get instance of value type
+CAMP_HOST_DEVICE
 template <typename T>
 auto val() noexcept -> decltype(std::declval<T>());
 
 /// metafunction to get instance of const type
+CAMP_HOST_DEVICE
 template <typename T>
 auto cval() noexcept -> decltype(std::declval<T const>());
 

--- a/include/camp/helpers.hpp
+++ b/include/camp/helpers.hpp
@@ -25,13 +25,13 @@ template <typename T>
 T* declptr();
 
 /// metafunction to get instance of value type
-CAMP_HOST_DEVICE
 template <typename T>
+CAMP_HOST_DEVICE
 auto val() noexcept -> decltype(std::declval<T>());
 
 /// metafunction to get instance of const type
-CAMP_HOST_DEVICE
 template <typename T>
+CAMP_HOST_DEVICE
 auto cval() noexcept -> decltype(std::declval<T const>());
 
 /// metafunction to expand a parameter pack and ignore result

--- a/include/camp/resource/cuda.hpp
+++ b/include/camp/resource/cuda.hpp
@@ -25,22 +25,21 @@ namespace resources
   inline namespace v1
   {
 
-  namespace {
-    struct device_guard {
-      device_guard(int device)
-      {
-        cudaGetDevice(&prev_device);
-        cudaSetDevice(device);
-      }
+    namespace
+    {
+      struct device_guard {
+        device_guard(int device)
+        {
+          cudaGetDevice(&prev_device);
+          cudaSetDevice(device);
+        }
 
-      ~device_guard() {
-        cudaSetDevice(prev_device);
-      }
+        ~device_guard() { cudaSetDevice(prev_device); }
 
-      int prev_device;
-    }
+        int prev_device;
+      };
 
-  }
+    }  // namespace
 
     class CudaEvent
     {
@@ -87,7 +86,7 @@ namespace resources
       }
 
     public:
-      Cuda(int group = -1, int device=0) : stream(get_a_stream(group)) {}
+      Cuda(int group = -1, int device = 0) : stream(get_a_stream(group)) {}
 
       // Methods
       Platform get_platform() { return Platform::cuda; }
@@ -97,17 +96,20 @@ namespace resources
         return h;
       }
 
-      CudaEvent get_event() { 
+      CudaEvent get_event()
+      {
         auto d{device_guard(device)};
         return CudaEvent(get_stream());
       }
 
-      Event get_event_erased() { 
+      Event get_event_erased()
+      {
         auto d{device_guard(device)};
         return Event{CudaEvent(get_stream())};
       }
 
-      void wait() { 
+      void wait()
+      {
         auto d{device_guard(device)};
         cudaStreamSynchronize(stream);
       }
@@ -117,9 +119,7 @@ namespace resources
         auto *cuda_event = e->try_get<CudaEvent>();
         if (cuda_event) {
           auto d{device_guard(device)};
-          cudaStreamWaitEvent(get_stream(),
-                              cuda_event->getCudaEvent_t(),
-                              0);
+          cudaStreamWaitEvent(get_stream(), cuda_event->getCudaEvent_t(), 0);
         } else {
           e->wait();
         }
@@ -143,7 +143,7 @@ namespace resources
         return p;
       }
       void deallocate(void *p)
-      { 
+      {
         auto d{device_guard(device)};
         cudaFree(p);
       }

--- a/include/camp/tuple.hpp
+++ b/include/camp/tuple.hpp
@@ -482,7 +482,9 @@ CAMP_HOST_DEVICE constexpr auto tuple_cat_pair(tuple<Lelem...> const& l,
     -> tuple<camp::at_v<camp::list<Lelem...>, Lidx>...,
              camp::at_v<camp::list<Relem...>, Ridx>...>
 {
-  return ::camp::make_tuple(get<Lidx>(l)..., get<Ridx>(r)...);
+  return ::camp::tuple<camp::at_v<camp::list<Lelem...>, Lidx>...,
+                       camp::at_v<camp::list<Relem...>, Ridx>...>(
+      get<Lidx>(l)..., get<Ridx>(r)...);
 }
 
 template <typename L, typename R>

--- a/include/camp/tuple.hpp
+++ b/include/camp/tuple.hpp
@@ -89,7 +89,7 @@ namespace internal
   template <camp::idx_t index,
             typename Type,
             bool Empty = std::is_empty<Type>::value>
-  struct tuple_storage {
+  struct CAMP_EMPTY_BASES tuple_storage {
     CAMP_HOST_DEVICE constexpr tuple_storage() : val(){};
 
     /* Workaround for bug in hipcc compiler */
@@ -120,7 +120,7 @@ namespace internal
     Type val;
   };
   template <camp::idx_t index, typename Type>
-  struct tuple_storage<index, Type, true> : private Type {
+  struct CAMP_EMPTY_BASES tuple_storage<index, Type, true> : private Type {
     CAMP_HOST_DEVICE constexpr tuple_storage() : Type(){};
 
     static_assert(std::is_empty<Type>::value,

--- a/include/camp/tuple.hpp
+++ b/include/camp/tuple.hpp
@@ -367,6 +367,14 @@ public:
   using type = tagged_tuple;
   using Base::Base;
 
+  constexpr tagged_tuple() = default;
+
+  constexpr tagged_tuple(tagged_tuple const& o) = default;
+  constexpr tagged_tuple(tagged_tuple&& o) = default;
+
+  tagged_tuple& operator=(tagged_tuple const& rhs) = default;
+  tagged_tuple& operator=(tagged_tuple&& rhs) = default;
+
   CAMP_HOST_DEVICE constexpr explicit tagged_tuple(const Base& rhs) : Base{rhs}
   {
   }

--- a/include/camp/tuple.hpp
+++ b/include/camp/tuple.hpp
@@ -252,7 +252,7 @@ public:
 
   CAMP_HOST_DEVICE constexpr tuple(tuple const& o) : base(o.base) {}
 
-  CAMP_HOST_DEVICE constexpr tuple(tuple&& o) : base(move(o.base)) {}
+  CAMP_HOST_DEVICE constexpr tuple(tuple&& o) : base(std::move(o.base)) {}
 
   CAMP_HOST_DEVICE tuple& operator=(tuple const& rhs)
   {
@@ -482,7 +482,7 @@ CAMP_HOST_DEVICE constexpr auto tuple_cat_pair(tuple<Lelem...> const& l,
     -> tuple<camp::at_v<camp::list<Lelem...>, Lidx>...,
              camp::at_v<camp::list<Relem...>, Ridx>...>
 {
-  return make_tuple(get<Lidx>(l)..., get<Ridx>(r)...);
+  return ::camp::make_tuple(get<Lidx>(l)..., get<Ridx>(r)...);
 }
 
 template <typename L, typename R>
@@ -510,15 +510,14 @@ CAMP_HOST_DEVICE constexpr auto invoke_with_order(TupleLike&& t,
 
 CAMP_SUPPRESS_HD_WARN
 template <typename Fn, typename TupleLike>
-CAMP_HOST_DEVICE constexpr auto invoke(TupleLike&& t, Fn&& f)
-    -> decltype(invoke_with_order(
-        forward<TupleLike>(t),
-        forward<Fn>(f),
-        camp::make_idx_seq_t<tuple_size<camp::decay<TupleLike>>::value>{}))
+CAMP_HOST_DEVICE constexpr auto invoke(TupleLike&& t, Fn&& f) -> decltype(
+    invoke_with_order(std::forward<TupleLike>(t),
+                      std::forward<Fn>(f),
+                      camp::make_idx_seq_t<tuple_size<camp::decay<TupleLike>>::value>{}))
 {
   return invoke_with_order(
-      forward<TupleLike>(t),
-      forward<Fn>(f),
+      std::forward<TupleLike>(t),
+      std::forward<Fn>(f),
       camp::make_idx_seq_t<tuple_size<camp::decay<TupleLike>>::value>{});
 }
 
@@ -527,7 +526,7 @@ namespace detail
   template <class T, class Tuple, idx_t... I>
   constexpr T make_from_tuple_impl(Tuple&& t, idx_seq<I...>)
   {
-    return T(get<I>(forward<Tuple>(t))...);
+    return T(::camp::get<I>(std::forward<Tuple>(t))...);
   }
 }  // namespace detail
 
@@ -537,7 +536,7 @@ template <class T, class Tuple>
 constexpr T make_from_tuple(Tuple&& t)
 {
   return detail::make_from_tuple_impl<T>(
-      forward<Tuple>(t),
+      std::forward<Tuple>(t),
       make_idx_seq_t<tuple_size<type::ref::rem<Tuple>>::value>{});
 }
 }  // namespace camp

--- a/include/camp/tuple.hpp
+++ b/include/camp/tuple.hpp
@@ -177,7 +177,7 @@ namespace internal
     CAMP_HOST_DEVICE tuple_helper& operator=(const RTuple& rhs)
     {
       return (camp::sink((this->tuple_storage<Indices, Types>::get_inner() =
-                              get<Indices>(rhs))...),
+                              ::camp::get<Indices>(rhs))...),
               *this);
     }
   };
@@ -484,7 +484,7 @@ CAMP_HOST_DEVICE constexpr auto tuple_cat_pair(tuple<Lelem...> const& l,
 {
   return ::camp::tuple<camp::at_v<camp::list<Lelem...>, Lidx>...,
                        camp::at_v<camp::list<Relem...>, Ridx>...>(
-      get<Lidx>(l)..., get<Ridx>(r)...);
+      ::camp::get<Lidx>(l)..., ::camp::get<Ridx>(r)...);
 }
 
 template <typename L, typename R>
@@ -505,9 +505,9 @@ template <typename Fn, camp::idx_t... Sequence, typename TupleLike>
 CAMP_HOST_DEVICE constexpr auto invoke_with_order(TupleLike&& t,
                                                   Fn&& f,
                                                   camp::idx_seq<Sequence...>)
-    -> decltype(f(get<Sequence>(t)...))
+    -> decltype(f(::camp::get<Sequence>(t)...))
 {
-  return f(get<Sequence>(t)...);
+  return f(::camp::get<Sequence>(t)...);
 }
 
 CAMP_SUPPRESS_HD_WARN

--- a/include/camp/tuple.hpp
+++ b/include/camp/tuple.hpp
@@ -158,7 +158,7 @@ namespace internal
   };
 
   template <typename... Types, camp::idx_t... Indices>
-  struct tuple_helper<camp::idx_seq<Indices...>, camp::list<Types...>>
+  struct CAMP_EMPTY_BASES tuple_helper<camp::idx_seq<Indices...>, camp::list<Types...>>
       : public internal::tuple_storage<Indices, Types>... {
 
     tuple_helper& operator=(const tuple_helper& rhs) = default;

--- a/include/camp/tuple.hpp
+++ b/include/camp/tuple.hpp
@@ -521,6 +521,25 @@ CAMP_HOST_DEVICE constexpr auto invoke(TupleLike&& t, Fn&& f)
       forward<Fn>(f),
       camp::make_idx_seq_t<tuple_size<camp::decay<TupleLike>>::value>{});
 }
+
+namespace detail
+{
+  template <class T, class Tuple, idx_t... I>
+  constexpr T make_from_tuple_impl(Tuple&& t, idx_seq<I...>)
+  {
+    return T(get<I>(forward<Tuple>(t))...);
+  }
+}  // namespace detail
+
+/// Instantiate T from tuple contents, like camp::invoke(tuple,constructor) but
+/// functional
+template <class T, class Tuple>
+constexpr T make_from_tuple(Tuple&& t)
+{
+  return detail::make_from_tuple_impl<T>(
+      forward<Tuple>(t),
+      make_idx_seq_t<tuple_size<type::ref::rem<Tuple>>::value>{});
+}
 }  // namespace camp
 
 namespace internal

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,5 +1,6 @@
 # Build google test
 if (NOT TARGET gtest)
+  set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
   add_subdirectory("${PROJECT_SOURCE_DIR}/extern/googletest" "extern/googletest"
     EXCLUDE_FROM_ALL)
 

--- a/test/tuple.cpp
+++ b/test/tuple.cpp
@@ -46,9 +46,11 @@ static_assert(sizeof(camp::tuple<A, B, ptrdiff_t>) == sizeof(ptrdiff_t),
 // static_assert(std::is_empty<camp::tuple<A, B>>::value, "it's empty right?");
 
 // Ensure trivial copyability for trivially copyable contents
+#if CAMP_HAS_IS_TRIVIALLY_COPY_CONSTRUCTIBLE
 static_assert(
     std::is_trivially_copy_constructible<camp::tuple<int, float>>::value,
     "can by trivially copy constructed");
+#endif
 
 // Execution tests
 

--- a/test/tuple.cpp
+++ b/test/tuple.cpp
@@ -30,9 +30,13 @@ struct A {
 struct B {
 };
 
-static_assert(sizeof(camp::tuple<A, B>) == 1, "EBO working as intended");
+static_assert(sizeof(camp::tuple<A, B>) == 1, "EBO working as intended with empty types");
+
 static_assert(sizeof(camp::tuple<A, B, ptrdiff_t>) == sizeof(ptrdiff_t),
-              "EBO working as intended");
+              "EBO working as intended with one sized type at the end");
+
+static_assert(sizeof(camp::tuple<A, B, ptrdiff_t>) == sizeof(ptrdiff_t),
+              "EBO working as intended with one sized type in the middle");
 
 // is_empty on all empty members currently is not true, same as libc++, though
 // libstdc++ supports it.  This could be fixed by refactoring base member into a
@@ -44,9 +48,6 @@ static_assert(sizeof(camp::tuple<A, B, ptrdiff_t>) == sizeof(ptrdiff_t),
 // Ensure trivial copyability for trivially copyable contents
 static_assert(
     std::is_trivially_copy_constructible<camp::tuple<int, float>>::value,
-    "can by trivially copy constructed");
-static_assert(
-    std::is_trivially_copy_constructible<std::tuple<int, float>>::value,
     "can by trivially copy constructed");
 
 // Execution tests

--- a/test/tuple.cpp
+++ b/test/tuple.cpp
@@ -16,6 +16,12 @@
 #include "camp/camp.hpp"
 #include "gtest/gtest.h"
 
+static_assert(std::is_same<camp::tuple<int &, int const &, int>,
+                           decltype(camp::tuple_cat_pair(
+                               camp::val<camp::tuple<int &>>(),
+                               camp::val<camp::tuple<int const &, int>>()))>::value,
+              "tuple_cat pair nuking refs");
+
 TEST(CampTuple, AssignCompat)
 {
   // Compatible, though different, tuples are assignable
@@ -69,7 +75,7 @@ TEST(CampTuple, GetByType)
 TEST(CampTuple, CatPair)
 {
   auto t1 = camp::make_tuple(5, 'a');
-  auto t2 = camp::make_tuple(5.1f, "meh");
+  auto t2 = camp::make_tuple(5.1f, std::string("meh"));
   auto t3 = tuple_cat_pair(t1,
                            camp::make_idx_seq_t<2>{},
                            t2,
@@ -90,16 +96,14 @@ TEST(CampTuple, CatPair)
 
 struct NoDefCon {
   NoDefCon() = delete;
-  NoDefCon(int i) : num{i} {(void)num;}
+  NoDefCon(int i) : num{i} { (void)num; }
   NoDefCon(NoDefCon const &) = default;
-  private:
+
+private:
   int num;
 };
 
-TEST(CampTuple, NoDefault)
-{
-  camp::tuple<NoDefCon> t(NoDefCon(1));
-}
+TEST(CampTuple, NoDefault) { camp::tuple<NoDefCon> t(NoDefCon(1)); }
 
 struct s1;
 struct s2;


### PR DESCRIPTION
@rrsettgast noted in GEOSX/GEOSX#866 that we're missing a way to use `invoke` on a tuple with a constructor, C++17 includes `make_from_tuple` for this use case, and I can't think of a reason not to provide it for us as well.