### PR TITLE
Making sure omp target is not compiled on TOSS, assuming no GPUs.

### DIFF
--- a/include/camp/defines.hpp
+++ b/include/camp/defines.hpp
@@ -98,7 +98,7 @@ namespace camp
 #if _OPENMP >= 201511
 #define CAMP_HAVE_OMP_OFFLOAD 1
 #endif
-#endif  // !defined(__x86_64__)
+#endif
 
 // This works for:
 //   clang

--- a/include/camp/defines.hpp
+++ b/include/camp/defines.hpp
@@ -94,9 +94,11 @@ namespace camp
 #define CAMP_SUPPRESS_HD_WARN
 #endif
 
+#if !defined(__x86_64__)
 #if _OPENMP >= 201511
 #define CAMP_HAVE_OMP_OFFLOAD 1
 #endif
+#endif  // !defined(__x86_64__)
 
 // This works for:
 //   clang

--- a/include/camp/defines.hpp
+++ b/include/camp/defines.hpp
@@ -94,7 +94,7 @@ namespace camp
 #define CAMP_SUPPRESS_HD_WARN
 #endif
 
-#if !defined(__x86_64__)
+#if defined(ENABLE_TARGET_OPENMP)
 #if _OPENMP >= 201511
 #define CAMP_HAVE_OMP_OFFLOAD 1
 #endif

--- a/include/camp/defines.hpp
+++ b/include/camp/defines.hpp
@@ -97,6 +97,9 @@ namespace camp
 #if defined(ENABLE_TARGET_OPENMP)
 #if _OPENMP >= 201511
 #define CAMP_HAVE_OMP_OFFLOAD 1
+#else
+#define CAMP_HAVE_OMP_OFFLOAD 0
+#warning Compiler does NOT support OpenMP Target Offload even though user has enabled it!
 #endif
 #endif
 


### PR DESCRIPTION
This seems to be causing some TOSS3-gcc6 failures in RAJA https://github.com/LLNL/RAJA/pull/930. GCC-6.1.0 has an advanced enough OpenMP version which turns on omp-target in CAMP. This problem correctly manifests itself as compilation errors when run manually. However, Travis compiles successfully but segfaults at runtime, which I'm not sure why.