### PR TITLE
Add EventProxy constructor for pointer to resource.

### DIFF
--- a/include/camp/resource.hpp
+++ b/include/camp/resource.hpp
@@ -194,6 +194,7 @@ namespace resources
       EventProxy &operator=(EventProxy const &) = delete;
 
       EventProxy(Res r) : resource_{move(r)} {}
+      EventProxy(Res *r) : resource_{move(*r)} {}
 
       template <typename T = Res>
       typename std::enable_if<!detail::is_erased_resource_or_proxy<T>::value,


### PR DESCRIPTION
A compilation error occurred when updating the RAJA Proxy repo to RAJA v0.14.0, where Lulesh 2.0 complains about the lack of an EventProxy constructor. This PR should fix the error below, see related Proxy issue https://github.com/LLNL/RAJAProxies/issues/22.

/usr/workspace/wsrzc/chen59/allraja/rajaproxy/rajaproxy_git/tpl/RAJA/include/RAJA/policy/cuda/forall.hpp(221): error: no instance of constructor "camp::resources::v1::EventProxy<Res>::EventProxy [with Res=camp::resources::v1::Cuda]" matches the argument list 
            argument types are: (camp::resources::v1::Cuda *)
          detected during:
            instantiation of "camp::resources::v1::EventProxy<camp::resources::v1::Cuda> RAJA::policy::cuda::forall_impl(camp::resources::v1::Cuda &, RAJA::policy::cuda::cuda_exec<BlockSize, Async>, Iterable &&, LoopBody &&) [with Iterable=const RAJA::RangeStrideSegment &, LoopBody=lambda [](int)->void &, BlockSize=256UL, Async=true]" 
/usr/workspace/wsrzc/chen59/allraja/rajaproxy/rajaproxy_git/tpl/RAJA/include/RAJA/pattern/forall.hpp(562): here 
            instantiation of "camp::resources::v1::EventProxy<Res> RAJA::detail::CallForall::operator()(const T &, ExecPol, Body, Res &) const [with T=RAJA::RangeStrideSegment, ExecPol=Segment_Exec, Body=lambda [](int)->void, Res=camp::resources::v1::Cuda]" 
/usr/workspace/wsrzc/chen59/allraja/rajaproxy/rajaproxy_git/tpl/RAJA/include/RAJA/index/IndexSet.hpp(353): here 
            instantiation of "void RAJA::TypedIndexSet<T0, TREST...>::segmentCall(size_t, BODY &&, ARGS &&...) const [with T0=RAJA::RangeStrideSegment, TREST=<>, BODY=RAJA::detail::CallForall, ARGS=<Segment_Exec, const lambda [](int)->void &, camp::resources::v1::Cuda &>]" 
/usr/workspace/wsrzc/chen59/allraja/rajaproxy/rajaproxy_git/tpl/RAJA/include/RAJA/index/IndexSet.hpp(349): here
            instantiation of "void RAJA::TypedIndexSet<T0, TREST...>::segmentCall(size_t, BODY &&, ARGS &&...) const [with T0=RAJA::ListSegment, TREST=<RAJA::RangeStrideSegment>, BODY=RAJA::detail::CallForall, ARGS=<Segment_Exec, const lambda [](int)->void &, camp::resources::v1::Cuda &>]"
/usr/workspace/wsrzc/chen59/allraja/rajaproxy/rajaproxy_git/tpl/RAJA/include/RAJA/index/IndexSet.hpp(349): here
            instantiation of "void RAJA::TypedIndexSet<T0, TREST...>::segmentCall(size_t, BODY &&, ARGS &&...) const [with T0=RAJA::RangeSegment, TREST=<RAJA::ListSegment, RAJA::RangeStrideSegment>, BODY=RAJA::detail::CallForall, ARGS=<Segment_Exec, const lambda [](int)->void &, camp::resources::v1::Cuda &>]" 
/usr/workspace/wsrzc/chen59/allraja/rajaproxy/rajaproxy_git/tpl/RAJA/include/RAJA/pattern/forall.hpp(245): here
            instantiation of "camp::resources::v1::EventProxy<Res> RAJA::wrap::forall(Res &, RAJA::policy::indexset::ExecPolicy<SegmentIterPolicy, SegmentExecPolicy>, const RAJA::TypedIndexSet<SegmentTypes...> &, LoopBody) [with Res=camp::resources::v1::Cuda, SegmentIterPolicy=Segment_Iter, SegmentExecPolicy=Segment_Exec, LoopBody=lambda [](int)->void, SegmentTypes=<RAJA::RangeSegment, RAJA::ListSegment, RAJA::RangeStrideSegment>]"
/usr/workspace/wsrzc/chen59/allraja/rajaproxy/rajaproxy_git/tpl/RAJA/include/RAJA/pattern/forall.hpp(358): here
            instantiation of "camp::concepts::enable_if_t<camp::resources::v1::EventProxy<Res>, RAJA::type_traits::is_indexset_policy<ExecutionPolicy>> RAJA::policy_by_value_interface::forall(ExecutionPolicy &&, Res &, IdxSet &&, LoopBody &&) [with ExecutionPolicy=elem_exec_policy, Res=camp::resources::v1::Cuda, IdxSet=LULESH_ISET &, LoopBody=lambda [](int)->void]"
/usr/workspace/wsrzc/chen59/allraja/rajaproxy/rajaproxy_git/tpl/RAJA/include/RAJA/pattern/forall.hpp(528): here
            instantiation of "camp::concepts::enable_if_t<camp::resources::v1::EventProxy<Res>, RAJA::type_traits::is_resource<Res>> RAJA::forall<ExecutionPolicy,Res,Args...>(Res &, Args &&...) [with ExecutionPolicy=elem_exec_policy, Res=camp::resources::v1::Cuda, Args=<LULESH_ISET &, lambda [](int)->void>]"
/usr/workspace/wsrzc/chen59/allraja/rajaproxy/rajaproxy_git/tpl/RAJA/include/RAJA/pattern/forall.hpp(523): here
            instantiation of "camp::resources::v1::EventProxy<Res> RAJA::forall<ExecutionPolicy,Args...,Res>(Args &&...) [with ExecutionPolicy=elem_exec_policy, Args=<LULESH_ISET &, lambda [](int)->void>, Res=camp::resources::v1::Cuda]"
/usr/workspace/wsrzc/chen59/allraja/rajaproxy/rajaproxy_git/build/lulesh-v2.0/RAJA/lulesh-cuda.cpp(287): here