### PR TITLE
Use current GPU instead of device 0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -131,7 +131,7 @@ endif()
 
 if (COMPILER_FAMILY_IS_MSVC)
   if (NOT BUILD_SHARED_LIBS)
-    target_compile_definitions(camp PUBLIC CAMP_WIN_STATIC_BUILD)
+    target_compile_definitions(camp PRIVATE CAMP_WIN_STATIC_BUILD)
   else (NOT BUILD_SHARED_LIBS)
     target_compile_definitions(camp PRIVATE CAMP_DLL_EXPORTS)
   endif (NOT BUILD_SHARED_LIBS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -131,7 +131,7 @@ endif()
 
 if (COMPILER_FAMILY_IS_MSVC)
   if (NOT BUILD_SHARED_LIBS)
-    target_compile_definitions(camp PUBLIC WIN_STATIC_BUILD)
+    target_compile_definitions(camp PUBLIC CAMP_WIN_STATIC_BUILD)
   else (NOT BUILD_SHARED_LIBS)
     target_compile_definitions(camp PRIVATE CAMP_DLL_EXPORTS)
   endif (NOT BUILD_SHARED_LIBS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -131,7 +131,7 @@ endif()
 
 if (COMPILER_FAMILY_IS_MSVC)
   if (NOT BUILD_SHARED_LIBS)
-    target_compile_definitions(camp PRIVATE CAMP_WIN_STATIC_BUILD)
+    target_compile_definitions(camp PUBLIC CAMP_WIN_STATIC_BUILD)
   else (NOT BUILD_SHARED_LIBS)
     target_compile_definitions(camp PRIVATE CAMP_DLL_EXPORTS)
   endif (NOT BUILD_SHARED_LIBS)

--- a/include/camp/config.in.hpp
+++ b/include/camp/config.in.hpp
@@ -5,6 +5,8 @@
 #cmakedefine CAMP_ENABLE_CUDA
 #cmakedefine CAMP_ENABLE_HIP
 #cmakedefine CAMP_ENABLE_SYCL
+#cmakedefine CAMP_WIN_STATIC_BUILD
+#cmakedefine CAMP_DLL_EXPORTS
 #endif
 
 #define CAMP_VERSION_MAJOR @camp_VERSION_MAJOR@

--- a/include/camp/config.in.hpp
+++ b/include/camp/config.in.hpp
@@ -6,7 +6,6 @@
 #cmakedefine CAMP_ENABLE_HIP
 #cmakedefine CAMP_ENABLE_SYCL
 #cmakedefine CAMP_WIN_STATIC_BUILD
-#cmakedefine CAMP_DLL_EXPORTS
 #endif
 
 #define CAMP_VERSION_MAJOR @camp_VERSION_MAJOR@

--- a/include/camp/defines.hpp
+++ b/include/camp/defines.hpp
@@ -181,6 +181,13 @@ CAMP_DLL_EXPORT void throw_re(const char *s);
 
 #ifdef CAMP_ENABLE_CUDA
 
+#define campCuErrchk(ans) ::camp::cuAssert((ans), #ans, __FILE__, __LINE__)
+
+CAMP_DLL_EXPORT CUresult cuAssert(CUresult code,
+                              const char *call,
+                              const char *file,
+                              int line);
+
 #define campCudaErrchk(ans) ::camp::cudaAssert((ans), #ans, __FILE__, __LINE__)
 
 CAMP_DLL_EXPORT cudaError_t cudaAssert(cudaError_t code,

--- a/include/camp/defines.hpp
+++ b/include/camp/defines.hpp
@@ -18,6 +18,7 @@ http://github.com/llnl/camp
 
 // include cuda header if configured, even if not in use
 #ifdef CAMP_ENABLE_CUDA
+#include <cuda.h>
 #include <cuda_runtime.h>
 #endif
 

--- a/include/camp/resource.hpp
+++ b/include/camp/resource.hpp
@@ -69,7 +69,7 @@ namespace resources
       {
         auto result = dynamic_cast<ContextModel<T> *>(m_value.get());
         if (result == nullptr) {
-          throw std::runtime_error("Incompatible Resource type get cast.");
+          ::camp::throw_re("Incompatible Resource type get cast.");
         }
         return *result->get();
       }

--- a/include/camp/resource/cuda.hpp
+++ b/include/camp/resource/cuda.hpp
@@ -167,7 +167,7 @@ namespace resources
       }
 
     public:
-      Cuda(int group = -1, int dev = get_current_device())
+      explicit Cuda(int group = -1, int dev = get_current_device())
           : stream(get_a_stream(group, dev)), device(dev)
       { }
 

--- a/include/camp/resource/cuda.hpp
+++ b/include/camp/resource/cuda.hpp
@@ -115,6 +115,10 @@ namespace resources
           return count;
         }());
 
