### PR TITLE
Fix warning in EventProxy copy constructor

### DIFF
--- a/include/camp/resource.hpp
+++ b/include/camp/resource.hpp
@@ -189,7 +189,7 @@ namespace resources
       using native_event = ::camp::resources::detail::get_event_type<Res>;
 
       EventProxy(EventProxy &&) = default;
-      EventProxy(EventProxy &) = delete;
+      EventProxy(EventProxy const &) = delete;
       EventProxy &operator=(EventProxy &&) = default;
       EventProxy &operator=(EventProxy const &) = delete;
 


### PR DESCRIPTION
Change the EventProxy copy constructor signature to const& to avoid a warning from the intel compiler.