### PR TITLE
use hipPointerAttribute_t.type as HIP is removing hipPointerAttribute_t.memoryType

### DIFF
--- a/include/camp/resource/hip.hpp
+++ b/include/camp/resource/hip.hpp
@@ -113,7 +113,11 @@ namespace resources
         hipPointerAttribute_t a;
         hipError_t status = hipPointerGetAttributes(&a, p);
         if (status == hipSuccess) {
+#if (HIP_VERSION_MAJOR >= 6)
+          switch (a.type) {
+#else
           switch (a.memoryType) {
+#endif
             case hipMemoryTypeHost:
               return MemoryAccess::Pinned;
             case hipMemoryTypeDevice:


### PR DESCRIPTION
- In ROCm6.0 hipPointerAttribute_t.memoryType will be removed from HIP.
- Instead hipPointerAttribute_t.type to be used.
- This is causing build failure for RAJAPerf