### PR TITLE
Faster sequences

### DIFF
--- a/include/camp/defines.hpp
+++ b/include/camp/defines.hpp
@@ -88,10 +88,39 @@ namespace camp
 #define CAMP_HAVE_OMP_OFFLOAD 1
 #endif
 
-#if defined(__has_builtin)
-#if __has_builtin(__make_integer_seq)
+// This works for clang, nvcc 10 and higher using clang as a host compiler
+#define CAMP_USE_MAKE_INTEGER_SEQ 0
+#define CAMP_USE_TYPE_PACK_ELEMENT 0
+#if defined(_MSC_FULL_VER) && _MSC_FULL_VER >= 191125507
+  // __has_builtin exists but does not always expose this
+#undef CAMP_USE_MAKE_INTEGER_SEQ
 #define CAMP_USE_MAKE_INTEGER_SEQ 1
+#undef CAMP_USE_TYPE_PACK_ELEMENT
+#define CAMP_USE_TYPE_PACK_ELEMENT 1
+#elif defined(__has_builtin)
+#if __has_builtin(__make_integer_seq) && ((!defined(__NVCC__) || __CUDACC_VER_MAJOR >= 10))
+#undef CAMP_USE_MAKE_INTEGER_SEQ
+#define CAMP_USE_MAKE_INTEGER_SEQ 1
+#undef CAMP_USE_TYPE_PACK_ELEMENT
+#define CAMP_USE_TYPE_PACK_ELEMENT 1
 #endif
+#endif
+
+// This works for:
+//   GCC >= 8
+//   intel 19+ in GCC 8 or higher mode
+//   nvcc 10+ in GCC 8 or higher mode
+//   PGI 19+ in GCC 8 or higher mode
+#if __GNUC__ >= 8 && (\
+    /* intel compiler in gcc 8+ mode */ \
+    ((!defined(__INTEL_COMPILER)) || __INTEL_COMPILER >= 1900) \
+    /* nvcc in gcc 8+ mode */ \
+  ||((!defined(__NVCC__)) || __CUDACC_VER_MAJOR >= 10) \
+  ||((!defined(__PGIC__)) || __PGIC__ >= 19) \
+    )
+#define CAMP_USE_INTEGER_PACK 1
+#else
+#define CAMP_USE_INTEGER_PACK 0
 #endif
 
 // Types

--- a/include/camp/defines.hpp
+++ b/include/camp/defines.hpp
@@ -88,7 +88,11 @@ namespace camp
 #define CAMP_HAVE_OMP_OFFLOAD 1
 #endif
 
-// This works for clang, nvcc 10 and higher using clang as a host compiler
+// This works for:
+//   clang
+//   nvcc 10 and higher using clang as a host compiler
+//   MSVC 1911... and higher, see check below
+//   XL C++ at least back to 16.1.0, possibly farther
 #define CAMP_USE_MAKE_INTEGER_SEQ 0
 #define CAMP_USE_TYPE_PACK_ELEMENT 0
 #if defined(_MSC_FULL_VER) && _MSC_FULL_VER >= 191125507

--- a/include/camp/list/at.hpp
+++ b/include/camp/list/at.hpp
@@ -22,6 +22,15 @@ namespace camp
 
 namespace detail
 {
+  template <typename T, idx_t Idx>
+  struct _at;
+
+  #if CAMP_USE_TYPE_PACK_ELEMENT
+  template <idx_t Idx, template <class...> class T, typename... Pack>
+  struct _at<T<Pack...>, Idx> {
+    using type = __type_pack_element<Idx, Pack...>;
+  };
+  #else
   // Lookup from metal::at machinery
   template <idx_t, typename>
   struct entry {
@@ -45,8 +54,6 @@ namespace detail
       : decltype(_lookup_impl<Idx>(declptr<entries<indices, vals>>())) {
   };
 
-  template <typename T, idx_t Idx>
-  struct _at;
   template <template <class...> class T, typename X, typename... Rest>
   struct _at<T<X, Rest...>, 0> {
     using type = X;
@@ -65,6 +72,7 @@ namespace detail
                                   make_idx_seq_t<sizeof...(Rest)>,
                                   Idx>::type;
   };
+  #endif
 }  // namespace detail
 
 // TODO: document

--- a/include/camp/number.hpp
+++ b/include/camp/number.hpp
@@ -36,10 +36,15 @@ namespace detail
 {
   template <typename T, typename N>
   struct gen_seq;
-#if defined(CAMP_USE_MAKE_INTEGER_SEQ) && !__NVCC__
+#if CAMP_USE_MAKE_INTEGER_SEQ
   template <typename T, T N>
   struct gen_seq<T, integral_constant<T, N>> {
     using type = __make_integer_seq<int_seq, T, N>;
+  };
+#elif CAMP_USE_INTEGER_PACK
+  template <typename T, T N>
+  struct gen_seq<T, integral_constant<T, N>> {
+    using type = int_seq<T, __integer_pack(N)...>;
   };
 #else
   template <typename T, typename S1, typename S2>


### PR DESCRIPTION
Incorporate more checks for integer sequence building intrinsics.  This makes explicit a number of checks for nvcc, icpc, xl, msvc and pgi so we get intrinsics working in as many places as possible for sequence building and pack element selection for `at<>`.

The libstdc++ and libc++ libraries use these at newer versions as well, so we could consider using these checks and deferring to the native `std::make_integer_sequence` in the future.  I'm vaguely for keeping the setup as-is, if only because it makes it easier for us to ensure we get a reasonably fast implementation everywhere.