### PR TITLE
Add "CAMP_" prefix to "ENABLE_TESTS" option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ option(ENABLE_CUDA "whether to build with cuda" Off)
 option(ENABLE_CLANG_CUDA "use clang cuda support rather than nvcc" Off)
 option(ENABLE_HIP "whether to build with hip" Off)
 option(ENABLE_TARGET_OPENMP "whether to build with OpenMP offload" Off)
-option(ENABLE_TESTS "whether to configure and build tests" On)
+option(CAMP_ENABLE_TESTS "whether to configure and build tests" On)
 
 if(ENABLE_CLANG_CUDA)
   if(NOT ${CMAKE_CXX_COMPILER_ID} STREQUAL Clang)
@@ -80,7 +80,7 @@ install(DIRECTORY
   DESTINATION
   include)
 
-if(ENABLE_TESTS)
+if(CAMP_ENABLE_TESTS)
 enable_testing()
 add_subdirectory(test)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,13 @@ option(ENABLE_HIP "whether to build with hip" Off)
 option(ENABLE_TARGET_OPENMP "whether to build with OpenMP offload" Off)
 option(CAMP_ENABLE_TESTS "whether to configure and build tests" On)
 
+# if ENABLE_TESTS is defined by a parent project, and
+# CAMP_ENABLE_TESTS has not been set to OFF set the
+# value of CAMP_ENABLE_TESTS to the value of ENABLE_TESTS.
+if (CAMP_ENABLE_TESTS AND DEFINED ENABLE_TESTS)
+  set(CAMP_ENABLE_TESTS ${ENABLE_TESTS})
+endif()
+
 if(ENABLE_CLANG_CUDA)
   if(NOT ${CMAKE_CXX_COMPILER_ID} STREQUAL Clang)
     message(ERROR "clang cuda can only be used with clang")


### PR DESCRIPTION
# Summary

The "ENABLE_TESTS" option is named too generically which leads to
name collisions when camp is used a sub-module within another
project. As a result, the CAMP tests will always be run with
the tests of the super-project, which may be using the same
option. Notably, BLT has also an option "ENABLE_TESTS", so
any BLT project that uses camp as a submodule will run into this.
This commit renames this option in order to give parent projects
more fine-grain control of whether to build CAMP's tests or not.