### PR TITLE
specify the release build type on configuration in appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,7 +13,7 @@ build_script:
 
     cd build
 
-    cmake ../
+    cmake -D CMAKE_BUILD_TYPE=Release ../
 
     cmake --build . --config Release
 test_script:


### PR DESCRIPTION
Hoping to fix the appveyor 2019 build.