### PR TITLE
Restrict tuple's converting constructor

### DIFF
--- a/include/camp/tuple.hpp
+++ b/include/camp/tuple.hpp
@@ -326,13 +326,17 @@ public:
   {
   }
 
-  template <typename... RTypes>
+  template <typename... RTypes,
+            typename std::enable_if<
+                sizeof...(RTypes) == sizeof...(Elements)>::type* = nullptr>
   CAMP_HOST_DEVICE constexpr explicit tuple(const tuple<RTypes...>& rhs)
       : base(internal::expand_tag{}, rhs)
   {
   }
 
-  template <typename... RTypes>
+  template <typename... RTypes,
+            typename std::enable_if<
+                sizeof...(RTypes) == sizeof...(Elements)>::type* = nullptr>
   CAMP_HOST_DEVICE constexpr explicit tuple(tuple<RTypes...>&& rhs)
       : base(internal::expand_tag{}, rhs)
   {

--- a/test/tuple.cpp
+++ b/test/tuple.cpp
@@ -197,6 +197,10 @@ static_assert(
     "can by trivially copy constructed");
 #endif
 
+// Test to ensure correct constructor is invoked when constructing from a single tuple argument
+static_assert(std::is_same<decltype(camp::make_tuple(camp::make_tuple(A{}, B{}))), camp::tuple<camp::tuple<A, B>>>::value,
+              "Avoids conversion constructor for a single tuple argument");
+
 // Execution tests
 
 TEST(CampTuple, AssignCompat)


### PR DESCRIPTION
This small PR fixes an issue I encountered when playing around implementing some algorithms on tuples (`zip` in particular).

When attempting to construct a `tuple<tuple<A,B>>` from a single argument of type `tuple<A,B> &&`, the converting constructor overload is chosen instead of direct constructor (using the terminology of [std::tuple](https://en.cppreference.com/w/cpp/utility/tuple/tuple) constructors).

This results in the error
```
In file included from /home/klevtsov/work/camp/include/camp/camp.hpp:24,
                 from /home/klevtsov/work/camp/test/tuple.cpp:18:
/home/klevtsov/work/camp/include/camp/tuple.hpp: In instantiation of ‘constexpr camp::internal::tuple_helper<camp::int_seq<long int, Indices ...>, camp::list<Args ...> >::tuple_helper(Args&& ...) [with Args = {A&}; Types = {A, B}; long int ...Indices = {0, 1}]’:
/home/klevtsov/work/camp/include/camp/tuple.hpp:325:9:   required from ‘constexpr camp::tuple<Rest>::tuple(Args&& ...) [with Args = {A&}; typename std::enable_if<(! camp::tuple<Rest>::is_pack_this_tuple<Ts>::value)>::type* <anonymous> = 0; Elements = {A, B}]’
/home/klevtsov/work/camp/include/camp/tuple.hpp:105:11:   required from ‘constexpr camp::internal::tuple_storage<index, Type, Empty>::tuple_storage(T&&) [with T = A&; long int index = 0; Type = camp::tuple<A, B>; bool Empty = false]’
/home/klevtsov/work/camp/include/camp/tuple.hpp:231:66:   required from ‘constexpr camp::internal::tuple_helper<camp::int_seq<long int, Indices ...>, camp::list<Args ...> >::tuple_helper(Args&& ...) [with Args = {A&}; Types = {camp::tuple<A, B>}; long int ...Indices = {0}]’
/home/klevtsov/work/camp/include/camp/tuple.hpp:237:44:   required from ‘constexpr camp::internal::tuple_helper<camp::int_seq<long int, Indices ...>, camp::list<Args ...> >::tuple_helper(camp::internal::expand_tag, T&&) [with T = camp::tuple<A, B>&; Types = {camp::tuple<A, B>}; long int ...Indices = {0}]’
/home/klevtsov/work/camp/include/camp/tuple.hpp:337:9:   required from ‘constexpr camp::tuple<Rest>::tuple(camp::tuple<RTypes ...>&&) [with RTypes = {A, B}; Elements = {camp::tuple<A, B>}]’
/home/klevtsov/work/camp/include/camp/tuple.hpp:580:79:   required from ‘constexpr auto camp::make_tuple(Args&& ...) [with Args = {camp::tuple<A, B>}]’
/home/klevtsov/work/camp/test/tuple.cpp:201:53:   required from here
/home/klevtsov/work/camp/include/camp/tuple.hpp:231:66: error: mismatched argument pack lengths while expanding ‘camp::internal::tuple_storage<Indices, Types>’
  231 |         : tuple_storage<Indices, Types>(std::forward<Args>(args))...
      |                                                                  ^~~

```

Interestingly, when the nested tuple only has one element, the converting constructor does its job correctly, initializing the inner tuple with the unpacked value of the argument. So it takes at least two elements to encounter the issue. The PR includes a simple reproducer.

The proposed fix is very simplistic: it requires the number of elements in the source tuple to match the tuple being constructed. It is one of the requirements on converting constructors of `std::tuple` (I did not attempt to enforce the full set of requirements, but I could try if there's interest).