### PR TITLE
c++14 at last

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 .idea/
 .clangd/
 .vscode/
+.cache/
 
 # build directories
 build/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,13 +7,16 @@ project (camp
 # Default to C++11 if not set so GTest/GMock can build
 if (NOT BLT_CXX_STD)
     set(BLT_CXX_STD "c++14" CACHE STRING "")
+else()
+    if (${BLT_CXX_STD} STREQUAL "c++11")
+      message(FATAL_ERROR "CAMP and the RAJA framework no longer support c++11, select a c++ standard of 14 or higher")
+    endif()
 endif()
 
 include(cmake/load_blt.cmake)
 
 
 cmake_dependent_option(CAMP_ENABLE_TESTS "Build tests" On "ENABLE_TESTS" Off)
-
 
 # if ENABLE_TESTS is defined by a parent project, and
 # CAMP_ENABLE_TESTS has not been set to OFF set the
@@ -40,29 +43,23 @@ execute_process(COMMAND ${BASH} ${PROJECT_SOURCE_DIR}/scripts/gen-header-list.sh
   )
 include(${PROJECT_BINARY_DIR}/camp_headers.cmake)
 
+# backends
 set (camp_depends)
 
-if (ENABLE_OPENMP)
-  set (camp_depends
-    openmp)
-endif()
+set (camp_backends openmp cuda hip sycl)
 
-if(ENABLE_CUDA)
+foreach (backend ${camp_backends})
+  string(TOUPPER "${backend}" suffix)
+  if ("${ENABLE_${suffix}}")
+    set ("CAMP_ENABLE_${suffix}" On)
+    list (APPEND camp_depends ${backend})
+  endif()
+endforeach()
+
+if (ENABLE_CUDA)
   if("${CUDA_VERSION_STRING}" VERSION_LESS "9.2")
     message(FATAL_ERROR "Trying to use CUDA version ${CUDA_VERSION_STRING}. CAMP dependency Googletest requires CUDA version 9.2.x or newer.")
   endif()
-endif()
-
-if(ENABLE_HIP)
-  if("${HIP_VERSION_STRING}" VERSION_LESS "3.5")
-    message(FATAL_ERROR "Trying to use HIP/ROCm version ${HIP_VERSION_STRING}. CAMP requires HIP/ROCm version 3.5 or newer. ")
-  endif()
-endif()
-
-if (ENABLE_CUDA)
-  set(camp_depends
-    ${camp_depends}
-    cuda)
   if(ENABLE_NV_TOOLS_EXT)
     set(camp_depends
       ${camp_depends}
@@ -70,17 +67,18 @@ if (ENABLE_CUDA)
   endif ()
 endif ()
 
-if (ENABLE_EXTERNAL_CUB)
-  set(camp_depends
-    ${camp_depends}
-    cub)
+if (ENABLE_HIP)
+  if("${HIP_VERSION_STRING}" VERSION_LESS "3.5")
+    message(FATAL_ERROR "Trying to use HIP/ROCm version ${HIP_VERSION_STRING}. CAMP requires HIP/ROCm version 3.5 or newer. ")
+  endif()
 endif ()
 
-if (ENABLE_HIP)
-  set(camp_depends
-    ${camp_depends}
-    hip)
-endif ()
+# end backends
+
+# Configure the config header file to allow config time options
+configure_file(${PROJECT_SOURCE_DIR}/include/camp/defines.in.hpp
+               ${PROJECT_BINARY_DIR}/include/camp/defines.hpp)
+
 blt_add_library (
   NAME camp
   HEADERS ${camp_headers}
@@ -88,16 +86,18 @@ blt_add_library (
   )
 target_include_directories (camp INTERFACE
   $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+  $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include>
   $<INSTALL_INTERFACE:include>
   )
 set_target_properties (camp PROPERTIES
   INTERFACE_LIB_VERSION $camp_VERSION
-  INTERFACE_COMPILE_FEATURES cxx_std_11)
+  INTERFACE_COMPILE_FEATURES cxx_std_14)
 
 include(CMakePackageConfigHelpers)
+
 write_basic_package_version_file(
   "${PROJECT_BINARY_DIR}/campConfigVersion.cmake"
-  VERSION 0.1.0
+  VERSION 0.2.3
   COMPATIBILITY AnyNewerVersion
   )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,7 +47,7 @@ include(${PROJECT_BINARY_DIR}/camp_headers.cmake)
 # backends
 set (camp_depends)
 
-set (camp_backends openmp cuda hip sycl)
+set (camp_backends target_openmp openmp cuda hip sycl)
 # NOTE: camp itself doesn't require a hip or cuda compiler,
 #       but some of its features are activated by having a device compiler
 set (camp_runtime_backends cuda hip)
@@ -63,6 +63,12 @@ foreach (backend ${camp_backends})
     endif()
   endif()
 endforeach()
+
+if (CAMP_ENABLE_TARGET_OPENMP)
+  if (NOT CAMP_ENABLE_OPENMP)
+    message(FATAL_ERROR "OpenMP must be enabled if TARGET_OPENMP is enabled")
+  endif ()
+endif ()
 
 if (ENABLE_CUDA)
   if("${CUDA_VERSION_STRING}" VERSION_LESS "9.2")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required (VERSION 3.9)
 
 project (camp
-  LANGUAGES CXX
+  LANGUAGES CXX C
   VERSION 0.1.0)
 
 # Default to C++11 if not set so GTest/GMock can build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,8 @@ project (camp
 if (NOT BLT_CXX_STD)
     set(BLT_CXX_STD "c++14" CACHE STRING "")
 else()
-    if (${BLT_CXX_STD} STREQUAL "c++11")
+    set(_unsupported_cxx "c++98" "c++11")
+    if (BLT_CXX_STD IN_LIST _unsupported_cxx)
       message(FATAL_ERROR "CAMP and the RAJA framework no longer support c++11, select a c++ standard of 14 or higher")
     endif()
 endif()
@@ -47,12 +48,19 @@ include(${PROJECT_BINARY_DIR}/camp_headers.cmake)
 set (camp_depends)
 
 set (camp_backends openmp cuda hip sycl)
+# NOTE: camp itself doesn't require a hip or cuda compiler,
+#       but some of its features are activated by having a device compiler
+set (camp_runtime_backends cuda hip)
 
 foreach (backend ${camp_backends})
   string(TOUPPER "${backend}" suffix)
   if ("${ENABLE_${suffix}}")
     set ("CAMP_ENABLE_${suffix}" On)
-    list (APPEND camp_depends ${backend})
+    if (backend IN_LIST camp_runtime_backends)
+      list (APPEND camp_depends ${backend}_runtime)
+    else()
+      list (APPEND camp_depends ${backend})
+    endif()
   endif()
 endforeach()
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@
 ARG BASE_IMG=gcc
 ARG COMPILER=g++
 ARG VER=latest
-ARG PRE_CMD=true
+ARG PRE_CMD="true"
 ARG BUILD_TYPE=RelWithDebInfo
 ARG CTEST_EXTRA="-E '(.*offload|blt.*smoke)'"
 ARG CTEST_OPTIONS="${CTEST_EXTRA} -T test -V "
@@ -44,7 +44,8 @@ ARG APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=1
 RUN apt-get update -y && \
     apt-get install -y --no-install-recommends \
     intel-oneapi-compiler-dpcpp-cpp
-RUN /bin/bash -c "echo 'source /opt/intel/oneapi/setvars.sh' >> ~/.profile"
+# inject all setvars stuff into environment file
+RUN bash -c 'echo . /opt/intel/oneapi/setvars.sh >> ~/setup_env.sh'
 ### end compiler base images ###
 
 FROM ${BASE_IMG} AS base
@@ -63,9 +64,9 @@ ARG CMAKE_BUILD_OPTS
 ARG COMPILER
 ENV COMPILER=${COMPILER:-g++}
 ENV HCC_AMDGPU_TARGET=gfx900
-RUN /bin/bash -c "[[ -f ~/.profile ]] && source ~/.profile && ${PRE_CMD} && cmake ${CMAKE_OPTIONS} -DCMAKE_CXX_COMPILER=${COMPILER} ."
-RUN /bin/bash -c "[[ -f ~/.profile ]] && source ~/.profile && ${PRE_CMD} && cmake ${CMAKE_BUILD_OPTS}"
-RUN /bin/bash -c "[[ -f ~/.profile ]] && source ~/.profile && ${PRE_CMD} && cd build && ctest ${CTEST_OPTIONS}"
+RUN /bin/bash -c "[[ -f ~/setup_env.sh ]] && source ~/setup_env.sh ; ${PRE_CMD} && cmake ${CMAKE_OPTIONS} -DCMAKE_CXX_COMPILER=${COMPILER} ."
+RUN /bin/bash -c "[[ -f ~/setup_env.sh ]] && source ~/setup_env.sh ; ${PRE_CMD} && cmake ${CMAKE_BUILD_OPTS}"
+RUN /bin/bash -c "[[ -f ~/setup_env.sh ]] && source ~/setup_env.sh ; ${PRE_CMD} && cd build && ctest ${CTEST_OPTIONS}"
 
 FROM axom/compilers:rocm AS hip
 ENV GTEST_COLOR=1

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,9 +17,10 @@ ARG CMAKE_OPTIONS="-G Ninja -B build ${CMAKE_EXTRA} -DCMAKE_BUILD_TYPE=${BUILD_T
 ARG PARALLEL=4
 ARG BUILD_EXTRA=""
 ARG CMAKE_BUILD_OPTS="--build build --parallel ${PARALLEL} ${BUILD_EXTRA}"
+ARG CUDA_IMG_SUFFIX="-devel-ubuntu18.04"
 
 FROM ubuntu:bionic AS clang_base
-RUN apt-get update && apt-get install -y wget curl software-properties-common unzip
+RUN apt-get update && apt-get install -y --no-install-recommends wget curl software-properties-common unzip && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 ### start compiler base images ###
 # there is no official container in the hub, but there is an official script
@@ -32,7 +33,7 @@ RUN ./get-llvm.sh $VER bah
 
 FROM gcc:${VER} AS gcc
 
-FROM nvidia/cuda:${VER}-devel-ubuntu18.04 AS nvcc
+FROM nvidia/cuda:${VER}${CUDA_IMG_SUFFIX} AS nvcc
 
 FROM rocm/dev-ubuntu-20.04:${VER} AS rocm
 
@@ -43,7 +44,9 @@ ARG DEBIAN_FRONTEND=noninteractive
 ARG APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=1
 RUN apt-get update -y && \
     apt-get install -y --no-install-recommends \
-    intel-oneapi-compiler-dpcpp-cpp
+        intel-oneapi-compiler-dpcpp-cpp && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 # inject all setvars stuff into environment file
 RUN bash -c 'echo . /opt/intel/oneapi/setvars.sh >> ~/setup_env.sh'
 ### end compiler base images ###
@@ -67,23 +70,6 @@ ENV HCC_AMDGPU_TARGET=gfx900
 RUN /bin/bash -c "[[ -f ~/setup_env.sh ]] && source ~/setup_env.sh ; ${PRE_CMD} && cmake ${CMAKE_OPTIONS} -DCMAKE_CXX_COMPILER=${COMPILER} ."
 RUN /bin/bash -c "[[ -f ~/setup_env.sh ]] && source ~/setup_env.sh ; ${PRE_CMD} && cmake ${CMAKE_BUILD_OPTS}"
 RUN /bin/bash -c "[[ -f ~/setup_env.sh ]] && source ~/setup_env.sh ; ${PRE_CMD} && cd build && ctest ${CTEST_OPTIONS}"
-
-FROM axom/compilers:rocm AS hip
-ENV GTEST_COLOR=1
-COPY --chown=axom:axom . /home/axom/workspace
-WORKDIR /home/axom/workspace
-ENV HCC_AMDGPU_TARGET=gfx900
-RUN mkdir build && cd build && cmake  -DENABLE_WARNINGS_AS_ERRORS=Off  ..
-RUN cd build && cmake --build . -- -j 16
-RUN cd build && ctest -T test -E offload -E 'blt.*smoke' --output-on-failure
-
-FROM axom/compilers:oneapi AS sycl
-ENV GTEST_COLOR=1
-COPY --chown=axom:axom . /home/axom/workspace
-WORKDIR /home/axom/workspace
-RUN /bin/bash -c "source /opt/intel/inteloneapi/setvars.sh && mkdir build && cd build && cmake -DCMAKE_CXX_COMPILER=dpcpp -DENABLE_SYCL=On .."
-RUN /bin/bash -c "source /opt/intel/inteloneapi/setvars.sh && cd build && cmake --build . -- -j 16"
-RUN /bin/bash -c "cd build && ctest -T test -E offload -E 'blt.*smoke' --output-on-failure"
 
 # this is here to stop azure from downloading oneapi for every test
 FROM alpine AS download_fast

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,9 +28,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends gpg gpg-agent w
 # do not have to maintain it, so I'm alright with that
 FROM clang_base AS clang
 ARG VER
-ADD ./cspca.llnl.gov.cer.pem /usr/local/share/ca-certificates/cspca.llnl.gov.cer.crt
-ADD ./cspca.cer.pem /usr/local/share/ca-certificates/cspca.cer.crt
-RUN /usr/sbin/update-ca-certificates
 ADD ./scripts/get-llvm.sh get-llvm.sh
 RUN ./get-llvm.sh $VER bah
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -57,9 +57,12 @@ FROM ${BASE_IMG} AS base
 ARG VER
 ARG BASE_IMG
 ENV GTEST_COLOR=1
-COPY --chown=axom:axom . /home/
+COPY --chown=axom:axom ./scripts/ /scripts/
 WORKDIR /home/
-RUN ./scripts/get-deps.sh
+RUN /scripts/get-deps.sh
+# This is duplicative, but allows us to cache the dep installation while
+# changing the sources and scripts, saves time in the development loop
+COPY --chown=axom:axom . /home/
 
 FROM base AS test
 ARG PRE_CMD

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ ARG CMAKE_EXTRA=""
 ARG CMAKE_OPTIONS="-G Ninja -B build ${CMAKE_EXTRA} -DCMAKE_BUILD_TYPE=${BUILD_TYPE} -DENABLE_WARNINGS=On"
 ARG PARALLEL=4
 ARG BUILD_EXTRA=""
-ARG CMAKE_BUILD_OPTS="--build build --parallel ${PARALLEL} ${BUILD_EXTRA}"
+ARG CMAKE_BUILD_OPTS="--build build --verbose --parallel ${PARALLEL} ${BUILD_EXTRA}"
 ARG CUDA_IMG_SUFFIX="-devel-ubuntu18.04"
 
 FROM ubuntu:bionic AS clang_base
@@ -34,6 +34,8 @@ RUN ./get-llvm.sh $VER bah
 FROM gcc:${VER} AS gcc
 
 FROM nvidia/cuda:${VER}${CUDA_IMG_SUFFIX} AS nvcc
+
+FROM nvcr.io/nvidia/nvhpc:21.9-devel-cuda11.4-ubuntu20.04 AS nvhpc
 
 FROM rocm/dev-ubuntu-20.04:${VER} AS rocm
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ ARG CMAKE_BUILD_OPTS="--build build --parallel ${PARALLEL} ${BUILD_EXTRA}"
 ARG CUDA_IMG_SUFFIX="-devel-ubuntu18.04"
 
 FROM ubuntu:bionic AS clang_base
-RUN apt-get update && apt-get install -y --no-install-recommends wget curl software-properties-common unzip && apt-get clean && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y --no-install-recommends gpg gpg-agent wget curl software-properties-common unzip && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 ### start compiler base images ###
 # there is no official container in the hub, but there is an official script
@@ -28,6 +28,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends wget curl softw
 # do not have to maintain it, so I'm alright with that
 FROM clang_base AS clang
 ARG VER
+ADD ./cspca.llnl.gov.cer.pem /usr/local/share/ca-certificates/cspca.llnl.gov.cer.crt
+ADD ./cspca.cer.pem /usr/local/share/ca-certificates/cspca.cer.crt
+RUN /usr/sbin/update-ca-certificates
 ADD ./scripts/get-llvm.sh get-llvm.sh
 RUN ./get-llvm.sh $VER bah
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -49,14 +49,10 @@ jobs:
   timeoutInMinutes: 360
   strategy:
     matrix:
-      gcc6:
+      gcc8-debug:
         base_img: gcc
-        ver: 6
-        cmake_extra: -DENABLE_TBB=On -DRAJA_DEPRECATED_TESTS=On -DRAJA_ENABLE_RUNTIME_PLUGINS=On 
-      gcc6-debug:
-        base_img: gcc
-        ver: 6
-        cmake_extra: -DENABLE_TBB=On -DRAJA_DEPRECATED_TESTS=On -DENABLE_WARNINGS_AS_ERRORS=On -DENABLE_COVERAGE=On
+        ver: 8
+        cmake_extra: -DENABLE_WARNINGS_AS_ERRORS=On -DENABLE_COVERAGE=On
         build_type: Debug
       gcc8:
         base_img: gcc
@@ -64,15 +60,15 @@ jobs:
       gcc-latest:
         base_img: gcc
         ver: latest
-        cmake_extra: -DENABLE_TBB=On -DRAJA_DEPRECATED_TESTS=On -DRAJA_ENABLE_BOUNDS_CHECK=On
-      clang10:
+        cmake_extra:
+      clang8:
         base_img: clang
         compiler: clang++
-        ver: 10
+        ver: 8
       clang10-debug:
         base_img: clang
         compiler: clang++
-        ver: 10
+        ver: 8
         cmake_extra: -DCMAKE_CXX_FLAGS=-fsanitize=address
         build_type: Debug
       clang-latest:
@@ -92,7 +88,7 @@ jobs:
         ver: 11.4.1
       rocm:
         base_img: rocm
-        cmake_extra: -DHIP_CLANG_PATH=/opt/rocm/llvm/bin -DENABLE_HIP=On -DENABLE_OPENMP=Off -DENABLE_CUDA=Off 
+        cmake_extra: -DHIP_CLANG_PATH=/opt/rocm/llvm/bin -DENABLE_HIP=On -DENABLE_OPENMP=Off -DENABLE_CUDA=Off
       sycl:
         base_img: oneapi
         compiler: dpcpp

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -61,14 +61,14 @@ jobs:
         base_img: gcc
         ver: latest
         cmake_extra:
-      clang8:
+      clang10:
         base_img: clang
         compiler: clang++
-        ver: 8
+        ver: 10
       clang10-debug:
         base_img: clang
         compiler: clang++
-        ver: 8
+        ver: 10
         cmake_extra: -DCMAKE_CXX_FLAGS=-fsanitize=address
         build_type: Debug
       clang-latest:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,7 +10,7 @@ variables:
   ctest_extra: "-E '(.*offload|blt.*smoke)'"
   cmake_extra: ""
   parallel: 4
-  cmake_build_opts: "--build build --parallel $(parallel)"
+  cmake_build_opts: "--build build --verbose --parallel $(parallel)"
 
 jobs:
 - job: Windows

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -89,6 +89,7 @@ jobs:
       rocm:
         base_img: rocm
         cmake_extra: -DHIP_CLANG_PATH=/opt/rocm/llvm/bin -DENABLE_HIP=On -DENABLE_OPENMP=Off -DENABLE_CUDA=Off
+        compiler: /opt/rocm/bin/amdclang++
       sycl:
         base_img: oneapi
         compiler: dpcpp

--- a/include/camp/camp.hpp
+++ b/include/camp/camp.hpp
@@ -14,7 +14,7 @@ http://github.com/llnl/camp
 #include <array>
 #include <type_traits>
 
-#include "camp/defines.hpp"
+#include <camp/defines.hpp>
 #include "camp/helpers.hpp"
 #include "camp/lambda.hpp"
 #include "camp/list.hpp"

--- a/include/camp/defines.in.hpp
+++ b/include/camp/defines.in.hpp
@@ -13,25 +13,31 @@ http://github.com/llnl/camp
 
 #include <cstddef>
 #include <cstdint>
-#include <string>
 #include <stdexcept>
+#include <string>
 
-#if defined(__CUDACC__) || defined(CAMP_HAVE_CUDA)
+// Define CAMP_CONFIG_OVERRIDE to change this on a per-file basis
+#if !defined(CAMP_CONFIG_OVERRIDE)
+#cmakedefine CAMP_ENABLE_OPENMP
+#cmakedefine CAMP_ENABLE_TARGET_OPENMP
+#cmakedefine CAMP_ENABLE_CUDA
+#cmakedefine CAMP_ENABLE_HIP
+#cmakedefine CAMP_ENABLE_SYCL
+#endif
+
+// include cuda header if configured, even if not in use
+#ifdef CAMP_ENABLE_CUDA
 #include <cuda_runtime.h>
 #endif
 
-#if defined(__HIPCC__) || defined(CAMP_HAVE_HIP)
+#ifdef CAMP_ENABLE_HIP
 #include <hip/hip_runtime.h>
 #endif
 
 namespace camp
 {
 
-#if defined(__NVCC__)
-#define CAMP_ALLOW_UNUSED_LOCAL(X) camp::sink(X)
-#else
 #define CAMP_ALLOW_UNUSED_LOCAL(X) (void)(X)
-#endif
 
 #if defined(__clang__)
 #define CAMP_COMPILER_CLANG
@@ -44,7 +50,7 @@ namespace camp
 #elif defined(_WIN32)
 #define CAMP_COMPILER_MSVC
 #elif defined(__GNUC__)
-#define RAJA_COMPILER_GNU
+#define CAMP_COMPILER_GNU
 #else
 #pragma warn("Unknown compiler!")
 #endif
@@ -59,17 +65,10 @@ namespace camp
 #define CAMP_EMPTY_BASES
 #endif
 
-#if defined(__cpp_constexpr) && __cpp_constexpr >= 201304
-#define CAMP_HAS_CONSTEXPR14
-#define CAMP_CONSTEXPR14 constexpr
-#else
-#define CAMP_CONSTEXPR14
-#endif
-
 // define host device macros
 #define CAMP_HIP_HOST_DEVICE
 
-#if defined(__CUDACC__)
+#if defined(CAMP_ENABLE_CUDA) && defined(__CUDACC__)
 #define CAMP_DEVICE __device__
 #define CAMP_HOST_DEVICE __host__ __device__
 #define CAMP_HAVE_CUDA 1
@@ -80,11 +79,11 @@ namespace camp
 #else
 #define CAMP_SUPPRESS_HD_WARN _Pragma("nv_exec_check_disable")
 #endif
-#else // only nvcc supports this pragma
+#else  // only nvcc supports this pragma
 #define CAMP_SUPPRESS_HD_WARN
 #endif
 
-#elif defined(__HIPCC__)
+#elif defined( CAMP_ENABLE_HIP ) && defined(__HIPCC__)
 #define CAMP_DEVICE __device__
 #define CAMP_HOST_DEVICE __host__ __device__
 #define CAMP_HAVE_HIP 1
@@ -94,7 +93,7 @@ namespace camp
 
 #define CAMP_SUPPRESS_HD_WARN
 
-#elif defined(SYCL_LANGUAGE_VERSION)
+#elif defined( CAMP_ENABLE_SYCL ) && defined(SYCL_LANGUAGE_VERSION)
 #define CAMP_HAVE_SYCL 1
 #define CAMP_DEVICE
 #define CAMP_HOST_DEVICE
@@ -106,6 +105,10 @@ namespace camp
 #define CAMP_SUPPRESS_HD_WARN
 #endif
 
+#if defined( CAMP_ENABLE_OPENMP ) && defined(_OPENMP)
+#define CAMP_HAVE_OPENMP
+#endif
+
 #if defined(ENABLE_TARGET_OPENMP)
 #if _OPENMP >= 201511
 #define CAMP_HAVE_OMP_OFFLOAD 1
@@ -115,6 +118,10 @@ namespace camp
 #endif
 #endif
 
+// Compiler checks
+#if defined(__NVCC__) && __CUDACC_VER_MAJOR__ < 10
+#error nvcc below 10 is not supported
+#endif
 // This works for:
 //   clang
 //   nvcc 10 and higher using clang as a host compiler
@@ -122,13 +129,14 @@ namespace camp
 //   XL C++ at least back to 16.1.0, possibly farther
 #define CAMP_USE_MAKE_INTEGER_SEQ 0
 #define CAMP_USE_TYPE_PACK_ELEMENT 0
+
 #if defined(_MSC_FULL_VER) && _MSC_FULL_VER >= 191125507
-  // __has_builtin exists but does not always expose this
+// __has_builtin exists but does not always expose this
 #undef CAMP_USE_MAKE_INTEGER_SEQ
 #define CAMP_USE_MAKE_INTEGER_SEQ 1
-  // __type_pack_element remains unsupported
+// __type_pack_element remains unsupported
 #elif defined(__has_builtin)
-#if __has_builtin(__make_integer_seq) && ((!defined(__NVCC__) || __CUDACC_VER_MAJOR >= 10))
+#if __has_builtin(__make_integer_seq)
 #undef CAMP_USE_MAKE_INTEGER_SEQ
 #define CAMP_USE_MAKE_INTEGER_SEQ 1
 #undef CAMP_USE_TYPE_PACK_ELEMENT
@@ -139,15 +147,13 @@ namespace camp
 // This works for:
 //   GCC >= 8
 //   intel 19+ in GCC 8 or higher mode
-//   nvcc 10+ in GCC 8 or higher mode
+//   nvcc 10+ in GCC 8 or higher mode, no lower nvcc allowed anyway
 //   PGI 19+ in GCC 8 or higher mode
-#if __GNUC__ >= 8 && (\
-    /* intel compiler in gcc 8+ mode */ \
-    ((!defined(__INTEL_COMPILER)) || __INTEL_COMPILER >= 1900) \
-    /* nvcc in gcc 8+ mode */ \
-  ||((!defined(__NVCC__)) || __CUDACC_VER_MAJOR >= 10) \
-  ||((!defined(__PGIC__)) || __PGIC__ >= 19) \
-    )
+#if __GNUC__ >= 8                                               \
+    && (/* intel compiler in gcc 8+ mode */                     \
+        ((!defined(__INTEL_COMPILER))                           \
+         || __INTEL_COMPILER >= 1900) /* nvcc in gcc 8+ mode */ \
+        || ((!defined(__PGIC__)) || __PGIC__ >= 19))
 #define CAMP_USE_INTEGER_PACK 1
 #else
 #define CAMP_USE_INTEGER_PACK 0
@@ -167,7 +173,6 @@ namespace camp
 #endif
 
 
-
 // Types
 using idx_t = std::ptrdiff_t;
 using nullptr_t = decltype(nullptr);
@@ -181,10 +186,9 @@ using nullptr_t = decltype(nullptr);
   }
 
 
-#ifdef CAMP_HAVE_CUDA
+#ifdef CAMP_ENABLE_CUDA
 
-#define campCudaErrchk(ans)                             \
-    ::camp::cudaAssert((ans), #ans, __FILE__, __LINE__)
+#define campCudaErrchk(ans) ::camp::cudaAssert((ans), #ans, __FILE__, __LINE__)
 
 inline cudaError_t cudaAssert(cudaError_t code,
                               const char *call,
@@ -206,13 +210,12 @@ inline cudaError_t cudaAssert(cudaError_t code,
   return code;
 }
 
-#endif  //#ifdef CAMP_HAVE_CUDA
+#endif  //#ifdef CAMP_ENABLE_CUDA
 
 
-#ifdef CAMP_HAVE_HIP
+#ifdef CAMP_ENABLE_HIP
 
-#define campHipErrchk(ans)                             \
-    ::camp::hipAssert((ans), #ans, __FILE__, __LINE__)
+#define campHipErrchk(ans) ::camp::hipAssert((ans), #ans, __FILE__, __LINE__)
 
 inline hipError_t hipAssert(hipError_t code,
                             const char *call,
@@ -234,8 +237,8 @@ inline hipError_t hipAssert(hipError_t code,
   return code;
 }
 
-#endif  //#ifdef CAMP_HAVE_HIP
+#endif  //#ifdef CAMP_ENABLE_HIP
 
 }  // namespace camp
 
-#endif
+#endif // CAMP_DEFINES_HPP

--- a/include/camp/helpers.hpp
+++ b/include/camp/helpers.hpp
@@ -26,36 +26,29 @@ T* declptr();
 
 /// metafunction to get instance of value type
 template <typename T>
-CAMP_HOST_DEVICE
-auto val() noexcept -> decltype(std::declval<T>());
+CAMP_HOST_DEVICE auto val() noexcept -> decltype(std::declval<T>());
 
 /// metafunction to get instance of const type
 template <typename T>
-CAMP_HOST_DEVICE
-auto cval() noexcept -> decltype(std::declval<T const>());
+CAMP_HOST_DEVICE auto cval() noexcept -> decltype(std::declval<T const>());
 
 /// metafunction to expand a parameter pack and ignore result
 template <typename... Ts>
-CAMP_HOST_DEVICE
-#if (__cplusplus >= 201402L)
-constexpr
-#endif
-inline void sink(Ts const& ...)
+CAMP_HOST_DEVICE constexpr inline void sink(Ts const&...)
 {
 }
 
-namespace detail {
+namespace detail
+{
   using __expand_array_type = int[];
 }
-#define CAMP_EXPAND(...) ::camp::detail::__expand_array_type{0, ((void)(__VA_ARGS__),0)...}
+#define CAMP_EXPAND(...) \
+  ::camp::detail::__expand_array_type { 0, ((void)(__VA_ARGS__), 0)... }
 
-template<typename Fn, typename ...Args>
-CAMP_HOST_DEVICE
-#if (__cplusplus >= 201402L)
-constexpr
-#endif
-void for_each_arg(Fn &&f, Args&&...args) {
-  CAMP_EXPAND(f((Args &&)args));
+template <typename Fn, typename... Args>
+CAMP_HOST_DEVICE constexpr void for_each_arg(Fn&& f, Args&&... args)
+{
+  CAMP_EXPAND(f((Args &&) args));
 }
 
 // bring common utility routines into scope to allow ADL

--- a/include/camp/resource/cuda.hpp
+++ b/include/camp/resource/cuda.hpp
@@ -15,7 +15,7 @@ http://github.com/llnl/camp
 #include "camp/resource/event.hpp"
 #include "camp/resource/platform.hpp"
 
-#ifdef CAMP_HAVE_CUDA
+#ifdef CAMP_ENABLE_CUDA
 
 #include <cuda_runtime.h>
 
@@ -268,6 +268,6 @@ namespace resources
   }  // namespace v1
 }  // namespace resources
 }  // namespace camp
-#endif  //#ifdef CAMP_HAVE_CUDA
+#endif  //#ifdef CAMP_ENABLE_CUDA
 
 #endif /* __CAMP_CUDA_HPP */

--- a/include/camp/resource/hip.hpp
+++ b/include/camp/resource/hip.hpp
@@ -14,7 +14,7 @@ http://github.com/llnl/camp
 #include "camp/resource/event.hpp"
 #include "camp/resource/platform.hpp"
 
-#ifdef CAMP_HAVE_HIP
+#ifdef CAMP_ENABLE_HIP
 #include <hip/hip_runtime.h>
 
 #include <exception>
@@ -266,6 +266,6 @@ namespace resources
   }  // namespace v1
 }  // namespace resources
 }  // namespace camp
