### PR TITLE
Avoid naming array in CAMP_EXPAND

### DIFF
--- a/include/camp/helpers.hpp
+++ b/include/camp/helpers.hpp
@@ -41,9 +41,8 @@ namespace detail
 {
   using __expand_array_type = int[];
 }
-#define CAMP_EXPAND(...) \
-  ::camp::detail::__expand_array_type camp_unused_expansion_array{ 0, ((void)(__VA_ARGS__), 0)... }; \
-  ::camp::sink(camp_unused_expansion_array)
+#define CAMP_EXPAND(...) ::camp::sink( \
+  ::camp::detail::__expand_array_type { 0, ((void)(__VA_ARGS__), 0)... })
 
 template <typename Fn, typename... Args>
 CAMP_HOST_DEVICE constexpr void for_each_arg(Fn&& f, Args&&... args)


### PR DESCRIPTION
Avoid naming array in CAMP_EXPAND so it is more compatible with existing code. This should avoid causing errors is EXPAND is used multiple times in the same scope.
@mcfadden8 found that the previous change broke umpire as umpire passed the result to a sink like function to quiet the warning. This change will still break umpire as sink returns void, but its fixed here https://github.com/LLNL/Umpire/pull/786#pullrequestreview-1133512641.