### PR TITLE
add get_event_erased to resource class

### DIFF
--- a/include/camp/resource.hpp
+++ b/include/camp/resource.hpp
@@ -91,7 +91,7 @@ namespace resources
         m_value->memset(p, val, size);
       }
       Event get_event() { return m_value->get_event(); }
-      Event get_event_erased() { return m_value->get_event(); }
+      Event get_event_erased() { return m_value->get_event_erased(); }
       void wait_for(Event *e) { m_value->wait_for(e); }
 
     private:

--- a/include/camp/resource.hpp
+++ b/include/camp/resource.hpp
@@ -91,6 +91,7 @@ namespace resources
         m_value->memset(p, val, size);
       }
       Event get_event() { return m_value->get_event(); }
+      Event get_event_erased() { return m_value->get_event(); }
       void wait_for(Event *e) { m_value->wait_for(e); }
 
     private:

--- a/include/camp/resource.hpp
+++ b/include/camp/resource.hpp
@@ -105,6 +105,7 @@ namespace resources
         virtual void memcpy(void *dst, const void *src, size_t size) = 0;
         virtual void memset(void *p, int val, size_t size) = 0;
         virtual Event get_event() = 0;
+        virtual Event get_event_erased() = 0;
         virtual void wait_for(Event *e) = 0;
       };
 
@@ -125,6 +126,7 @@ namespace resources
           m_modelVal.memset(p, val, size);
         }
         Event get_event() override { return m_modelVal.get_event_erased(); }
+        Event get_event_erased() override { return m_modelVal.get_event_erased(); }
         void wait_for(Event *e) override { m_modelVal.wait_for(e); }
         T *get() { return &m_modelVal; }
 


### PR DESCRIPTION
Since we pass back a erased resource type in https://github.com/LLNL/RAJA/pull/1029, we need to add get_event_erased method class to the resource class. 