### PR TITLE
Fix oneapi in ci

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,17 +34,8 @@ FROM nvcr.io/nvidia/nvhpc:21.9-devel-cuda11.4-ubuntu20.04 AS nvhpc
 
 FROM rocm/dev-ubuntu-20.04:${VER} AS rocm
 
-# use the runtime container and then have it install the compiler,
-# save us a few gigabytes every time
-FROM intel/oneapi-runtime:${VER} AS oneapi
-ARG DEBIAN_FRONTEND=noninteractive
-ARG APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=1
-RUN apt-get update -y && \
-    apt-get install -y --no-install-recommends \
-        intel-oneapi-compiler-dpcpp-cpp && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
-# inject all setvars stuff into environment file
+# The intel-runtime container no longer works, use the fat one
+FROM intel/oneapi:${VER} AS oneapi
 RUN bash -c 'echo . /opt/intel/oneapi/setvars.sh >> ~/setup_env.sh'
 ### end compiler base images ###
 

--- a/scripts/get-deps.sh
+++ b/scripts/get-deps.sh
@@ -5,10 +5,10 @@ apt-get install -y --no-install-recommends curl unzip sudo
 apt-get clean
 rm -rf /var/lib/apt/lists/*
 
-CMAKE=3.14.7
+CMAKE=3.26.4
 mkdir installers
 pushd installers
-curl -s -L https://github.com/Kitware/CMake/releases/download/v$CMAKE/cmake-$CMAKE-linux-x86_64.sh > cmake.sh
+curl -s -L https://github.com/Kitware/CMake/releases/download/v$CMAKE/cmake-$CMAKE-linux-$(uname -m).sh > cmake.sh
 bash cmake.sh --prefix=/usr/local --skip-license
 
 curl -s -L https://github.com/ninja-build/ninja/releases/download/v1.10.2/ninja-linux.zip > ninja.zip


### PR DESCRIPTION
The tricks we were using to avoid having to download a few GB extra for every oneapi test stopped working.  Revert this to the simpler usage.