### PR TITLE
Compiler define mismatch

### DIFF
--- a/include/camp/defines.hpp
+++ b/include/camp/defines.hpp
@@ -15,7 +15,7 @@ http://github.com/llnl/camp
 #include <cstdint>
 #include <string>
 
-#if defined(__CUDACC__)
+#ifdef CAMP_HAVE_CUDA
 #include <cuda_runtime.h>
 #endif
 

--- a/include/camp/defines.hpp
+++ b/include/camp/defines.hpp
@@ -15,7 +15,7 @@ http://github.com/llnl/camp
 #include <cstdint>
 #include <string>
 
-#ifdef CAMP_HAVE_CUDA
+#if defined(__CUDACC__) || defined(CAMP_HAVE_CUDA)
 #include <cuda_runtime.h>
 #endif
 


### PR DESCRIPTION
The compiler defines need to match between including this header and where the `cudaError_t` type is used below.  This fixes the following error:

```
[  6%] Building CXX object src/umpire/resource/CMakeFiles/umpire_resource.dir/MemoryResource.cpp.o
cd spack-stage-umpire-5.0.1-effmrh5m4m5c2vxd6cdtos3zbrkhymz3/spack-build-effmrh5/src/umpire/resource && /usr/WS2/white238/serac/libs/blueos_3_ppc64le_ib_p9/2021_06_24_15_13_34/spack/lib/spack/env/clang/clang++ -DCAMP_HAVE_CUDA -Icamp-0.1.0serac/include -I/usr/tce/packages/cuda/cuda-11.2.0/include -Ispack-stage-umpire-5.0.1-effmrh5m4m5c2vxd6cdtos3zbrkhymz3/spack-src/src -Ispack-stage-umpire-5.0.1-effmrh5m4m5c2vxd6cdtos3zbrkhymz3/spack-build-effmrh5/include -Wpedantic       -Wall -Wextra  -O2 -g -DNDEBUG -fPIC -std=c++11 -o CMakeFiles/umpire_resource.dir/MemoryResource.cpp.o -c spack-stage-umpire-5.0.1-effmrh5m4m5c2vxd6cdtos3zbrkhymz3/spack-src/src/umpire/resource/MemoryResource.cpp
make[2]: Leaving directory 'spack-stage-umpire-5.0.1-effmrh5m4m5c2vxd6cdtos3zbrkhymz3/spack-build-effmrh5'
In file included from src/umpire/op/GenericReallocateOperation.cpp:7:
In file included from src/umpire/op/GenericReallocateOperation.hpp:10:
In file included from src/umpire/op/MemoryOperation.hpp:12:
In file included from camp-0.1.0serac/include/camp/resource.hpp:19:
In file included from camp-0.1.0serac/include/camp/helpers.hpp:18:
camp-0.1.0serac/include/camp/defines.hpp:183:8: error: unknown type name 'cudaError_t'
inline cudaError_t cudaAssert(cudaError_t code,
       ^
```

I noticed this when I bumped to RAJA's submodule version of camp and using the newest release of Umpire (5.0.1).  This was built via spack but I confirmed it outside of it as well.

If this is not the fix you prefer, I can test something else as well.