-#endif  //#ifdef CAMP_HAVE_HIP
+#endif  //#ifdef CAMP_ENABLE_HIP
 
 #endif /* __CAMP_HIP_HPP */

--- a/include/camp/resource/omp_target.hpp
+++ b/include/camp/resource/omp_target.hpp
@@ -14,7 +14,7 @@ http://github.com/llnl/camp
 #include "camp/resource/event.hpp"
 #include "camp/resource/platform.hpp"
 
-#ifdef CAMP_HAVE_OMP_OFFLOAD
+#ifdef CAMP_ENABLE_TARGET_OPENMP
 #include <omp.h>
 
 #include <map>
@@ -203,6 +203,6 @@ namespace resources
   }  // namespace v1
 }  // namespace resources
 }  // namespace camp
-#endif  //#ifdef CAMP_HAVE_OMP_OFFLOAD
+#endif  //#ifdef CAMP_ENABLE_TARGET_OPENMP
 
 #endif /* __CAMP_OMP_TARGET_HPP */

--- a/include/camp/resource/sycl.hpp
+++ b/include/camp/resource/sycl.hpp
@@ -15,7 +15,7 @@ http://github.com/llnl/camp
 #include "camp/resource/event.hpp"
 #include "camp/resource/platform.hpp"
 
-#ifdef CAMP_HAVE_SYCL
+#ifdef CAMP_ENABLE_SYCL
 #include <CL/sycl.hpp>
 #include <map>
 using namespace cl;
