### PR TITLE
Don't zero in Resource::allocate

### DIFF
--- a/include/camp/resource.hpp
+++ b/include/camp/resource.hpp
@@ -77,7 +77,7 @@ namespace resources
       template <typename T>
       T *allocate(size_t size, MemoryAccess ma = MemoryAccess::Device)
       {
-        return (T *)m_value->calloc(size * sizeof(T), ma);
+        return (T *)m_value->allocate(size * sizeof(T), ma);
       }
       void *calloc(size_t size, MemoryAccess ma = MemoryAccess::Device) { return m_value->calloc(size, ma); }
       void deallocate(void *p, MemoryAccess ma = MemoryAccess::Device) { m_value->deallocate(p, ma); }
@@ -100,6 +100,7 @@ namespace resources
       public:
         virtual ~ContextInterface() {}
         virtual Platform get_platform() = 0;
+        virtual void *allocate(size_t size, MemoryAccess ma = MemoryAccess::Device) = 0;
         virtual void *calloc(size_t size, MemoryAccess ma = MemoryAccess::Device) = 0;
         virtual void deallocate(void *p, MemoryAccess ma = MemoryAccess::Device) = 0;
         virtual void memcpy(void *dst, const void *src, size_t size) = 0;
@@ -116,6 +117,7 @@ namespace resources
       public:
         ContextModel(T const &modelVal) : m_modelVal(modelVal) {}
         Platform get_platform() override { return m_modelVal.get_platform(); }
+        void *allocate(size_t size, MemoryAccess ma = MemoryAccess::Device) override { return m_modelVal.template allocate<char>(size, ma); }
         void *calloc(size_t size, MemoryAccess ma = MemoryAccess::Device) override { return m_modelVal.calloc(size, ma); }
         void deallocate(void *p, MemoryAccess ma = MemoryAccess::Device) override { m_modelVal.deallocate(p, ma); }
         void memcpy(void *dst, const void *src, size_t size) override


### PR DESCRIPTION
I ran into an issue where I setting pinned memory on the host immediately allocating it failed intermittently.
I discovered that Resource::allcoate actually calls the underlying calloc instead of allocate.