+        if (dev < 0) {
+          dev = get_current_device();
+        }
+
         std::call_once(devices[dev].onceFlag, [&] {
           auto d{device_guard(dev)};
           if (devices[dev].streams[0] == nullptr) {

--- a/include/camp/resource/cuda.hpp
+++ b/include/camp/resource/cuda.hpp
@@ -18,6 +18,7 @@ http://github.com/llnl/camp
 #ifdef CAMP_ENABLE_CUDA
 
 #include <cuda_runtime.h>
+#include <mutex>
 
 namespace camp
 {
@@ -113,10 +114,9 @@ namespace resources
         });
 
         if (num < 0) {
-          devices[dev].mtx.lock();
+          std::lock_guard<std::mutex> guard(devices[dev].mtx);
           devices[dev].previous = (devices[dev].previous + 1) % num_streams;
           num = devices[dev].previous;
-          devices[dev].mtx.unlock();
         } else {
           num = num % num_streams;
         }

--- a/include/camp/resource/cuda.hpp
+++ b/include/camp/resource/cuda.hpp
@@ -87,6 +87,17 @@ namespace resources
         return dev;
       }
 
+      static int get_device_from_stream(cudaStream_t stream)
+      {
+        int dev = -1;
+        CUcontext stream_ctx;
+        campCuErrchk(cuStreamGetCtx(stream, &stream_ctx));
+        campCuErrchk(cuCtxPushCurrent(stream_ctx));
+        campCuErrchk(cuCtxGetDevice(&dev));
+        campCuErrchk(cuCtxPopCurrent(stream_ctx));
+        return dev;
+      }
+
       static cudaStream_t get_a_stream(int num, int dev)
       {
         static constexpr int num_streams = 16;
@@ -155,12 +166,10 @@ namespace resources
       {
       }
 
-      /// Create a resource from a custom stream
-      /// The device specified must match the stream, if none is specified the
-      /// currently selected device is used.
-      static Cuda CudaFromStream(cudaStream_t s, int dev = get_current_device())
+      /// Create a resource from a custom stream.
+      static Cuda CudaFromStream(cudaStream_t s)
       {
-        return Cuda(s, dev);
+        return Cuda(s, get_device_from_stream(s));
       }
 
       // Methods

--- a/include/camp/resource/cuda.hpp
+++ b/include/camp/resource/cuda.hpp
@@ -136,7 +136,9 @@ namespace resources
       }
 
       // Private from-stream constructor
-      Cuda(cudaStream_t s, int dev) : stream(s), device(dev) {}
+      Cuda(cudaStream_t s, int dev)
+        : stream(s), device((dev >= 0) ? dev : get_device_from_stream(s))
+      { }
 
       MemoryAccess get_access_type(void *p) {
         cudaPointerAttributes a;
@@ -163,8 +165,7 @@ namespace resources
     public:
       Cuda(int group = -1, int dev = get_current_device())
           : stream(get_a_stream(group, dev)), device(dev)
-      {
-      }
+      { }
 
       /// Create a resource from a custom stream.
       /// The device specified must match the stream, if none is specified the
@@ -173,7 +174,7 @@ namespace resources
       /// this to be called before entering main.
       static Cuda CudaFromStream(cudaStream_t s, int dev = -1)
       {
-        return Cuda(s, (dev >= 0) ? dev : get_device_from_stream(s));
+        return Cuda(s, dev);
       }
 
       // Methods

--- a/include/camp/resource/cuda.hpp
+++ b/include/camp/resource/cuda.hpp
@@ -19,6 +19,7 @@ http://github.com/llnl/camp
 
 #include <cuda_runtime.h>
 #include <mutex>
+#include <vector>
 
 namespace camp
 {
@@ -89,12 +90,12 @@ namespace resources
 
       static int get_device_from_stream(cudaStream_t stream)
       {
-        int dev = -1;
         CUcontext stream_ctx;
         campCuErrchk(cuStreamGetCtx(stream, &stream_ctx));
         campCuErrchk(cuCtxPushCurrent(stream_ctx));
+        int dev = -1;
         campCuErrchk(cuCtxGetDevice(&dev));
-        campCuErrchk(cuCtxPopCurrent(stream_ctx));
+        campCuErrchk(cuCtxPopCurrent(&stream_ctx));
         return dev;
       }
 
@@ -111,7 +112,7 @@ namespace resources
 
         static std::vector<Streams> devices([] {
           int count = -1;
-          campcudaErrchk(cudaGetDeviceCount(&count));
+          campCudaErrchk(cudaGetDeviceCount(&count));
           return count;
         }());
 
@@ -123,7 +124,7 @@ namespace resources
           auto d{device_guard(dev)};
           if (devices[dev].streams[0] == nullptr) {
             for (auto &s : devices[dev].streams) {
-              campcudaErrchk(cudaStreamCreate(&s));
+              campCudaErrchk(cudaStreamCreate(&s));
             }
           }
         });

--- a/include/camp/resource/cuda.hpp
+++ b/include/camp/resource/cuda.hpp
@@ -167,9 +167,13 @@ namespace resources
       }
 
       /// Create a resource from a custom stream.
