### PR TITLE
Update hip.hpp to use hipMalloc

### DIFF
--- a/include/camp/resource/hip.hpp
+++ b/include/camp/resource/hip.hpp
@@ -106,8 +106,10 @@ namespace resources
       template <typename T>
       T *allocate(size_t size)
       {
+        //Dec 7th 2020, hipMallocManaged is broken with HIP 3.6.0
+        //use hipMalloc instead
         T *ret = nullptr;
-        hipMallocManaged(&ret, sizeof(T) * size);
+        hipMalloc((void **)&ret, sizeof(T) * size);
         return ret;
       }
       void *calloc(size_t size)


### PR DESCRIPTION
hipMallocManaged appears to be broken with rocm 3.6.0 on LC platforms, this PR will switch to hipMalloc