### PR TITLE
add wait method to type-erased Resource

### DIFF
--- a/include/camp/resource.hpp
+++ b/include/camp/resource.hpp
@@ -92,6 +92,7 @@ namespace resources
       }
       Event get_event() { return m_value->get_event(); }
       void wait_for(Event *e) { m_value->wait_for(e); }
+      void wait() { m_value->wait(); }
 
     private:
       class ContextInterface
@@ -105,6 +106,7 @@ namespace resources
         virtual void memset(void *p, int val, size_t size) = 0;
         virtual Event get_event() = 0;
         virtual void wait_for(Event *e) = 0;
+        virtual void wait() = 0;
       };
 
       template <typename T>
@@ -125,6 +127,7 @@ namespace resources
         }
         Event get_event() override { return m_modelVal.get_event_erased(); }
         void wait_for(Event *e) override { m_modelVal.wait_for(e); }
+        void wait() override { m_modelVal.wait(); }
         T *get() { return &m_modelVal; }
 
       private:

--- a/test/resource.cpp
+++ b/test/resource.cpp
@@ -215,3 +215,12 @@ TEST(CampEventProxy, Get)
     Event e = ep.get();
   }
 }
+
+TEST(CampResource, Wait) {
+  auto h = camp::resources::Host();
+  h.wait();
+  Event he = h.get_event_erased();
+  h.wait_for(&he);
+  Resource r(h);
+  r.wait();
+}


### PR DESCRIPTION
Fixes #49
Adds the link through for the wait method in the type erased version of
Resource.