### PR TITLE
add memory access type to allocation routines

### DIFF
--- a/include/camp/resource.hpp
+++ b/include/camp/resource.hpp
@@ -43,7 +43,6 @@ namespace resources
 {
   inline namespace v1
   {
-
     class Resource
     {
     public:
@@ -76,12 +75,12 @@ namespace resources
       }
       Platform get_platform() { return m_value->get_platform(); }
       template <typename T>
-      T *allocate(size_t size)
+      T *allocate(size_t size, MemoryAccess ma = MemoryAccess::Device)
       {
-        return (T *)m_value->calloc(size * sizeof(T));
+        return (T *)m_value->calloc(size * sizeof(T), ma);
       }
-      void *calloc(size_t size) { return m_value->calloc(size); }
-      void deallocate(void *p) { m_value->deallocate(p); }
+      void *calloc(size_t size, MemoryAccess ma = MemoryAccess::Device) { return m_value->calloc(size, ma); }
+      void deallocate(void *p, MemoryAccess ma = MemoryAccess::Device) { m_value->deallocate(p, ma); }
       void memcpy(void *dst, const void *src, size_t size)
       {
         m_value->memcpy(dst, src, size);
@@ -101,8 +100,8 @@ namespace resources
       public:
         virtual ~ContextInterface() {}
         virtual Platform get_platform() = 0;
-        virtual void *calloc(size_t size) = 0;
-        virtual void deallocate(void *p) = 0;
+        virtual void *calloc(size_t size, MemoryAccess ma = MemoryAccess::Device) = 0;
+        virtual void deallocate(void *p, MemoryAccess ma = MemoryAccess::Device) = 0;
         virtual void memcpy(void *dst, const void *src, size_t size) = 0;
         virtual void memset(void *p, int val, size_t size) = 0;
         virtual Event get_event() = 0;
@@ -117,8 +116,8 @@ namespace resources
       public:
         ContextModel(T const &modelVal) : m_modelVal(modelVal) {}
         Platform get_platform() override { return m_modelVal.get_platform(); }
-        void *calloc(size_t size) override { return m_modelVal.calloc(size); }
-        void deallocate(void *p) override { m_modelVal.deallocate(p); }
+        void *calloc(size_t size, MemoryAccess ma = MemoryAccess::Device) override { return m_modelVal.calloc(size, ma); }
+        void deallocate(void *p, MemoryAccess ma = MemoryAccess::Device) override { m_modelVal.deallocate(p, ma); }
         void memcpy(void *dst, const void *src, size_t size) override
         {
           m_modelVal.memcpy(dst, src, size);

--- a/include/camp/resource/cuda.hpp
+++ b/include/camp/resource/cuda.hpp
@@ -200,7 +200,7 @@ namespace resources
       }
       void *calloc(size_t size, MemoryAccess ma = MemoryAccess::Device)
       {
-        void *p = allocate<char>(size);
+        void *p = allocate<char>(size, ma);
         this->memset(p, 0, size);
         return p;
       }

--- a/include/camp/resource/hip.hpp
+++ b/include/camp/resource/hip.hpp
@@ -161,7 +161,7 @@ namespace resources
             case MemoryAccess::Device:
               campHipErrchk(hipMalloc(&ret, sizeof(T) * size));
               break;
-            case MemoryAccess::Shared:
+            case MemoryAccess::Pinned:
               // TODO: do a test here for whether managed is *actually* shared
               // so we can use the better performing memory
               campHipErrchk(hipMallocHost(&ret, sizeof(T) * size));
@@ -186,7 +186,7 @@ namespace resources
           case MemoryAccess::Device:
             campHipErrchk(hipFree(p));
             break;
-          case MemoryAccess::Shared:
+          case MemoryAccess::Pinned:
             // TODO: do a test here for whether managed is *actually* shared
             // so we can use the better performing memory
             campHipErrchk(hipFreeHost(p));

--- a/include/camp/resource/host.hpp
+++ b/include/camp/resource/host.hpp
@@ -52,17 +52,17 @@ namespace resources
 
       // Memory
       template <typename T>
-      T *allocate(size_t n)
+      T *allocate(size_t n, MemoryAccess = MemoryAccess::Device)
       {
         return (T *)malloc(sizeof(T) * n);
       }
-      void *calloc(size_t size)
+      void *calloc(size_t size, MemoryAccess = MemoryAccess::Device)
       {
         void *p = allocate<char>(size);
         this->memset(p, 0, size);
         return p;
       }
-      void deallocate(void *p) { free(p); }
+      void deallocate(void *p, MemoryAccess = MemoryAccess::Device) { free(p); }
       void memcpy(void *dst, const void *src, size_t size) { std::memcpy(dst, src, size); }
       void memset(void *p, int val, size_t size) { std::memset(p, val, size); }
     };

--- a/include/camp/resource/platform.hpp
+++ b/include/camp/resource/platform.hpp
@@ -27,6 +27,11 @@ namespace resources
       sycl = 16
     };
 
+    enum class MemoryAccess {
+      Device,
+      Pinned,
+      Managed
+    };
   }  // namespace v1
 }  // namespace resources
 }  // namespace camp

--- a/include/camp/resource/platform.hpp
+++ b/include/camp/resource/platform.hpp
@@ -28,6 +28,7 @@ namespace resources
     };
 
     enum class MemoryAccess {
+      Unknown,
       Device,
       Pinned,
       Managed

--- a/include/camp/resource/sycl.hpp
+++ b/include/camp/resource/sycl.hpp
@@ -156,6 +156,7 @@ namespace resources
         if (size > 0) {
           ret = sycl::malloc_shared<T>(size, *qu);
           switch (ma) {
+            case MemoryAccess::Unknown:
             case MemoryAccess::Device:
               ret = sycl::malloc_device(sizeof(T) * size, *qu);
               break;

--- a/include/camp/resource/sycl.hpp
+++ b/include/camp/resource/sycl.hpp
@@ -155,6 +155,17 @@ namespace resources
         T *ret = nullptr;
         if (size > 0) {
           ret = sycl::malloc_shared<T>(size, *qu);
+          switch (ma) {
+            case MemoryAccess::Device:
+              ret = sycl::malloc_device(sizeof(T) * size, *qu);
+              break;
+            case MemoryAccess::Pinned:
+              ret = sycl::malloc_host(sizeof(T) * size, *qu);
+              break;
+            case MemoryAccess::Managed:
+              ret = sycl::malloc_shared(sizeof(T) * size, *qu);
+              break;
+          }
         }
         return ret;
       }


### PR DESCRIPTION
@rhornung67

Here's my first cut at adding different allocation types to the resources.  I decided to start it off as an argument that's defaulted to device, but if we want them to be separate functions that's an option.  There are three modes, device, pinned, and managed currently.  I'm tempted to make it device, *shared* and managed so that it's based on the access semantics of the memory rather than the location, but most people aren't used to that (it's what we've been working on for OpenMP, pinned and true shared can provide the same stronger guarantee than managed can, but on cuda, sycl and hip both shared and managed are accessed through the same function).

One aspect I'm not terribly fond of is having to pass the access type to the free as well.  While SYCL doesn't need it, and OpenMP probably won't need it when it matters, technically both cuda and hip do.  It's possible to query the type of memory from them to decide, but it's not a fast operation, and they don't do it internally, so we have to either always incur that cost, or pass the requirement to identify the memory type to the user.

Thoughts on this would be appreciated.