### PR TITLE
Draft: SYCL Warnings

### DIFF
--- a/include/camp/resource/sycl.hpp
+++ b/include/camp/resource/sycl.hpp
@@ -52,7 +52,7 @@ namespace resources
                                       int num,
                                       bool useContext)
       {
-        static sycl::gpu_selector gpuSelector;
+        constexpr auto gpuSelector = sycl::gpu_selector_v;
         static sycl::property_list propertyList =
             sycl::property_list(sycl::property::queue::in_order());
         static sycl::context privateContext;


### PR DESCRIPTION
Change to new SYCL API with callable `gpu_selector_v`.

Related to RAJA update https://github.com/LLNL/RAJA/pull/1619.