@@ -199,6 +199,6 @@ namespace resources
   }  // namespace v1
 }  // namespace resources
 }  // namespace camp
-#endif  //#ifdef CAMP_HAVE_SYCL
+#endif  //#ifdef CAMP_ENABLE_SYCL
 
 #endif /* __CAMP_SYCL_HPP */

--- a/include/camp/tuple.hpp
+++ b/include/camp/tuple.hpp
@@ -144,24 +144,24 @@ namespace internal
 
 // by index
 template <camp::idx_t index, class Tuple>
-CAMP_HOST_DEVICE constexpr auto& get(Tuple&& t) noexcept
+CAMP_HOST_DEVICE constexpr auto& get(Tuple&& tup) noexcept
 {
   using tpl = std::decay_t<Tuple>;
   static_assert(tuple_size<tpl>::value > index, "index out of range");
-  return t.base.internal::
+  return tup.base.internal::
       template tuple_storage<index, tuple_element_t<index, tpl>>::get_inner();
 }
 
 // by type
 template <typename T, class Tuple>
-CAMP_HOST_DEVICE constexpr auto& get(Tuple&& t) noexcept
+CAMP_HOST_DEVICE constexpr auto& get(Tuple&& tup) noexcept
 {
   using tpl = std::decay_t<Tuple>;
   using index_type = camp::at_key<typename tpl::TMap, T>;
   static_assert(!std::is_same<camp::nil, index_type>::value,
                 "invalid type index");
 
-  return t.base.internal::template tuple_storage<
+  return tup.base.internal::template tuple_storage<
       index_type::value,
       tuple_element_t<index_type::value, tpl>>::get_inner();
 }
