### PR TITLE
Make tuple base public.

### DIFF
--- a/include/camp/tuple.hpp
+++ b/include/camp/tuple.hpp
@@ -263,7 +263,7 @@ public:
       camp::list<Elements...>,
       camp::make_idx_seq_t<sizeof...(Elements)>>::type;
   using type = tuple;
-  Base base;
+  Base base;  // Place this back into private when XLC can handle this better. 
 
 private:
 

--- a/include/camp/tuple.hpp
+++ b/include/camp/tuple.hpp
@@ -263,9 +263,9 @@ public:
       camp::list<Elements...>,
       camp::make_idx_seq_t<sizeof...(Elements)>>::type;
   using type = tuple;
+  Base base;
 
 private:
-  Base base;
 
   template <camp::idx_t index, class Tuple>
   CAMP_HOST_DEVICE constexpr friend auto& get(Tuple& t) noexcept;


### PR DESCRIPTION
While the `test-kernel-single-loop-ForICount-8-OpenMPTarget` test in RAJA (https://github.com/LLNL/RAJA/pull/1207), there was a compilation error in CAMP tuple. I'm not sure if this is the right solution, but making the base tuple_helper class publicly accessible solved the build error (although the test still failed with XLC).

Note: This solution does not solve the clang internal error https://github.com/LLNL/RAJA/issues/1216.

Error:
In file included from /usr/WS1/chen59/allraja/rajaatomicexhaustive/raja_git_atomicexhaustive/build_lc_blueos-xl_omptarget-2021.12.22/test/functional/kernel/single-loop-tile-icount-tcount/test-kernel-single-loop-ForICount-8-OpenMPTarget.cpp:11:
In file included from /usr/WS1/chen59/allraja/rajaatomicexhaustive/raja_git_atomicexhaustive/test/include/RAJA_test-base.hpp:15:
In file included from /usr/WS1/chen59/allraja/rajaatomicexhaustive/raja_git_atomicexhaustive/include/RAJA/RAJA.hpp:33:
In file included from /usr/WS1/chen59/allraja/rajaatomicexhaustive/raja_git_atomicexhaustive/include/RAJA/util/camp_aliases.hpp:31:
/usr/WS1/chen59/allraja/rajaatomicexhaustive/raja_git_atomicexhaustive/tpl/camp/include/camp/tuple.hpp:154:60: error: 'base' is a private member of 'camp::tuple<RAJA::TypedRangeSegment<unsigned long long, long long> >'
  return static_cast<tpl_get_store<Tuple, index> const&>(t.base).get_inner();
                                                           ^
