### PR TITLE
Specify unused vars in resource test for old gccs.

### DIFF
--- a/include/camp/defines.hpp
+++ b/include/camp/defines.hpp
@@ -26,8 +26,13 @@ http://github.com/llnl/camp
 namespace camp
 {
 
+template <typename... T>
+void varsink(T &&...) noexcept
+{
+}
+
 #if defined(__NVCC__)
-#define CAMP_ALLOW_UNUSED_LOCAL(X) sink(X)
+#define CAMP_ALLOW_UNUSED_LOCAL(X) varsink(X)
 #else
 #define CAMP_ALLOW_UNUSED_LOCAL(X) (void)(X)
 #endif

--- a/include/camp/defines.hpp
+++ b/include/camp/defines.hpp
@@ -26,13 +26,8 @@ http://github.com/llnl/camp
 namespace camp
 {
 
-template <typename... T>
-void varsink(T &&...) noexcept
-{
-}
-
 #if defined(__NVCC__)
-#define CAMP_ALLOW_UNUSED_LOCAL(X) varsink(X)
+#define CAMP_ALLOW_UNUSED_LOCAL(X) camp::sink(X)
 #else
 #define CAMP_ALLOW_UNUSED_LOCAL(X) (void)(X)
 #endif

--- a/test/resource.cpp
+++ b/test/resource.cpp
@@ -252,6 +252,7 @@ TEST(CampEventProxy, Get)
   {
     EventProxy<Host> ep{h1};
     HostEvent e = ep;
+    CAMP_ALLOW_UNUSED_LOCAL(e);
   }
 
   {
@@ -264,6 +265,7 @@ TEST(CampEventProxy, Get)
 
   {
     HostEvent e = do_stuff(h1);
+    CAMP_ALLOW_UNUSED_LOCAL(e);
   }
 
   {
@@ -283,6 +285,7 @@ TEST(CampEventProxy, Get)
   {
     EventProxy<Host> ep{h1};
     HostEvent e = ep.get();
+    CAMP_ALLOW_UNUSED_LOCAL(e);
   }
 }
 


### PR DESCRIPTION
Needed for older gcc's in RAJA tests.