### PR TITLE
add support for native events from EventProxy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,16 @@
 *.a
 *.exe
 *.gch
+
+# editor directories
+.idea/
+.clangd/
+.vscode/
+
+# build directories
 build/
 build-*/
+cmake-build-*/
+docker-*-build/
 /Debug/
 ./extern/googletest/*

--- a/include/camp/resource.hpp
+++ b/include/camp/resource.hpp
@@ -176,20 +176,20 @@ namespace resources
     using native_event = decltype(std::declval<Res>().get_event());
     
     EventProxy(EventProxy &&) = default;
-    EventProxy(EventProxy const &) = delete;
+    EventProxy(EventProxy &) = delete;
     EventProxy &operator=(EventProxy &&) = default;
-    EventProxy &operator=(EventProxy const &) = delete;
+    EventProxy &operator=(EventProxy &) = delete;
 
     EventProxy(Res r) :
       resource_{r}
     {}
 
-    native_event get() const {
-      return resource_->get_event();
+    native_event get() {
+      return resource_.get_event();
     }
 
-    operator native_event() const {
-      return resource_->get_event();
+    operator native_event() {
+      return resource_.get_event();
     }
 
     operator Event() {

--- a/include/camp/resource.hpp
+++ b/include/camp/resource.hpp
@@ -181,7 +181,7 @@ namespace resources
     EventProxy &operator=(EventProxy &) = delete;
 
     EventProxy(Res r) :
-      resource_{r}
+      resource_{move(r)}
     {}
 
     native_event get() {

--- a/include/camp/resource.hpp
+++ b/include/camp/resource.hpp
@@ -172,7 +172,9 @@ namespace resources
 #endif
 
   template<typename Res>
-  struct EventProxy {
+  struct EventProxy : ::camp::resources::detail::EventProxyBase {
+    using native_event = decltype(std::declval<Res>().get_event());
+    
     EventProxy(EventProxy &&) = default;
     EventProxy(EventProxy const &) = delete;
     EventProxy &operator=(EventProxy &&) = default;
@@ -182,8 +184,12 @@ namespace resources
       resource_{r}
     {}
 
-    Event get() {
-      return resource_.get_event_erased();
+    native_event get() const {
+      return resource_->get_event();
+    }
+
+    operator native_event() const {
+      return resource_->get_event();
     }
 
     operator Event() {

--- a/include/camp/resource.hpp
+++ b/include/camp/resource.hpp
@@ -192,7 +192,7 @@ namespace resources
       EventProxy(EventProxy &&) = default;
       EventProxy(EventProxy &) = delete;
       EventProxy &operator=(EventProxy &&) = default;
-      EventProxy &operator=(EventProxy &) = delete;
+      EventProxy &operator=(EventProxy const &) = delete;
 
       EventProxy(Res r) : resource_{move(r)} {}
 

--- a/include/camp/resource.hpp
+++ b/include/camp/resource.hpp
@@ -173,8 +173,8 @@ namespace resources
 
   template<typename Res>
   struct EventProxy : ::camp::resources::detail::EventProxyBase {
-    using native_event = decltype(std::declval<Res>().get_event());
-    
+    using native_event = typename std::decay<decltype(std::declval<Res>().get_event())>::type;
+
     EventProxy(EventProxy &&) = default;
     EventProxy(EventProxy &) = delete;
     EventProxy &operator=(EventProxy &&) = default;
@@ -188,6 +188,10 @@ namespace resources
       return resource_.get_event();
     }
 
+    template <typename T = Res,
+              typename = typename std::enable_if<
+                  !std::is_same<typename std::decay<decltype(std::declval<T>().get_event())>::type,
+                                Event>::value>::type>
     operator native_event() {
       return resource_.get_event();
     }

--- a/include/camp/resource/event.hpp
+++ b/include/camp/resource/event.hpp
@@ -11,27 +11,33 @@ http://github.com/llnl/camp
 #ifndef __CAMP_EVENT_HPP
 #define __CAMP_EVENT_HPP
 
+#include<type_traits>
+#include<exception>
+#include<memory>
+
 namespace camp
 {
 namespace resources
 {
   inline namespace v1
   {
-    namespace detail {
-      struct EventProxyBase{}; // helper to identify EventProxy in sfinae
-    }
+    namespace detail
+    {
+      struct EventProxyBase {
+      };  // helper to identify EventProxy in sfinae
+    }     // namespace detail
     class Event
     {
     public:
-      Event() {}
-      template <
-          typename T,
-          typename = typename std::enable_if<!(
-              std::is_same<typename std::decay<T>::type, Event>::value
-              || std::is_convertible<typename std::decay<T>::type *,
-                              ::camp::resources::detail::EventProxyBase *>::value
-
-              )>::type>
+      Event() = default;
+      Event(Event const &e) = default;
+      Event(Event &&e) = default;
+      template <typename T,
+                typename std::enable_if<
+                    !(std::is_convertible<
+                        typename std::decay<T>::type *,
+                        ::camp::resources::detail::EventProxyBase *>::value
+                      )>::type * = nullptr>
       Event(T &&value)
       {
         m_value.reset(new EventModel<T>(value));

--- a/include/camp/resource/event.hpp
+++ b/include/camp/resource/event.hpp
@@ -17,13 +17,22 @@ namespace resources
 {
   inline namespace v1
   {
-
+    namespace detail {
+      struct EventProxyBase{}; // helper to identify EventProxy in sfinae
+    }
     class Event
     {
     public:
       Event() {}
-      template <typename T>
-      explicit Event(T &&value)
+      template <
+          typename T,
+          typename = typename std::enable_if<!(
+              std::is_same<typename std::decay<T>::type, Event>::value
+              || std::is_convertible<typename std::decay<T>::type *,
+                              ::camp::resources::detail::EventProxyBase *>::value
+
+              )>::type>
+      Event(T &&value)
       {
         m_value.reset(new EventModel<T>(value));
       }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -38,12 +38,18 @@ function(camp_add_test TESTNAME)
   endif()
 
 
+  if(NOT CMAKE_BUILD_TYPE)
+    set(TEST_BUILD_TYPE Release)
+  else()
+    set(TEST_BUILD_TYPE ${CMAKE_BUILD_TYPE})
+  endif()
+
   # target that is run by the test, build and run
   if(ABT_GTEST OR ABT_RUN)
     # Actual build setup, do not build by default
     add_executable(${TESTNAME} EXCLUDE_FROM_ALL ${ABT_BUILD})
     add_custom_target(${TESTNAME}.runner
-      COMMAND ${CMAKE_COMMAND} --build . --target ${TESTNAME} --config ${CMAKE_BUILD_TYPE}
+      COMMAND ${CMAKE_COMMAND} --build . --target ${TESTNAME} --config ${TEST_BUILD_TYPE}
       COMMAND "$<TARGET_FILE:${TESTNAME}>"
       WORKING_DIRECTORY ${CURRENT_BINARY_DIR}
       )
@@ -51,7 +57,7 @@ function(camp_add_test TESTNAME)
     # Actual build setup, do not build by default, use a lib so no main required
     add_library(${TESTNAME} EXCLUDE_FROM_ALL ${ABT_BUILD})
     add_custom_target(${TESTNAME}.runner
-      COMMAND ${CMAKE_COMMAND} --build . --target ${TESTNAME} --config ${CMAKE_BUILD_TYPE}
+      COMMAND ${CMAKE_COMMAND} --build . --target ${TESTNAME} --config ${TEST_BUILD_TYPE}
       WORKING_DIRECTORY ${CURRENT_BINARY_DIR}
       )
   endif()

--- a/test/resource.cpp
+++ b/test/resource.cpp
@@ -244,7 +244,16 @@ TEST(CampEventProxy, Get)
   }
 
   {
+    EventProxy<Host> ep{h1};
+    HostEvent e = ep;
+  }
+
+  {
     Event e = do_stuff(h1);
+  }
+
+  {
+    HostEvent e = do_stuff(h1);
   }
 
   {
@@ -254,6 +263,11 @@ TEST(CampEventProxy, Get)
   {
     EventProxy<Host> ep{h1};
     Event e = ep.get();
+  }
+
+  {
+    EventProxy<Host> ep{h1};
+    HostEvent e = ep.get();
   }
 }
 

--- a/test/resource.cpp
+++ b/test/resource.cpp
@@ -238,6 +238,12 @@ static EventProxy<Res> do_stuff(Res r)
 TEST(CampEventProxy, Get)
 {
   Host h1{Host{}};
+
+  {
+    EventProxy<Resource> ep{Resource{h1}};
+    Event e = ep;
+  }
+
   {
     EventProxy<Host> ep{h1};
     Event e = ep;
@@ -246,6 +252,10 @@ TEST(CampEventProxy, Get)
   {
     EventProxy<Host> ep{h1};
     HostEvent e = ep;
+  }
+
+  {
+    Event e = do_stuff(Resource{h1});
   }
 
   {
@@ -258,6 +268,11 @@ TEST(CampEventProxy, Get)
 
   {
     do_stuff(h1);
+  }
+
+  {
+    EventProxy<Resource> ep{Resource{h1}};
+    Event e = ep.get();
   }
 
   {


### PR DESCRIPTION
Fixes #51

Add support for getting the native event type out of EventProxy.
This is now the default, with Event fixed to allow implicit conversion
from native event types and a new `operator Event()` overload on
EventProxy all tests pass in tree, need to see how this impacts codes.