### PR TITLE
Add vector header

### DIFF
--- a/include/camp/resource/hip.hpp
+++ b/include/camp/resource/hip.hpp
@@ -11,6 +11,8 @@ http://github.com/llnl/camp
 #ifndef __CAMP_HIP_HPP
 #define __CAMP_HIP_HPP
 
+#include <vector>
+
 #include "camp/defines.hpp"
 #include "camp/resource/event.hpp"
 #include "camp/resource/platform.hpp"


### PR DESCRIPTION
CI is failing here: https://github.com/LLNL/RAJA/pull/1473

```
dev/shm/corona231-1182981/rocmcc-5.1.1/camp-main-zqztddopfxbca63bp2qpco54qgsoq5vq/include/camp/resource/hip.hpp:104:21: error: no template named 'vector' in namespace 'std'
```

due to missing header. 