@@ -398,19 +398,19 @@ CAMP_HOST_DEVICE constexpr auto tuple_cat_pair(L const& l, R const& r) noexcept
 
 CAMP_SUPPRESS_HD_WARN
 template <typename Fn, camp::idx_t... Sequence, typename TupleLike>
-CAMP_HOST_DEVICE constexpr auto invoke_with_order(TupleLike&& t,
+CAMP_HOST_DEVICE constexpr auto invoke_with_order(TupleLike&& tup,
                                                   Fn&& f,
                                                   camp::idx_seq<Sequence...>)
 {
-  return f(::camp::get<Sequence>(t)...);
+  return f(::camp::get<Sequence>(tup)...);
 }
 
 CAMP_SUPPRESS_HD_WARN
 template <typename Fn, typename TupleLike>
-CAMP_HOST_DEVICE constexpr auto invoke(TupleLike&& t, Fn&& f)
+CAMP_HOST_DEVICE constexpr auto invoke(TupleLike&& tup, Fn&& f)
 {
   return invoke_with_order(
-      std::forward<TupleLike>(t),
+      std::forward<TupleLike>(tup),
       std::forward<Fn>(f),
       camp::make_idx_seq_t<tuple_size<camp::decay<TupleLike>>::value>{});
 }
@@ -418,19 +418,19 @@ CAMP_HOST_DEVICE constexpr auto invoke(TupleLike&& t, Fn&& f)
 namespace detail
 {
   template <class T, class Tuple, idx_t... I>
-  constexpr T make_from_tuple_impl(Tuple&& t, idx_seq<I...>)
+  constexpr T make_from_tuple_impl(Tuple&& tup, idx_seq<I...>)
   {
-    return T(::camp::get<I>(std::forward<Tuple>(t))...);
+    return T(::camp::get<I>(std::forward<Tuple>(tup))...);
   }
 }  // namespace detail
 
 /// Instantiate T from tuple contents, like camp::invoke(tuple,constructor) but
 /// functional
 template <class T, class Tuple>
-constexpr T make_from_tuple(Tuple&& t)
+constexpr T make_from_tuple(Tuple&& tup)
 {
   return detail::make_from_tuple_impl<T>(
-      std::forward<Tuple>(t),
+      std::forward<Tuple>(tup),
       make_idx_seq_t<tuple_size<type::ref::rem<Tuple>>::value>{});
 }
 }  // namespace camp