-      static Cuda CudaFromStream(cudaStream_t s)
+      /// The device specified must match the stream, if none is specified the
+      /// device is found from the stream.
+      /// Note that if dev is specified then no runtime calls are made allowing
+      /// this to be called before entering main.
+      static Cuda CudaFromStream(cudaStream_t s, int dev = -1)
       {
-        return Cuda(s, get_device_from_stream(s));
+        return Cuda(s, (dev >= 0) ? dev : get_device_from_stream(s));
       }
 
       // Methods

--- a/include/camp/resource/cuda.hpp
+++ b/include/camp/resource/cuda.hpp
@@ -172,10 +172,10 @@ namespace resources
       { }
 
       /// Create a resource from a custom stream.
-      /// The device specified must match the stream, if none is specified the
-      /// device is found from the stream.
-      /// Note that if dev is specified then no runtime calls are made allowing
-      /// this to be called before entering main.
+      /// If device is specified it must match the stream. If device is
+      /// unspecified, we will get it from the stream.
+      /// This may be called before main if device is specified as no calls to
+      /// the runtime are made in this case.
       static Cuda CudaFromStream(cudaStream_t s, int dev = -1)
       {
         return Cuda(s, dev);

--- a/include/camp/resource/hip.hpp
+++ b/include/camp/resource/hip.hpp
@@ -75,34 +75,53 @@ namespace resources
 
     class Hip
     {
-      static hipStream_t get_a_stream(int num)
+      static int get_current_device()
       {
-        static hipStream_t streams[16] = {};
-        static int previous = 0;
+        int dev = -1;
+        campHipErrchk(hipGetDevice(&dev));
+        return dev;
+      }
 
-        static std::once_flag m_onceFlag;
-        static std::mutex m_mtx;
+      static hipStream_t get_a_stream(int num, int dev)
+      {
+        static constexpr int num_streams = 16;
+        struct Streams {
+          hipStream_t streams[num_streams] = {};
+          int previous = 0;
 
-        std::call_once(m_onceFlag, [] {
-          if (streams[0] == nullptr) {
-            for (auto &s : streams) {
+          std::once_flag onceFlag;
+          std::mutex mtx;
+        };
+
+        static std::vector<Streams> devices([] {
+          int count = -1;
+          campHipErrchk(hipGetDeviceCount(&count));
+          return count;
+        }());
+
+        std::call_once(devices[dev].onceFlag, [=] {
+          auto d{device_guard(dev)};
+          if (devices[dev].streams[0] == nullptr) {
+            for (auto &s : devices[dev].streams) {
               campHipErrchk(hipStreamCreate(&s));
             }
           }
         });
 
         if (num < 0) {
-          m_mtx.lock();
-          previous = (previous + 1) % 16;
-          m_mtx.unlock();
-          return streams[previous];
+          devices[dev].mtx.lock();
+          devices[dev].previous = (devices[dev].previous + 1) % num_streams;
+          num = devices[dev].previous;
+          devices[dev].mtx.unlock();
+        } else {
+          num = num % num_streams;
         }
 
-        return streams[num % 16];
+        return devices[dev].streams[num];
       }
 
       // Private from-stream constructor
-      Hip(hipStream_t s, int dev = 0) : stream(s), device(dev) {}
+      Hip(hipStream_t s, int dev) : stream(s), device(dev) {}
 
       MemoryAccess get_access_type(void *p)
       {
@@ -126,19 +145,16 @@ namespace resources
       }
 
     public:
-      Hip(int group = -1, int dev = 0)
-          : stream(get_a_stream(group)), device(dev)
+      Hip(int group = -1, int dev = get_current_device())
+          : stream(get_a_stream(group, dev)), device(dev)
       {
       }
 
       /// Create a resource from a custom stream
       /// The device specified must match the stream, if none is specified the
       /// currently selected device is used.
-      static Hip HipFromStream(hipStream_t s, int dev = -1)
+      static Hip HipFromStream(hipStream_t s, int dev = get_current_device())
       {
-        if (dev < 0) {
-          campHipErrchk(hipGetDevice(&dev));
-        }
         return Hip(s, dev);
       }
 
@@ -154,7 +170,7 @@ namespace resources
           campHipErrchk(hipStreamCreate(&s));
 #endif
           return s;
-        }());
+        }(), get_current_device());
         return h;
       }
 

--- a/include/camp/resource/hip.hpp
+++ b/include/camp/resource/hip.hpp
@@ -158,7 +158,7 @@ namespace resources
       }
 
     public:
