### PR TITLE
Only change device if necessary in device guards

### DIFF
--- a/include/camp/resource/cuda.hpp
+++ b/include/camp/resource/cuda.hpp
@@ -32,13 +32,22 @@ namespace resources
         device_guard(int device)
         {
           campCudaErrchk(cudaGetDevice(&prev_device));
-          campCudaErrchk(cudaSetDevice(device));
+          if (device != prev_device) {
+            campCudaErrchk(cudaSetDevice(device));
+          } else {
+            prev_device = -1;
+          }
         }
 
-        ~device_guard() { campCudaErrchk(cudaSetDevice(prev_device)); }
+        ~device_guard()
+        {
+          if (prev_device != -1) {
+            campCudaErrchk(cudaSetDevice(prev_device));
+          }
+        }
 
-      int prev_device;
-    };
+        int prev_device;
+      };
 
     }  // namespace
 

--- a/include/camp/resource/cuda.hpp
+++ b/include/camp/resource/cuda.hpp
@@ -46,7 +46,7 @@ namespace resources
           }
         }
 
-        int prev_device;
+        int prev_device = -1;
       };
 
     }  // namespace

--- a/include/camp/resource/hip.hpp
+++ b/include/camp/resource/hip.hpp
@@ -31,13 +31,22 @@ namespace resources
         device_guard(int device)
         {
           campHipErrchk(hipGetDevice(&prev_device));
-          campHipErrchk(hipSetDevice(device));
+          if (device != prev_device) {
+            campHipErrchk(hipSetDevice(device));
+          } else {
+            prev_device = -1;
+          }
         }
 
-        ~device_guard() { campHipErrchk(hipSetDevice(prev_device)); }
+        ~device_guard()
+        {
+          if (prev_device != -1) {
+            campHipErrchk(hipSetDevice(prev_device));
+          }
+        }
 
-      int prev_device;
-    };
+        int prev_device;
+      };
 
     }  // namespace
     class HipEvent

--- a/include/camp/resource/hip.hpp
+++ b/include/camp/resource/hip.hpp
@@ -45,7 +45,7 @@ namespace resources
           }
         }
 
-        int prev_device;
+        int prev_device = -1;
       };
 
     }  // namespace


### PR DESCRIPTION
Do not change device if the requested device is already in use.
This let's us avoid overheads especially during profiling as these are
used frequently.