### PR TITLE
Remove block of BLT check logic (redundant with block below)

### DIFF
--- a/cmake/load_blt.cmake
+++ b/cmake/load_blt.cmake
@@ -1,21 +1,3 @@
-if (DEFINED BLT_SOURCE_DIR)
-    # Support having a shared BLT outside of the repository if given a BLT_SOURCE_DIR
-    if (NOT EXISTS ${BLT_SOURCE_DIR}/SetupBLT.cmake)
-        message(FATAL_ERROR "Given BLT_SOURCE_DIR does not contain SetupBLT.cmake")
-    endif()
-else()
-    # Use internal BLT if no BLT_SOURCE_DIR is given
-    set(BLT_SOURCE_DIR "${PROJECT_SOURCE_DIR}/extern/blt" CACHE PATH "")
-    if (NOT EXISTS ${BLT_SOURCE_DIR}/SetupBLT.cmake)
-        message(FATAL_ERROR
-            "The BLT git submodule is not present. "
-            "Either run the following two commands in your git repository: \n"
-            "    git submodule init\n"
-            "    git submodule update\n"
-            "Or add -DBLT_SOURCE_DIR=/path/to/blt to your CMake command." )
-    endif()
-endif()
-
 if (NOT BLT_LOADED)
   if (DEFINED BLT_SOURCE_DIR)
     if (NOT EXISTS ${BLT_SOURCE_DIR}/SetupBLT.cmake)


### PR DESCRIPTION
Also make sure check for whether BLT is loaded is in the right spot
when camp is a submodule in a project that is a submodule of another project.

Note: that the removed code is not wrong, technically. However, what is in this PR is consistent with our other projects that use BLT.