-      Hip(int group = -1, int dev = get_current_device())
+      explicit Hip(int group = -1, int dev = get_current_device())
           : stream(get_a_stream(group, dev)), device(dev)
       { }
 

--- a/include/camp/resource/hip.hpp
+++ b/include/camp/resource/hip.hpp
@@ -159,10 +159,12 @@ namespace resources
 
       /// Create a resource from a custom stream
       /// The device specified must match the stream, if none is specified the
-      /// currently selected device is used.
-      static Hip HipFromStream(hipStream_t s)
+      /// device is found from the stream.
+      /// Note that if dev is specified then no runtime calls are made allowing
+      /// this to be called before entering main.
+      static Hip HipFromStream(hipStream_t s, int dev = -1)
       {
-        return Hip(s, get_device_from_stream(s));
+        return Hip(s, (dev >= 0) ? dev : get_device_from_stream(s));
       }
 
       // Methods

--- a/include/camp/resource/hip.hpp
+++ b/include/camp/resource/hip.hpp
@@ -128,7 +128,9 @@ namespace resources
       }
 
       // Private from-stream constructor
-      Hip(hipStream_t s, int dev) : stream(s), device(dev) {}
+      Hip(hipStream_t s, int dev)
+        : stream(s), device((dev >= 0) ? dev : get_device_from_stream(s))
+      { }
 
       MemoryAccess get_access_type(void *p)
       {
@@ -154,8 +156,7 @@ namespace resources
     public:
       Hip(int group = -1, int dev = get_current_device())
           : stream(get_a_stream(group, dev)), device(dev)
-      {
-      }
+      { }
 
       /// Create a resource from a custom stream
       /// The device specified must match the stream, if none is specified the
@@ -164,7 +165,7 @@ namespace resources
       /// this to be called before entering main.
       static Hip HipFromStream(hipStream_t s, int dev = -1)
       {
-        return Hip(s, (dev >= 0) ? dev : get_device_from_stream(s));
+        return Hip(s, dev);
       }
 
       // Methods

--- a/include/camp/resource/hip.hpp
+++ b/include/camp/resource/hip.hpp
@@ -107,6 +107,10 @@ namespace resources
           return count;
         }());
 