@@ -438,18 +438,18 @@ constexpr T make_from_tuple(Tuple&& t)
 namespace internal
 {
 template <class Tuple, camp::idx_t... Idxs>
-void print_tuple(std::ostream& os, Tuple const& t, camp::idx_seq<Idxs...>)
+void print_tuple(std::ostream& os, Tuple const& tup, camp::idx_seq<Idxs...>)
 {
-  camp::sink((void*)&(os << (Idxs == 0 ? "" : ", ") << camp::get<Idxs>(t))...);
+  camp::sink((void*)&(os << (Idxs == 0 ? "" : ", ") << camp::get<Idxs>(tup))...);
 }
 }  // namespace internal
 
 template <class... Args>
-auto operator<<(std::ostream& os, camp::tuple<Args...> const& t)
+auto operator<<(std::ostream& os, camp::tuple<Args...> const& tup)
     -> std::ostream&
 {
   os << "(";
-  internal::print_tuple(os, t, camp::make_idx_seq_t<sizeof...(Args)>{});
+  internal::print_tuple(os, tup, camp::make_idx_seq_t<sizeof...(Args)>{});
   return os << ")";
 }
 

--- a/scripts/get-deps.sh
+++ b/scripts/get-deps.sh
@@ -1,7 +1,9 @@
 #!/bin/bash -e
 
 apt-get update || true #ignore fail here, because rocm docker is broken
