### PR TITLE
Support CTAD and structured bindings with tuple

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,9 @@
 .vscode/
 .cache/
 
+# editor temporaries
+*.swp
+
 # build directories
 build/
 build-*/

--- a/include/camp/tuple.hpp
+++ b/include/camp/tuple.hpp
@@ -372,9 +372,6 @@ public:
 /// e.g. camp::tuple t{1, 2.0};
 template <class... T>
 tuple(T...) -> tuple<T...>;
-
-template <class... T>
-tagged_tuple(T...) -> tagged_tuple<T...>;
 #endif
 
 template <typename... Tags, typename... Args>
@@ -509,14 +506,14 @@ namespace std {
     using type = decltype(camp::get<i>(camp::tuple<T...>{}));
   };
 
-  template <typename... T>
-  struct tuple_size<camp::tagged_tuple<T...> > {
-    static constexpr size_t value = sizeof...(T);
+  template <typename TagList, typename... Elements>
+  struct tuple_size<camp::tagged_tuple<TagList, Elements...> > {
+    static constexpr size_t value = sizeof...(Elements);
   };
 
-  template <size_t i, typename ... T>
-  struct tuple_element<i, camp::tagged_tuple<T...>> {
-    using type = decltype(camp::get<i>(camp::tagged_tuple<T...>{}));
+  template <size_t i, typename TagList, typename... Elements>
+  struct tuple_element<i, camp::tagged_tuple<TagList, Elements...>> {
+    using type = decltype(camp::get<i>(camp::tagged_tuple<TagList, Elements...>{}));
   };
 } // namespace std
 #endif

--- a/include/camp/tuple.hpp
+++ b/include/camp/tuple.hpp
@@ -492,10 +492,10 @@ auto operator<<(std::ostream& os, camp::tuple<Args...> const& tup)
 }
 
 #if defined(__cplusplus) && __cplusplus >= 201703L
-/// This allows structured bindings to be used with camp::tuple
-/// e.g. auto t = make_tuple(1, 2.0);
-///      auto [a, b] = t;
 namespace std {
+  /// This allows structured bindings to be used with camp::tuple
+  /// e.g. auto t = make_tuple(1, 2.0);
+  ///      auto [a, b] = t;
   template <typename... T>
   struct tuple_size<camp::tuple<T...> > {
     static constexpr size_t value = sizeof...(T);
@@ -506,6 +506,11 @@ namespace std {
     using type = decltype(camp::get<i>(camp::tuple<T...>{}));
   };
 
+  /// This allows structured bindings to be used with camp::tagged_tuple
+  /// e.g. struct s1;
+  ///      struct s2;
+  ///      auto t = make_tagged_tuple<list<s1, s2>>(1, 2.0);
+  ///      auto [a, b] = t;
   template <typename TagList, typename... Elements>
   struct tuple_size<camp::tagged_tuple<TagList, Elements...> > {
     static constexpr size_t value = sizeof...(Elements);

--- a/include/camp/tuple.hpp
+++ b/include/camp/tuple.hpp
@@ -359,13 +359,20 @@ public:
 };
 
 template <>
-class tuple<>
+struct tuple<>
 {
 public:
   using TList = camp::list<>;
   using TMap = TList;
   using type = tuple;
 };
+
+#if defined(__cplusplus) && __cplusplus >= 201703L
+/// Class template argument deduction rule for tuples
+/// e.g. camp::tuple t{1, 2.0};
+template <typename... T>
+tuple(T...) -> tuple<T...>;
+#endif
 
 template <typename... Tags, typename... Args>
 struct as_list_s<tagged_tuple<camp::list<Tags...>, Args...>> {
@@ -484,5 +491,21 @@ auto operator<<(std::ostream& os, camp::tuple<Args...> const& tup)
   return os << ")";
 }
 
+#if defined(__cplusplus) && __cplusplus >= 201703L
+/// This allows structured bindings to be used with camp::tuple
+/// e.g. auto t = make_tuple(1, 2.0);
+///      auto [a, b] = t;
+namespace std {
+  template <typename... T>
+  struct tuple_size<camp::tuple<T...> > {
+    static constexpr size_t value = sizeof...(T);
+  };
+
+  template <size_t i, typename ... T>
+  struct tuple_element<i, camp::tuple<T...>> {
+    using type = decltype(camp::get<i>(camp::tuple<T...>{}));
+  };
+} // namespace std
+#endif
 
 #endif /* camp_tuple_HPP__ */

--- a/include/camp/tuple.hpp
+++ b/include/camp/tuple.hpp
@@ -370,8 +370,11 @@ public:
 #if defined(__cplusplus) && __cplusplus >= 201703L
 /// Class template argument deduction rule for tuples
 /// e.g. camp::tuple t{1, 2.0};
-template <typename... T>
+template <class... T>
 tuple(T...) -> tuple<T...>;
+
+template <class... T>
+tagged_tuple(T...) -> tagged_tuple<T...>;
 #endif
 
 template <typename... Tags, typename... Args>
@@ -504,6 +507,16 @@ namespace std {
   template <size_t i, typename ... T>
   struct tuple_element<i, camp::tuple<T...>> {
     using type = decltype(camp::get<i>(camp::tuple<T...>{}));
+  };
+
+  template <typename... T>
+  struct tuple_size<camp::tagged_tuple<T...> > {
+    static constexpr size_t value = sizeof...(T);
+  };
+
+  template <size_t i, typename ... T>
+  struct tuple_element<i, camp::tagged_tuple<T...>> {
+    using type = decltype(camp::get<i>(camp::tagged_tuple<T...>{}));
   };
 } // namespace std
 #endif

--- a/test/tuple.cpp
+++ b/test/tuple.cpp
@@ -171,6 +171,23 @@ TEST(CampTuple, Apply)
   ASSERT_NEAR(camp::apply(testLambda, t3), 7.5, 1e-15);
 }
 
+#if defined(__cplusplus) && __cplusplus >= 201703L
+TEST(CampTuple, ClassTemplateArgumentDeduction)
+{
+  camp::tuple t{3, 9.9};
+  ASSERT_EQ(camp::get<0>(t), 3);
+  ASSERT_NEAR(camp::get<1>(t), 9.9, 1e-15);
+}
+
+TEST(CampTuple, StructuredBindings)
+{
+  auto t = camp::make_tuple(3, 9.9);
+  auto [a, b] = t;
+  ASSERT_EQ(a, 3);
+  ASSERT_NEAR(b, 9.9, 1e-15);
+}
+#endif
+
 struct s1;
 struct s2;
 struct s3;

--- a/test/tuple.cpp
+++ b/test/tuple.cpp
@@ -209,3 +209,13 @@ TEST(CampTaggedTuple, MakeTagged)
   camp::get<s1>(t) = 15;
   ASSERT_EQ(camp::get<s1>(t), 15);
 }
+
+#if defined(__cplusplus) && __cplusplus >= 201703L
+TEST(CampTaggedTuple, StructuredBindings)
+{
+  auto t = camp::make_tagged_tuple<camp::list<s1, s2>>('a', 5);
+  auto [a, b] = t;
+  ASSERT_EQ(a, 'a');
+  ASSERT_EQ(b, 5);
+}
+#endif


### PR DESCRIPTION
These are features of c++17 that make using tuples much easier.

Class template argument deduction allows the following shorthand:
`camp::tuple t{1, 2.0};`
Contribution from Sam Mish (@samuelpmishLLNL)

Structured binding also allows some shorthand:
`auto [a, b] = t;`
Contribution from Jon Wong (@jonwong12)