+        if (dev < 0) {
+          dev = get_current_device();
+        }
+
         std::call_once(devices[dev].onceFlag, [=] {
           auto d{device_guard(dev)};
           if (devices[dev].streams[0] == nullptr) {

--- a/include/camp/resource/hip.hpp
+++ b/include/camp/resource/hip.hpp
@@ -85,6 +85,11 @@ namespace resources
         return dev;
       }
 
+      static int get_device_from_stream(hipStream_t stream)
+      {
+        return hipGetStreamDeviceId(stream);
+      }
+
       static hipStream_t get_a_stream(int num, int dev)
       {
         static constexpr int num_streams = 16;
@@ -155,9 +160,9 @@ namespace resources
       /// Create a resource from a custom stream
       /// The device specified must match the stream, if none is specified the
       /// currently selected device is used.
-      static Hip HipFromStream(hipStream_t s, int dev = get_current_device())
+      static Hip HipFromStream(hipStream_t s)
       {
-        return Hip(s, dev);
+        return Hip(s, get_device_from_stream(s));
       }
 
       // Methods

--- a/include/camp/resource/hip.hpp
+++ b/include/camp/resource/hip.hpp
@@ -162,11 +162,11 @@ namespace resources
           : stream(get_a_stream(group, dev)), device(dev)
       { }
 
-      /// Create a resource from a custom stream
-      /// The device specified must match the stream, if none is specified the
-      /// device is found from the stream.
-      /// Note that if dev is specified then no runtime calls are made allowing
-      /// this to be called before entering main.
+      /// Create a resource from a custom stream.
+      /// If device is specified it must match the stream. If device is
+      /// unspecified, we will get it from the stream.
+      /// This may be called before main if device is specified as no calls to
+      /// the runtime are made in this case.
       static Hip HipFromStream(hipStream_t s, int dev = -1)
       {
         return Hip(s, dev);

--- a/include/camp/resource/hip.hpp
+++ b/include/camp/resource/hip.hpp
@@ -11,11 +11,14 @@ http://github.com/llnl/camp
 #ifndef __CAMP_HIP_HPP
 #define __CAMP_HIP_HPP
 
+#include "camp/defines.hpp"
 #include "camp/resource/event.hpp"
 #include "camp/resource/platform.hpp"
 
 #ifdef CAMP_ENABLE_HIP
+
 #include <hip/hip_runtime.h>
+#include <mutex>
 
 namespace camp
 {
@@ -109,10 +112,9 @@ namespace resources
         });
 
         if (num < 0) {
-          devices[dev].mtx.lock();
+          std::lock_guard<std::mutex> guard(devices[dev].mtx);
           devices[dev].previous = (devices[dev].previous + 1) % num_streams;
           num = devices[dev].previous;
-          devices[dev].mtx.unlock();
         } else {
           num = num % num_streams;
         }

--- a/include/camp/resource/host.hpp
+++ b/include/camp/resource/host.hpp
@@ -14,6 +14,9 @@ http://github.com/llnl/camp
 #include "camp/resource/event.hpp"
 #include "camp/resource/platform.hpp"
 
+#include <cstdlib>
+#include <cstring>
+
 namespace camp
 {
 namespace resources
@@ -54,7 +57,7 @@ namespace resources
       template <typename T>
       T *allocate(size_t n, MemoryAccess = MemoryAccess::Device)
       {
-        return (T *)malloc(sizeof(T) * n);
+        return (T *)std::malloc(sizeof(T) * n);
       }
       void *calloc(size_t size, MemoryAccess = MemoryAccess::Device)
       {
@@ -62,7 +65,7 @@ namespace resources
         this->memset(p, 0, size);
         return p;
       }
-      void deallocate(void *p, MemoryAccess = MemoryAccess::Device) { free(p); }
+      void deallocate(void *p, MemoryAccess = MemoryAccess::Device) { std::free(p); }
       void memcpy(void *dst, const void *src, size_t size) { std::memcpy(dst, src, size); }
       void memset(void *p, int val, size_t size) { std::memset(p, val, size); }
     };

--- a/include/camp/resource/host.hpp
+++ b/include/camp/resource/host.hpp
@@ -32,7 +32,7 @@ namespace resources
     class Host
     {
     public:
-      Host(int /* group */ = -1) {}
+      explicit Host(int /* group */ = -1) {}
 
       // Methods
       Platform get_platform() { return Platform::host; }

--- a/include/camp/resource/omp_target.hpp
+++ b/include/camp/resource/omp_target.hpp
@@ -83,7 +83,7 @@ namespace resources
         }
       }
     public:
-      Omp(int group = -1, int device = omp_get_default_device())
+      explicit Omp(int group = -1, int device = omp_get_default_device())
           : addr(get_addr(group)), dev(device)
       {
       }

--- a/include/camp/resource/omp_target.hpp
+++ b/include/camp/resource/omp_target.hpp
@@ -79,7 +79,7 @@ namespace resources
 
       void check_ma(MemoryAccess ma) {
         if(ma != MemoryAccess::Device) {
-          throw std::runtime_error("OpenMP Target currently does not support allocating shared or managed memory");
+          ::camp::throw_re("OpenMP Target currently does not support allocating shared or managed memory");
         }
       }
     public:

--- a/include/camp/resource/sycl.hpp
+++ b/include/camp/resource/sycl.hpp
@@ -19,6 +19,7 @@ http://github.com/llnl/camp
 #include <CL/sycl.hpp>
 #include <map>
 #include <array>
+#include <mutex>
 using namespace cl;
 
 namespace camp
@@ -53,9 +54,11 @@ namespace resources
         static sycl::context *contextInUse = NULL;
         static std::map<sycl::context *, std::array<sycl::queue, 16>> queueMap;
 
+        static int previous = 0;
 
         static std::mutex m_mtx;
-        m_mtx.lock();
+
+        std::lock_guard<std::mutex> guard(m_mtx);
 
         // User passed a context, use it
         if (useContext) {
@@ -102,19 +105,15 @@ namespace resources
                 sycl::queue(*contextInUse, gpuSelector, propertyList)};
           }
         }