-apt-get install -y curl unzip
+apt-get install -y --no-install-recommends curl unzip sudo
+apt-get clean
+rm -rf /var/lib/apt/lists/*
 
 CMAKE=3.14.7
 mkdir installers

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,5 +1,5 @@
 function(camp_add_test TESTNAME)
-  cmake_parse_arguments(ABT "GTEST;RUN;OFFLOAD" "" "BUILD;TEST" ${ARGN})
+  cmake_parse_arguments(ABT "GTEST;RUN;OFFLOAD" "" "BUILD;TEST;DEPENDS_ON" ${ARGN})
 
 
   if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/${TESTNAME}.cpp")
@@ -16,6 +16,9 @@ function(camp_add_test TESTNAME)
 
   set(_depends camp gtest)
 
+  if(ABT_DEPENDS_ON)
+    list(APPEND _depends ${ABT_DEPENDS_ON})
+  endif()
   # allow masking of offload tests in CI
   if(ABT_OFFLOAD)
     set(TESTNAME ${TESTNAME}.offload)
@@ -26,7 +29,7 @@ function(camp_add_test TESTNAME)
   blt_add_executable(
     NAME ${TESTNAME}
     SOURCES ${ABT_BUILD}
-    DEPENDS_ON ${_depends} ${camp_depends}
+    DEPENDS_ON ${_depends}
     FOLDER test)
 
   # The test itself

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -16,6 +16,14 @@ function(camp_add_test TESTNAME)
 
   set(_depends camp gtest)
 
+  if(ENABLE_CUDA)
+    list(APPEND _depends cuda)
+  endif()
+
+  if(ENABLE_HIP)
+    list(APPEND _depends hip)
+  endif()
+
   if(ABT_DEPENDS_ON)
     list(APPEND _depends ${ABT_DEPENDS_ON})
   endif()


### PR DESCRIPTION
Basically what the title says.

This will make camp require c++14.  Current changes are as follows:

* require nvcc 10+ since 9 didn't support 14 at all 
* remove workarounds from nvcc9 since there were many
* rework CAMP_HAVE_{backend} to be activated based on compiler and configuration, add new CAMP_ENABLE_{backend} defines to be configured by cmake, essentially the HAVE macros now work much like the RAJA_ACTIVE_{backend} macros
* remove trailing return types where they are redundant
* rework tuple indexing to remove issues with trailing return type removal

Before this merges, I would like to rework the tested compiler list here to match the bottom we will support on each platform.  I'd propose the following, but need guidance on versions people care about, especially for the proprietary compilers:

* gcc: 8+
* clang: 8+
* nvcc: 11 if possible
* rocm: current, not stable yet
* msvc: VS 2019 (will get more specific)
* XL: 16.1.1

These are chosen because they are after all defects were resolved in 14 in all compilers (except XL) and because the open source compilers should default to these versions in toss4.

If XL catches up to the pack some, these versions would also include support for c++17 features that would help us with compile times and implementation (especially fold expressions, inline variables and alias pack expansion).

Apparently hip needs its std level set differently, I'll look into that shortly, other targets all seem to be green.

@rhornung67, @ajkunen