-        m_mtx.unlock();
 
-        static int previous = 0;
-
-        static std::once_flag m_onceFlag;
         if (num < 0) {
-          m_mtx.lock();
           previous = (previous + 1) % 16;
-          m_mtx.unlock();
-          return &queueMap[contextInUse][previous];
+          num = previous;
+        } else {
+          num = num % 16;
         }
 
-        return &queueMap[contextInUse][num % 16];
+        return &queueMap[contextInUse][num];
       }
 
     public:

--- a/include/camp/resource/sycl.hpp
+++ b/include/camp/resource/sycl.hpp
@@ -116,16 +116,16 @@ namespace resources
         return &queueMap[contextInUse][num];
       }
 
-      Sycl(sycl::queue* queue) : qu(queue) {}
+      explicit Sycl(sycl::queue* queue) : qu(queue) {}
 
     public:
-      Sycl(int group = -1)
+      explicit Sycl(int group = -1)
       {
         sycl::context temp;
         qu = get_a_queue(temp, group, false);
       }
 
-      Sycl(sycl::context &syclContext, int group = -1)
+      explicit Sycl(sycl::context &syclContext, int group = -1)
           : qu(get_a_queue(syclContext, group, true))
       {
       }

--- a/include/camp/resource/sycl.hpp
+++ b/include/camp/resource/sycl.hpp
@@ -116,6 +116,8 @@ namespace resources
         return &queueMap[contextInUse][num];
       }
 
+      Sycl(sycl::queue* queue) : qu(queue) {}
+
     public:
       Sycl(int group = -1)
       {
@@ -126,6 +128,12 @@ namespace resources
       Sycl(sycl::context &syclContext, int group = -1)
           : qu(get_a_queue(syclContext, group, true))
       {
+      }
+
+      /// Create a resource from a custom queue.
+      static Sycl SyclFromQueue(sycl::queue* queue)
+      {
+        return Sycl(queue);
       }
 
       // Methods

--- a/src/errors.cpp
+++ b/src/errors.cpp
@@ -22,6 +22,30 @@ void throw_re(const char *s) { throw std::runtime_error(s); }
 #ifdef CAMP_ENABLE_CUDA
 
 
+CUresult cuAssert(CUresult code,
+                              const char *call,
+                              const char *file,
+                              int line)
+{
+  if (code != CUDA_SUCCESS && code != CUDA_ERROR_NOT_READY) {
+    const char* error_string = nullptr;
+    if (cuGetErrorString(code, &error_string) != CUDA_SUCCESS) {
+      error_string = "Unknown Error code";
+    }
+    std::string msg;
+    msg += "campCuErrchk(";
+    msg += call;
+    msg += ") ";
+    msg += error_string;
+    msg += " ";
+    msg += file;
+    msg += ":";
+    msg += std::to_string(line);
+    throw std::runtime_error(msg);
+  }
+  return code;
+}
+
 cudaError_t cudaAssert(cudaError_t code,
                               const char *call,
                               const char *file,

--- a/test/resource.cpp
+++ b/test/resource.cpp
@@ -83,23 +83,21 @@ TEST(CampResource, MultipleDevices)
   for (int d = 0; d < num_devices; ++d) {
     cudaSetDevice(d);
 
-    Cuda c1{Cuda::get_default()};
-    Cuda c2{Cuda::CudaFromStream(0)};
-    Cuda c3{Cuda::CudaFromStream(0), d};
-    Cuda c4{};
-    Cuda c5{0};
-    Cuda c6{0, d};
+    Cuda c1{Cuda::CudaFromStream(0)};
+    Cuda c2{Cuda::CudaFromStream(0, d)};
+    Cuda c3{};
+    Cuda c4{0};
+    Cuda c5{0, d};
 
     EXPECT_EQ(c1.get_device(), d);
     EXPECT_EQ(c2.get_device(), d);
     EXPECT_EQ(c3.get_device(), d);
     EXPECT_EQ(c4.get_device(), d);
     EXPECT_EQ(c5.get_device(), d);
-    EXPECT_EQ(c6.get_device(), d);
 
+    EXPECT_EQ(c1.get_stream(), cudaStream_t{0});
     EXPECT_EQ(c2.get_stream(), cudaStream_t{0});
-    EXPECT_EQ(c3.get_stream(), cudaStream_t{0});
-    EXPECT_EQ(c5.get_stream(), c6.get_stream());
+    EXPECT_EQ(c4.get_stream(), c5.get_stream());
 
     const int N = 5;
     int* d_array1 = c1.allocate<int>(N);
@@ -120,7 +118,7 @@ TEST(CampResource, DifferentDevice)
   if (num_devices > 1) {
     int diff_dev = (cur_dev + 1) % num_devices;
 
-    Cuda c1{Cuda::CudaFromStream(0), diff_dev};
+    Cuda c1{Cuda::CudaFromStream(0, diff_dev)};
     Cuda c2{0, diff_dev};
 
     EXPECT_EQ(c1.get_device(), diff_dev);
@@ -132,7 +130,7 @@ TEST(CampResource, DifferentDevice)
   }
 
   int check_dev = -1;
-  cudaGetDevice(&cur_dev);
+  cudaGetDevice(&check_dev);
 
   EXPECT_EQ(check_dev, cur_dev);
 }
@@ -233,23 +231,21 @@ TEST(CampResource, MultipleDevices)
   for (int d = 0; d < num_devices; ++d) {
     hipSetDevice(d);
 
-    Hip c1{Hip::get_default()};
-    Hip c2{Hip::HipFromStream(0)};
-    Hip c3{Hip::HipFromStream(0), d};
-    Hip c4{};
-    Hip c5{0};
-    Hip c6{0, d};
+    Hip c1{Hip::HipFromStream(0)};
+    Hip c2{Hip::HipFromStream(0, d)};
+    Hip c3{};
+    Hip c4{0};
+    Hip c5{0, d};
 
     EXPECT_EQ(c1.get_device(), d);
     EXPECT_EQ(c2.get_device(), d);
     EXPECT_EQ(c3.get_device(), d);
     EXPECT_EQ(c4.get_device(), d);
     EXPECT_EQ(c5.get_device(), d);
-    EXPECT_EQ(c6.get_device(), d);
 
+    EXPECT_EQ(c1.get_stream(), hipStream_t{0});
     EXPECT_EQ(c2.get_stream(), hipStream_t{0});
-    EXPECT_EQ(c3.get_stream(), hipStream_t{0});
-    EXPECT_EQ(c5.get_stream(), c6.get_stream());
+    EXPECT_EQ(c4.get_stream(), c5.get_stream());
 
     const int N = 5;
     int* d_array1 = c1.allocate<int>(N);
@@ -270,7 +266,7 @@ TEST(CampResource, DifferentDevice)
   if (num_devices > 1) {
     int diff_dev = (cur_dev + 1) % num_devices;
 
-    Hip c1{Hip::HipFromStream(0), diff_dev};
+    Hip c1{Hip::HipFromStream(0, diff_dev)};
     Hip c2{0, diff_dev};
 
     EXPECT_EQ(c1.get_device(), diff_dev);
@@ -282,7 +278,7 @@ TEST(CampResource, DifferentDevice)
   }
 
   int check_dev = -1;
-  hipGetDevice(&cur_dev);
+  hipGetDevice(&check_dev);
 
   EXPECT_EQ(check_dev, cur_dev);
 }

--- a/test/resource.cpp
+++ b/test/resource.cpp
@@ -72,6 +72,27 @@ TEST(CampResource, Reassignment)
   ASSERT_EQ(typeid(c2), typeid(h2));
 }
 
+TEST(CampResource, StreamSelect)
+{
+  cudaStream_t stream1, stream2;
+
+  cudaStreamCreate(&stream1);
+  cudaStreamCreate(&stream2);
+
+  Resource c1{Cuda::CudaFromStream(stream1)};
+  Resource c2{Cuda::CudaFromStream(stream2)};
+
+  const int N = 5;
+  int* d_array1 = c1.allocate<int>(N);
+  int* d_array2 = c2.allocate<int>(N);
+
+  c1.deallocate(d_array1);
+  c2.deallocate(d_array2);
+
+  cudaStreamDestroy(stream1);
+  cudaStreamDestroy(stream2);
+}
+
 TEST(CampResource, MultipleDevices)
 {
   int cur_dev = 0;
@@ -133,27 +154,6 @@ TEST(CampResource, DifferentDevice)
   cudaGetDevice(&check_dev);
 
   EXPECT_EQ(check_dev, cur_dev);
-}
-
-TEST(CampResource, StreamSelect)
-{
-  cudaStream_t stream1, stream2;
-
-  cudaStreamCreate(&stream1);
-  cudaStreamCreate(&stream2);
-
-  Resource c1{Cuda::CudaFromStream(stream1)};
-  Resource c2{Cuda::CudaFromStream(stream2)};
-
-  const int N = 5;
-  int* d_array1 = c1.allocate<int>(N);
-  int* d_array2 = c2.allocate<int>(N);
-
-  c1.deallocate(d_array1);
-  c2.deallocate(d_array2);
-
-  cudaStreamDestroy(stream1);
-  cudaStreamDestroy(stream2);
 }
 
 TEST(CampResource, Get)
@@ -220,6 +220,27 @@ TEST(CampResource, Reassignment)
   ASSERT_EQ(typeid(c2), typeid(h2));
 }
 
+TEST(CampResource, StreamSelect)
+{
+  hipStream_t stream1, stream2;
+
+  hipStreamCreate(&stream1);
+  hipStreamCreate(&stream2);
+
+  Resource c1{Hip::HipFromStream(stream1)};
+  Resource c2{Hip::HipFromStream(stream2)};
+
+  const int N = 5;
+  int* d_array1 = c1.allocate<int>(N);
+  int* d_array2 = c2.allocate<int>(N);
+
+  c1.deallocate(d_array1);
+  c2.deallocate(d_array2);
+
+  hipStreamDestroy(stream1);
+  hipStreamDestroy(stream2);
+}
+
 TEST(CampResource, MultipleDevices)
 {
   int cur_dev = 0;
@@ -281,27 +302,6 @@ TEST(CampResource, DifferentDevice)
   hipGetDevice(&check_dev);
 
   EXPECT_EQ(check_dev, cur_dev);
-}
-
-TEST(CampResource, StreamSelect)
-{
-  hipStream_t stream1, stream2;
-
-  hipStreamCreate(&stream1);
-  hipStreamCreate(&stream2);
-
-  Resource c1{Hip::HipFromStream(stream1)};
-  Resource c2{Hip::HipFromStream(stream2)};
-
-  const int N = 5;
-  int* d_array1 = c1.allocate<int>(N);
-  int* d_array2 = c2.allocate<int>(N);
-
-  c1.deallocate(d_array1);
-  c2.deallocate(d_array2);
-
-  hipStreamDestroy(stream1);
-  hipStreamDestroy(stream2);
 }
 
 TEST(CampResource, Get)


### PR DESCRIPTION
Use whatever is the current device in hip and cuda resources instead of using device 0.
Fix race conditions in the Cuda, Hip, and Sycl resource get stream and queue methods.

This is aimed at fixing this umpire issue https://github.com/LLNL/Umpire/issues/798 from @gzagaris.