### PR TITLE
Add a way to compare resources

### DIFF
--- a/include/camp/resource.hpp
+++ b/include/camp/resource.hpp
@@ -127,7 +127,7 @@ namespace resources
       bool operator==(T const& t) const
       {
         if(get_platform() == t.get_platform()) { 
-          return get<T>().compare(t);
+          return get<T>() == t;
         }
         return false;
       }

--- a/include/camp/resource.hpp
+++ b/include/camp/resource.hpp
@@ -123,22 +123,6 @@ namespace resources
         return !(*this == r);
       }
 
-      /*
-       * \brief Compares a generic Resource and a concrete Resource to see if they are equal. To find out, we
-       * first check to see if they are on the same platform. Then we call the operator == to compare the 
-       * type of the generic Resource (T) and the concrete one.
-       *
-       * \return True or false depending on comparison with m_value and t, assuming they are on the same platform.
-       */
-      template <typename T, std::enable_if_t<!std::is_same<T, Resource>::value>* = nullptr>
-      bool operator==(T const& t) const
-      {
-        if(get_platform() == t.get_platform()) { 
-          return get<T>() == t;
-        }
-        return false;
-      }
-
     private:
       class ContextInterface
       {
@@ -197,6 +181,22 @@ namespace resources
 
       std::shared_ptr<ContextInterface> m_value;
     };
+
+    /*
+     * \brief Compares a generic Resource and a concrete Resource to see if they are equal. To find out, we
+     * first check to see if they are on the same platform. Then we call the operator == to compare the 
+     * type of the generic Resource (T) and the concrete one.
+     *
+     * \return True or false depending on comparison with m_value and t, assuming they are on the same platform.
+     */
+    template <typename T, std::enable_if_t<!std::is_same<T, Resource>::value>* = nullptr>
+    bool operator==(Resource const& r, T const& t)
+    {
+      if(r.get_platform() == t.get_platform()) { 
+        return r.get<T>() == t;
+      }
+      return false;
+    }
 
     template <typename T, std::enable_if_t<!std::is_same<T, Resource>::value>* = nullptr>
     bool operator==(T const& t, Resource const& r)

--- a/include/camp/resource.hpp
+++ b/include/camp/resource.hpp
@@ -123,7 +123,7 @@ namespace resources
         return !(*this == r);
       }
 
-      template <typename T>
+      template <typename T, std::enable_if_t<!std::is_same<T, Resource>::value>* = nullptr>
       bool operator==(T const& t) const
       {
         if(get_platform() == t.get_platform()) { 

--- a/include/camp/resource.hpp
+++ b/include/camp/resource.hpp
@@ -151,10 +151,7 @@ namespace resources
         ContextModel(T const &modelVal) : m_modelVal(modelVal) {}
         Platform get_platform() const override { return m_modelVal.get_platform(); }
 
-        bool compare(Resource const& r) const override { 
-          T val = r.get<T>();
-          return m_modelVal == val; 
-        }
+        bool compare(Resource const& r) const override { return m_modelVal == r.get<T>(); }
 
         void *allocate(size_t size, MemoryAccess ma = MemoryAccess::Device) override { return m_modelVal.template allocate<char>(size, ma); }
         void *calloc(size_t size, MemoryAccess ma = MemoryAccess::Device) override { return m_modelVal.calloc(size, ma); }

--- a/include/camp/resource.hpp
+++ b/include/camp/resource.hpp
@@ -94,6 +94,12 @@ namespace resources
       void wait_for(Event *e) { m_value->wait_for(e); }
       void wait() { m_value->wait(); }
 
+      template <typename T>
+      bool compare (const camp::resources::Resource& r) {
+        auto result = dynamic_cast<ContextModel<T> *>(m_value.get());
+        return *result->compare(r);
+      }
+
     private:
       class ContextInterface
       {
@@ -225,6 +231,14 @@ namespace resources
 
       Res resource_;
     };
+
+      bool operator== (const camp::resources::Resource& l, const camp::resources::Resource& r)
+      {
+        if(l.get_platform() == r.get_platform()) {
+          return l.compare(r);
+        }
+        return false;
+      }
 
   }  // namespace v1
 }  // namespace resources

--- a/include/camp/resource.hpp
+++ b/include/camp/resource.hpp
@@ -95,9 +95,10 @@ namespace resources
       void wait() { m_value->wait(); }
 
       template <typename T>
-      bool compare (const camp::resources::Resource& r) {
-        auto result = dynamic_cast<ContextModel<T> *>(m_value.get());
-        return *result->compare(r);
+      bool compare (camp::resources::Resource& r) {
+        auto this_result = dynamic_cast<T>(m_value.get());
+        auto r_result = dynamic_cast<T>(r.get());
+        return this_result.compare(r_result);
       }
 
     private:
@@ -232,13 +233,13 @@ namespace resources
       Res resource_;
     };
 
-      bool operator== (const camp::resources::Resource& l, const camp::resources::Resource& r)
-      {
-        if(l.get_platform() == r.get_platform()) {
-          return l.compare(r);
-        }
-        return false;
+    bool operator== (camp::resources::Resource& l, camp::resources::Resource& r)
+    {
+      if(l.get_platform() == r.get_platform()) {
+        return l.compare(r);
       }
+      return false;
+    }
 
   }  // namespace v1
 }  // namespace resources

--- a/include/camp/resource.hpp
+++ b/include/camp/resource.hpp
@@ -95,7 +95,7 @@ namespace resources
       void wait() { m_value->wait(); }
 
       template <typename T>
-      bool compare (camp::resources::Resource& r) {
+      bool compare (const camp::resources::Resource& r) {
         auto this_result = dynamic_cast<T>(m_value.get());
         auto r_result = dynamic_cast<T>(r.get());
         return this_result.compare(r_result);
@@ -233,7 +233,7 @@ namespace resources
       Res resource_;
     };
 
-    bool operator== (camp::resources::Resource& l, camp::resources::Resource& r)
+    bool operator== (const camp::resources::Resource& l, const camp::resources::Resource& r)
     {
       if(l.get_platform() == r.get_platform()) {
         return l.compare(r);

--- a/include/camp/resource.hpp
+++ b/include/camp/resource.hpp
@@ -188,37 +188,6 @@ namespace resources
       std::shared_ptr<ContextInterface> m_value;
     };
 
-    /*
-     * \brief Compares a generic Resource and a concrete Resource to see if they are equal. To find out, we
-     * first check to see if they are on the same platform. Then we call the operator == to compare the 
-     * type of the generic Resource (T) and the concrete one.
-     *
-     * \return True or false depending on comparison with m_value and t, assuming they are on the same platform.
-     */
-    template <typename T, std::enable_if_t<!std::is_same<T, Resource>::value>* = nullptr>
-    bool operator==(Resource const& r, T const& t)
-    {
-      if(r.get_platform() == t.get_platform()) { 
-        return r.get<T>() == t;
-      }
-      return false;
-    }
-
-    template <typename T, std::enable_if_t<!std::is_same<T, Resource>::value>* = nullptr>
-    bool operator==(T const& t, Resource const& r)
-    {
-      if(t.get_platform() == r.get_platform()) { 
-        return t == r.get<T>();
-      }
-      return false;
-    }
-
-    template <typename T, std::enable_if_t<!std::is_same<T, Resource>::value>* = nullptr>
-    bool operator!=(T const& t, Resource const& r)
-    {
-      return !(t == r);
-    }
-
     template <Platform p>
     struct resource_from_platform;
     template <>

--- a/include/camp/resource.hpp
+++ b/include/camp/resource.hpp
@@ -106,7 +106,7 @@ namespace resources
       bool operator==(Resource const& r)
       {
         if(get_platform() == r.get_platform()) {
-          return (*m_value == r);
+          return (m_value->compare(r));
         }
         return false;
       }
@@ -130,8 +130,7 @@ namespace resources
         virtual ~ContextInterface() {}
         virtual Platform get_platform() const = 0;
 
-        virtual bool operator==(Resource const& r) = 0;
-        virtual bool operator!=(Resource const& r) = 0;
+        virtual bool compare(Resource const& r) = 0;
 
         virtual void *allocate(size_t size, MemoryAccess ma = MemoryAccess::Device) = 0;
         virtual void *calloc(size_t size, MemoryAccess ma = MemoryAccess::Device) = 0;
@@ -152,8 +151,7 @@ namespace resources
         ContextModel(T const &modelVal) : m_modelVal(modelVal) {}
         Platform get_platform() const override { return m_modelVal.get_platform(); }
 
-        bool operator==(Resource const& r) override { return m_modelVal == r.get<T>(); }
-        bool operator!=(Resource const& r) override { return m_modelVal != r.get<T>(); }
+        bool compare(Resource const& r) override { return m_modelVal == r.get<T>(); }
 
         void *allocate(size_t size, MemoryAccess ma = MemoryAccess::Device) override { return m_modelVal.template allocate<char>(size, ma); }
         void *calloc(size_t size, MemoryAccess ma = MemoryAccess::Device) override { return m_modelVal.calloc(size, ma); }

--- a/include/camp/resource.hpp
+++ b/include/camp/resource.hpp
@@ -198,6 +198,21 @@ namespace resources
       std::shared_ptr<ContextInterface> m_value;
     };
 
+    template <typename T, std::enable_if_t<!std::is_same<T, Resource>::value>* = nullptr>
+    bool operator==(T const& t, Resource const& r)
+    {
+      if(t.get_platform() == r.get_platform()) { 
+        return t == r.get<T>();
+      }
+      return false;
+    }
+
+    template <typename T, std::enable_if_t<!std::is_same<T, Resource>::value>* = nullptr>
+    bool operator!=(T const& t, Resource const& r)
+    {
+      return !(t == r);
+    }
+
     template <Platform p>
     struct resource_from_platform;
     template <>

--- a/include/camp/resource.hpp
+++ b/include/camp/resource.hpp
@@ -151,7 +151,10 @@ namespace resources
         ContextModel(T const &modelVal) : m_modelVal(modelVal) {}
         Platform get_platform() const override { return m_modelVal.get_platform(); }
 
-        bool compare(Resource const& r) const override { return m_modelVal == r.get<T>(); }
+        bool compare(Resource const& r) const override { 
+          T val = r.get<T>();
+          return m_modelVal == val; 
+        }
 
         void *allocate(size_t size, MemoryAccess ma = MemoryAccess::Device) override { return m_modelVal.template allocate<char>(size, ma); }
         void *calloc(size_t size, MemoryAccess ma = MemoryAccess::Device) override { return m_modelVal.calloc(size, ma); }

--- a/include/camp/resource.hpp
+++ b/include/camp/resource.hpp
@@ -94,6 +94,11 @@ namespace resources
       void wait_for(Event *e) { m_value->wait_for(e); }
       void wait() { m_value->wait(); }
 
+      /*
+       * \brief Compares two Resources to see if they are equal.
+       *
+       * \return True or false depending on comparison with m_value if they are on the same platform.
+       */
       bool operator==(Resource const& r)
       {
         if(get_platform() == r.get_platform()) {
@@ -101,6 +106,11 @@ namespace resources
         }
         return false;
       }
+      /*
+       * \brief Compares two Resources to see if they are NOT equal.
+       *
+       * \return True or false depending on result of == operator.
+       */
       bool operator!=(Resource const& r)
       {
         return !(*this == r);

--- a/include/camp/resource.hpp
+++ b/include/camp/resource.hpp
@@ -53,7 +53,10 @@ namespace resources
       template <typename T,
                 typename = typename std::enable_if<
                     !std::is_same<typename std::decay<T>::type,
-                                  Resource>::value>::type>
+                                  Resource>::value>::type,
+                typename = typename std::enable_if<
+                    !std::is_same<typename std::decay<T>::type,
+                                  char*>::value>::type>
       Resource(T &&value)
       {
         m_value.reset(new ContextModel<type::ref::rem<T>>(forward<T>(value)));

--- a/include/camp/resource.hpp
+++ b/include/camp/resource.hpp
@@ -103,7 +103,7 @@ namespace resources
        *
        * \return True or false depending on comparison with m_value if they are on the same platform.
        */
-      bool operator==(Resource const& r)
+      bool operator==(Resource const& r) const
       {
         if(get_platform() == r.get_platform()) {
           return (m_value->compare(r));

--- a/include/camp/resource.hpp
+++ b/include/camp/resource.hpp
@@ -118,7 +118,7 @@ namespace resources
        *
        * \return Negation of == operator. 
        */
-      bool operator!=(Resource const& r)
+      bool operator!=(Resource const& r) const
       {
         return !(*this == r);
       }
@@ -130,7 +130,7 @@ namespace resources
         virtual ~ContextInterface() {}
         virtual Platform get_platform() const = 0;
 
-        virtual bool compare(Resource const& r) = 0;
+        virtual bool compare(Resource const& r) const = 0;
 
         virtual void *allocate(size_t size, MemoryAccess ma = MemoryAccess::Device) = 0;
         virtual void *calloc(size_t size, MemoryAccess ma = MemoryAccess::Device) = 0;
@@ -151,7 +151,7 @@ namespace resources
         ContextModel(T const &modelVal) : m_modelVal(modelVal) {}
         Platform get_platform() const override { return m_modelVal.get_platform(); }
 
-        bool compare(Resource const& r) override { return m_modelVal == r.get<T>(); }
+        bool compare(Resource const& r) const override { return m_modelVal == r.get<T>(); }
 
         void *allocate(size_t size, MemoryAccess ma = MemoryAccess::Device) override { return m_modelVal.template allocate<char>(size, ma); }
         void *calloc(size_t size, MemoryAccess ma = MemoryAccess::Device) override { return m_modelVal.calloc(size, ma); }

--- a/include/camp/resource.hpp
+++ b/include/camp/resource.hpp
@@ -53,10 +53,7 @@ namespace resources
       template <typename T,
                 typename = typename std::enable_if<
                     !std::is_same<typename std::decay<T>::type,
-                                  Resource>::value>::type,
-                typename = typename std::enable_if<
-                    !std::is_same<typename std::decay<T>::type,
-                                  char*>::value>::type>
+                                  Resource>::value>::type>
       Resource(T &&value)
       {
         m_value.reset(new ContextModel<type::ref::rem<T>>(forward<T>(value)));

--- a/include/camp/resource.hpp
+++ b/include/camp/resource.hpp
@@ -94,12 +94,16 @@ namespace resources
       void wait_for(Event *e) { m_value->wait_for(e); }
       void wait() { m_value->wait(); }
 
-      bool operator==(camp::resources::Resource const& r)
+      bool operator==(Resource const& r)
       {
         if(get_platform() == r.get_platform()) {
           return (*m_value == r);
         }
         return false;
+      }
+      bool operator!=(Resource const& r)
+      {
+        return !(*this == r);
       }
 
     private:
@@ -109,6 +113,7 @@ namespace resources
         virtual ~ContextInterface() {}
         virtual Platform get_platform() const = 0;
         virtual bool operator==(Resource const& r) = 0;
+        virtual bool operator!=(Resource const& r) = 0;
         virtual void *allocate(size_t size, MemoryAccess ma = MemoryAccess::Device) = 0;
         virtual void *calloc(size_t size, MemoryAccess ma = MemoryAccess::Device) = 0;
         virtual void deallocate(void *p, MemoryAccess ma = MemoryAccess::Device) = 0;
@@ -126,7 +131,8 @@ namespace resources
       public:
         ContextModel(T const &modelVal) : m_modelVal(modelVal) {}
         Platform get_platform() const override { return m_modelVal.get_platform(); }
-        bool operator==( Resource const& r) override { return m_modelVal == r.get<T>(); }
+        bool operator==(Resource const& r) override { return m_modelVal == r.get<T>(); }
+        bool operator!=(Resource const& r) override { return m_modelVal != r.get<T>(); }
         void *allocate(size_t size, MemoryAccess ma = MemoryAccess::Device) override { return m_modelVal.template allocate<char>(size, ma); }
         void *calloc(size_t size, MemoryAccess ma = MemoryAccess::Device) override { return m_modelVal.calloc(size, ma); }
         void deallocate(void *p, MemoryAccess ma = MemoryAccess::Device) override { m_modelVal.deallocate(p, ma); }
@@ -235,7 +241,6 @@ namespace resources
 
       Res resource_;
     };
-
 
   }  // namespace v1
 }  // namespace resources

--- a/include/camp/resource.hpp
+++ b/include/camp/resource.hpp
@@ -123,6 +123,13 @@ namespace resources
         return !(*this == r);
       }
 
+      /*
+       * \brief Compares a generic Resource and a concrete Resource to see if they are equal. To find out, we
+       * first check to see if they are on the same platform. Then we call the operator == to compare the 
+       * type of the generic Resource (T) and the concrete one.
+       *
+       * \return True or false depending on comparison with m_value and t, assuming they are on the same platform.
+       */
       template <typename T>
       bool operator==(T const& t) const
       {

--- a/include/camp/resource.hpp
+++ b/include/camp/resource.hpp
@@ -95,9 +95,10 @@ namespace resources
       void wait() { m_value->wait(); }
 
       bool compare (camp::resources::Resource& r) {
-        //auto this_result = dynamic_cast<T>(m_value.get());
-        //auto r_result = dynamic_cast<T>(r.get());
-        return m_value->compare(r);
+        if(l.get_platform() == r.get_platform()) {
+          return m_value->compare(r);
+        }
+        return false;
       }
 
     private:
@@ -240,10 +241,7 @@ namespace resources
 
     bool operator== (camp::resources::Resource& l, camp::resources::Resource& r)
     {
-      if(l.get_platform() == r.get_platform()) {
-        return l.compare(r);
-      }
-      return false;
+      return l.compare(r);
     }
 
   }  // namespace v1

--- a/include/camp/resource.hpp
+++ b/include/camp/resource.hpp
@@ -95,7 +95,7 @@ namespace resources
       void wait() { m_value->wait(); }
 
       bool compare (camp::resources::Resource& r) {
-        if(l.get_platform() == r.get_platform()) {
+        if(get_platform() == r.get_platform()) {
           return m_value->compare(r);
         }
         return false;

--- a/include/camp/resource.hpp
+++ b/include/camp/resource.hpp
@@ -95,7 +95,11 @@ namespace resources
       void wait() { m_value->wait(); }
 
       /*
-       * \brief Compares two Resources to see if they are equal.
+       * \brief Compares two Resources to see if they are equal. Two Resources are equal if they are
+       * on the same platform and they describe the same stream (i.e. CUDA, HIP) or queue (i.e. SYCL).
+       * (Note: This operator overload is on the generic Resource. Using the ContextModel's operator
+       * overload, we can call the specific resource's (i.e. T) operator== to compare streams or
+       * queues.)
        *
        * \return True or false depending on comparison with m_value if they are on the same platform.
        */
@@ -106,11 +110,13 @@ namespace resources
         }
         return false;
       }
-      
       /*
-       * \brief Compares two Resources to see if they are NOT equal.
+       * \brief Compares two Resources to see if they are NOT equal. Two Resources are not equal
+       * if they are on separate platforms. Also, even if they are on the same platform, if they
+       * describe different streams (i.e. CUDA, HIP) or different queues (i.e. SYCL), then they 
+       * are not equal.
        *
-       * \return True or false depending on result of == operator.
+       * \return Negation of == operator. 
        */
       bool operator!=(Resource const& r)
       {
@@ -123,13 +129,16 @@ namespace resources
       public:
         virtual ~ContextInterface() {}
         virtual Platform get_platform() const = 0;
+
         virtual bool operator==(Resource const& r) = 0;
         virtual bool operator!=(Resource const& r) = 0;
+
         virtual void *allocate(size_t size, MemoryAccess ma = MemoryAccess::Device) = 0;
         virtual void *calloc(size_t size, MemoryAccess ma = MemoryAccess::Device) = 0;
         virtual void deallocate(void *p, MemoryAccess ma = MemoryAccess::Device) = 0;
         virtual void memcpy(void *dst, const void *src, size_t size) = 0;
         virtual void memset(void *p, int val, size_t size) = 0;
+
         virtual Event get_event() = 0;
         virtual Event get_event_erased() = 0;
         virtual void wait_for(Event *e) = 0;
@@ -142,8 +151,10 @@ namespace resources
       public:
         ContextModel(T const &modelVal) : m_modelVal(modelVal) {}
         Platform get_platform() const override { return m_modelVal.get_platform(); }
+
         bool operator==(Resource const& r) override { return m_modelVal == r.get<T>(); }
         bool operator!=(Resource const& r) override { return m_modelVal != r.get<T>(); }
+
         void *allocate(size_t size, MemoryAccess ma = MemoryAccess::Device) override { return m_modelVal.template allocate<char>(size, ma); }
         void *calloc(size_t size, MemoryAccess ma = MemoryAccess::Device) override { return m_modelVal.calloc(size, ma); }
         void deallocate(void *p, MemoryAccess ma = MemoryAccess::Device) override { m_modelVal.deallocate(p, ma); }
@@ -155,6 +166,7 @@ namespace resources
         {
           m_modelVal.memset(p, val, size);
         }
+
         Event get_event() override { return m_modelVal.get_event_erased(); }
         Event get_event_erased() override
         {
@@ -162,6 +174,7 @@ namespace resources
         }
         void wait_for(Event *e) override { m_modelVal.wait_for(e); }
         void wait() override { m_modelVal.wait(); }
+
         T *get() { return &m_modelVal; }
 
       private:

--- a/include/camp/resource.hpp
+++ b/include/camp/resource.hpp
@@ -106,6 +106,7 @@ namespace resources
         }
         return false;
       }
+      
       /*
        * \brief Compares two Resources to see if they are NOT equal.
        *

--- a/include/camp/resource.hpp
+++ b/include/camp/resource.hpp
@@ -123,6 +123,15 @@ namespace resources
         return !(*this == r);
       }
 
+      template <typename T>
+      bool operator==(T const& t) const
+      {
+        if(get_platform() == t.get_platform()) { 
+          return get<T>().compare(t);
+        }
+        return false;
+      }
+
     private:
       class ContextInterface
       {

--- a/include/camp/resource/cuda.hpp
+++ b/include/camp/resource/cuda.hpp
@@ -29,7 +29,6 @@ namespace resources
   inline namespace v1
   {
     class Cuda;
-    class Resource;
 
     namespace
     {

--- a/include/camp/resource/cuda.hpp
+++ b/include/camp/resource/cuda.hpp
@@ -258,14 +258,14 @@ namespace resources
       }
 
       cudaStream_t get_stream() const { return stream; }
-      int get_device() { return device; }
+      int get_device() const { return device; }
 
       /*
        * \brief Compares two (Cuda) resources to see if they are equal.
        *
        * \return True or false depending on if it is the same stream.
        */
-      bool operator==(Cuda const& c)
+      const bool operator==(Cuda const& c)
       {
         return (get_stream() == c.get_stream());
       }
@@ -274,7 +274,7 @@ namespace resources
        *
        * \return True or false depending on result of == operator.
        */
-      bool operator!=(Cuda const& c)
+      const bool operator!=(Cuda const& c)
       {
         return !(*this == c);
       }

--- a/include/camp/resource/cuda.hpp
+++ b/include/camp/resource/cuda.hpp
@@ -259,6 +259,13 @@ namespace resources
       cudaStream_t get_stream() { return stream; }
       int get_device() { return device; }
 
+      bool compare (camp::resources::Cuda r)
+      {
+        if(get_stream() == r.get_stream()) {
+          return true;
+        }
+        return false;
+      }
     private:
       cudaStream_t stream;
       int device;

--- a/include/camp/resource/cuda.hpp
+++ b/include/camp/resource/cuda.hpp
@@ -16,6 +16,7 @@ http://github.com/llnl/camp
 #ifdef CAMP_ENABLE_CUDA
 
 #include "camp/defines.hpp"
+#include "camp/resource.hpp"
 #include "camp/resource/event.hpp"
 #include "camp/resource/platform.hpp"
 
@@ -259,13 +260,18 @@ namespace resources
       cudaStream_t get_stream() { return stream; }
       int get_device() { return device; }
 
-      bool compare (camp::resources::Cuda r)
+      bool compare (camp::resources::Resource r)
       {
-        if(get_stream() == r.get_stream()) {
-          return true;
+        Cuda* other = r.try_get();
+        if (!other) return false;
+        else {
+          if(get_stream() == r.get_stream()) {
+            return true;
+          }
         }
         return false;
       }
+
     private:
       cudaStream_t stream;
       int device;

--- a/include/camp/resource/cuda.hpp
+++ b/include/camp/resource/cuda.hpp
@@ -260,9 +260,23 @@ namespace resources
       cudaStream_t get_stream() const { return stream; }
       int get_device() { return device; }
 
+      /*
+       * \brief Compares two (Cuda) resources to see if they are equal.
+       *
+       * \return True or false depending on if it is the same stream.
+       */
       bool operator==(Cuda const& c)
       {
         return (get_stream() == c.get_stream());
+      }
+      /*
+       * \brief Compares two (Cuda) resources to see if they are NOT equal.
+       *
+       * \return True or false depending on result of == operator.
+       */
+      bool operator!=(Cuda const& c)
+      {
+        return !(*this == c);
       }
 
     private:

--- a/include/camp/resource/cuda.hpp
+++ b/include/camp/resource/cuda.hpp
@@ -16,7 +16,7 @@ http://github.com/llnl/camp
 #ifdef CAMP_ENABLE_CUDA
 
 #include "camp/defines.hpp"
-#include "camp/resource.hpp"
+//#include "camp/resource.hpp"
 #include "camp/resource/event.hpp"
 #include "camp/resource/platform.hpp"
 
@@ -30,6 +30,7 @@ namespace resources
   inline namespace v1
   {
     class Cuda;
+    class Resource;
 
     namespace
     {
@@ -260,16 +261,10 @@ namespace resources
       cudaStream_t get_stream() { return stream; }
       int get_device() { return device; }
 
-      bool compare (camp::resources::Resource r)
+      bool compare (Cuda* c)
       {
-        Cuda* other = r.try_get();
-        if (!other) return false;
-        else {
-          if(get_stream() == r.get_stream()) {
-            return true;
-          }
-        }
-        return false;
+        if (!c) return false;
+        return (get_stream() == c->get_stream());
       }
 
     private:

--- a/include/camp/resource/cuda.hpp
+++ b/include/camp/resource/cuda.hpp
@@ -16,7 +16,6 @@ http://github.com/llnl/camp
 #ifdef CAMP_ENABLE_CUDA
 
 #include "camp/defines.hpp"
-//#include "camp/resource.hpp"
 #include "camp/resource/event.hpp"
 #include "camp/resource/platform.hpp"
 

--- a/include/camp/resource/cuda.hpp
+++ b/include/camp/resource/cuda.hpp
@@ -257,13 +257,12 @@ namespace resources
         }
       }
 
-      cudaStream_t get_stream() { return stream; }
+      cudaStream_t get_stream() const { return stream; }
       int get_device() { return device; }
 
-      bool compare (Cuda* c)
+      bool operator==(Cuda const& c)
       {
-        if (!c) return false;
-        return (get_stream() == c->get_stream());
+        return (get_stream() == c.get_stream());
       }
 
     private:

--- a/include/camp/resource/cuda.hpp
+++ b/include/camp/resource/cuda.hpp
@@ -265,7 +265,7 @@ namespace resources
        *
        * \return True or false depending on if it is the same stream.
        */
-      const bool operator==(Cuda const& c)
+      bool operator==(Cuda const& c) const
       {
         return (get_stream() == c.get_stream());
       }
@@ -274,7 +274,7 @@ namespace resources
        *
        * \return True or false depending on result of == operator.
        */
-      const bool operator!=(Cuda const& c)
+      bool operator!=(Cuda const& c) const
       {
         return !(*this == c);
       }

--- a/include/camp/resource/cuda.hpp
+++ b/include/camp/resource/cuda.hpp
@@ -269,10 +269,11 @@ namespace resources
       {
         return (get_stream() == c.get_stream());
       }
+      
       /*
        * \brief Compares two (Cuda) resources to see if they are NOT equal.
        *
-       * \return True or false depending on result of == operator.
+       * \return Negation of == operator
        */
       bool operator!=(Cuda const& c) const
       {

--- a/include/camp/resource/hip.hpp
+++ b/include/camp/resource/hip.hpp
@@ -260,12 +260,24 @@ namespace resources
       hipStream_t get_stream() { return stream; }
       int get_device() { return device; }
 
-      bool compare (Hip* h)
+      /*
+       * \brief Compares two (Hip) resources to see if they are equal.
+       *
+       * \return True or false depending on if this is the same stream.
+       */
+      bool operator==(Hip const& h)
       {
-        if (!h) return false;
-        return (get_stream() == h->get_stream());
+        return (get_stream() == h.get_stream());
       }
-
+      /*
+       * \brief Compares two (Hip) resources to see if they are NOT equal.
+       *
+       * \return True or false depending on result of == operator.
+       */
+      bool operator!=(Hip const& h)
+      {
+        return !(*this == h);
+      }
 
     private:
       hipStream_t stream;

--- a/include/camp/resource/hip.hpp
+++ b/include/camp/resource/hip.hpp
@@ -257,7 +257,7 @@ namespace resources
         }
       }
 
-      hipStream_t get_stream() { return stream; }
+      hipStream_t get_stream() const { return stream; }
       int get_device() { return device; }
 
       /*

--- a/include/camp/resource/hip.hpp
+++ b/include/camp/resource/hip.hpp
@@ -260,13 +260,18 @@ namespace resources
       hipStream_t get_stream() { return stream; }
       int get_device() { return device; }
 
-      bool compare (camp::resources::Hip r)
+      bool compare (camp::resources::Resource r)
       {
-        if(get_stream() == r.get_stream()) {
-          return true;
+        Hip* other = r.try_get();
+        if (!other) return false;
+        else {
+          if(get_stream() == r.get_stream()) {
+            return true;
+          }
         }
         return false;
       }
+
 
     private:
       hipStream_t stream;

--- a/include/camp/resource/hip.hpp
+++ b/include/camp/resource/hip.hpp
@@ -269,10 +269,11 @@ namespace resources
       {
         return (get_stream() == h.get_stream());
       }
+      
       /*
        * \brief Compares two (Hip) resources to see if they are NOT equal.
        *
-       * \return True or false depending on result of == operator.
+       * \return Negation of == operator
        */
       bool operator!=(Hip const& h) const
       {

--- a/include/camp/resource/hip.hpp
+++ b/include/camp/resource/hip.hpp
@@ -260,16 +260,10 @@ namespace resources
       hipStream_t get_stream() { return stream; }
       int get_device() { return device; }
 
-      bool compare (camp::resources::Resource r)
+      bool compare (Hip* h)
       {
-        Hip* other = r.try_get();
-        if (!other) return false;
-        else {
-          if(get_stream() == r.get_stream()) {
-            return true;
-          }
-        }
-        return false;
+        if (!h) return false;
+        return (get_stream() == h->get_stream());
       }
 
 

--- a/include/camp/resource/hip.hpp
+++ b/include/camp/resource/hip.hpp
@@ -265,7 +265,7 @@ namespace resources
        *
        * \return True or false depending on if this is the same stream.
        */
-      const bool operator==(Hip const& h)
+      bool operator==(Hip const& h) const
       {
         return (get_stream() == h.get_stream());
       }
@@ -274,7 +274,7 @@ namespace resources
        *
        * \return True or false depending on result of == operator.
        */
-      const bool operator!=(Hip const& h)
+      bool operator!=(Hip const& h) const
       {
         return !(*this == h);
       }

--- a/include/camp/resource/hip.hpp
+++ b/include/camp/resource/hip.hpp
@@ -258,14 +258,14 @@ namespace resources
       }
 
       hipStream_t get_stream() const { return stream; }
-      int get_device() { return device; }
+      int get_device() const { return device; }
 
       /*
        * \brief Compares two (Hip) resources to see if they are equal.
        *
        * \return True or false depending on if this is the same stream.
        */
-      bool operator==(Hip const& h)
+      const bool operator==(Hip const& h)
       {
         return (get_stream() == h.get_stream());
       }
@@ -274,7 +274,7 @@ namespace resources
        *
        * \return True or false depending on result of == operator.
        */
-      bool operator!=(Hip const& h)
+      const bool operator!=(Hip const& h)
       {
         return !(*this == h);
       }

--- a/include/camp/resource/hip.hpp
+++ b/include/camp/resource/hip.hpp
@@ -260,6 +260,14 @@ namespace resources
       hipStream_t get_stream() { return stream; }
       int get_device() { return device; }
 
+      bool compare (camp::resources::Hip r)
+      {
+        if(get_stream() == r.get_stream()) {
+          return true;
+        }
+        return false;
+      }
+
     private:
       hipStream_t stream;
       int device;

--- a/include/camp/resource/host.hpp
+++ b/include/camp/resource/host.hpp
@@ -68,6 +68,13 @@ namespace resources
       void deallocate(void *p, MemoryAccess = MemoryAccess::Device) { std::free(p); }
       void memcpy(void *dst, const void *src, size_t size) { std::memcpy(dst, src, size); }
       void memset(void *p, int val, size_t size) { std::memset(p, val, size); }
+      bool compare (camp::resources::Host r)
+      {
+        if(get_platform() == r.get_platform()) {
+          return true;
+        }
+        return false;
+      }
     };
 
   }  // namespace v1

--- a/include/camp/resource/host.hpp
+++ b/include/camp/resource/host.hpp
@@ -69,16 +69,15 @@ namespace resources
       void memcpy(void *dst, const void *src, size_t size) { std::memcpy(dst, src, size); }
       void memset(void *p, int val, size_t size) { std::memset(p, val, size); }
 
-      bool compare (camp::resources::Resource r)
+      bool compare (Host* other)
       {
-        Host* other = r.try_get();
         if(!other) return false;
-        else {
-          if(get_platform() == r.get_platform()) {
+        //else {
+        //  if(get_platform() == r.get_platform()) {
             return true;
-          }
-        }
-        return false;
+        //  }
+        //}
+        //return false;
       }
     };
 

--- a/include/camp/resource/host.hpp
+++ b/include/camp/resource/host.hpp
@@ -78,6 +78,7 @@ namespace resources
       {
         return true;
       }
+      
       /*
        * \brief Compares two (Host) resources to see if they are NOT equal.
        *

--- a/include/camp/resource/host.hpp
+++ b/include/camp/resource/host.hpp
@@ -72,12 +72,7 @@ namespace resources
       bool compare (Host* other)
       {
         if(!other) return false;
-        //else {
-        //  if(get_platform() == r.get_platform()) {
-            return true;
-        //  }
-        //}
-        //return false;
+        return true;
       }
     };
 

--- a/include/camp/resource/host.hpp
+++ b/include/camp/resource/host.hpp
@@ -85,7 +85,7 @@ namespace resources
        */
       bool operator!=(Host const&)
       {
-        return true;
+        return false;
       }
     };
 

--- a/include/camp/resource/host.hpp
+++ b/include/camp/resource/host.hpp
@@ -69,7 +69,7 @@ namespace resources
       void memcpy(void *dst, const void *src, size_t size) { std::memcpy(dst, src, size); }
       void memset(void *p, int val, size_t size) { std::memset(p, val, size); }
 
-      bool operator==(Host const& other)
+      bool operator==(Host const&)
       {
         return true;
       }

--- a/include/camp/resource/host.hpp
+++ b/include/camp/resource/host.hpp
@@ -68,10 +68,15 @@ namespace resources
       void deallocate(void *p, MemoryAccess = MemoryAccess::Device) { std::free(p); }
       void memcpy(void *dst, const void *src, size_t size) { std::memcpy(dst, src, size); }
       void memset(void *p, int val, size_t size) { std::memset(p, val, size); }
-      bool compare (camp::resources::Host r)
+
+      bool compare (camp::resources::Resource r)
       {
-        if(get_platform() == r.get_platform()) {
-          return true;
+        Host* other = r.try_get();
+        if(!other) return false;
+        else {
+          if(get_platform() == r.get_platform()) {
+            return true;
+          }
         }
         return false;
       }

--- a/include/camp/resource/host.hpp
+++ b/include/camp/resource/host.hpp
@@ -68,28 +68,29 @@ namespace resources
       void deallocate(void *p, MemoryAccess = MemoryAccess::Device) { std::free(p); }
       void memcpy(void *dst, const void *src, size_t size) { std::memcpy(dst, src, size); }
       void memset(void *p, int val, size_t size) { std::memset(p, val, size); }
+    };
 
       /*
        * \brief Compares two (Host) resources to see if they are equal.
+       * (This was made in to a free function to appease MSVC and SYCL compilers)
        *
        * \return Always return true since we are on the Host in this case.
        */
-      bool operator==(Host const&) const
+      bool operator==(Host const&, Host const&)
       {
         return true;
       }
       
       /*
        * \brief Compares two (Host) resources to see if they are NOT equal.
+       * (This was made in to a free function to appease MSVC and SYCL compilers)
        *
        * \return Always return false. Host resources are always the same.
        */
-      bool operator!=(Host const&) const
+      bool operator!=(Host const&, Host const&)
       {
         return false;
       }
-    };
-
   }  // namespace v1
 }  // namespace resources
 }  // namespace camp

--- a/include/camp/resource/host.hpp
+++ b/include/camp/resource/host.hpp
@@ -69,9 +69,8 @@ namespace resources
       void memcpy(void *dst, const void *src, size_t size) { std::memcpy(dst, src, size); }
       void memset(void *p, int val, size_t size) { std::memset(p, val, size); }
 
-      bool compare (Host* other)
+      bool operator==(Host const& other)
       {
-        if(!other) return false;
         return true;
       }
     };

--- a/include/camp/resource/host.hpp
+++ b/include/camp/resource/host.hpp
@@ -69,7 +69,16 @@ namespace resources
       void memcpy(void *dst, const void *src, size_t size) { std::memcpy(dst, src, size); }
       void memset(void *p, int val, size_t size) { std::memset(p, val, size); }
 
+      /*
+       * \brief Compares two (Host) resources to see if they are the same or not.
+       *
+       * \return Always return true since we are on the Host in this case.
+       */
       bool operator==(Host const&)
+      {
+        return true;
+      }
+      bool operator!=(Host const&)
       {
         return true;
       }

--- a/include/camp/resource/host.hpp
+++ b/include/camp/resource/host.hpp
@@ -74,7 +74,7 @@ namespace resources
        *
        * \return Always return true since we are on the Host in this case.
        */
-      bool operator==(Host const&)
+      bool operator==(Host const&) const
       {
         return true;
       }
@@ -84,7 +84,7 @@ namespace resources
        *
        * \return Always return false. Host resources are always the same.
        */
-      bool operator!=(Host const&)
+      bool operator!=(Host const&) const
       {
         return false;
       }

--- a/include/camp/resource/host.hpp
+++ b/include/camp/resource/host.hpp
@@ -70,7 +70,7 @@ namespace resources
       void memset(void *p, int val, size_t size) { std::memset(p, val, size); }
 
       /*
-       * \brief Compares two (Host) resources to see if they are the same or not.
+       * \brief Compares two (Host) resources to see if they are equal.
        *
        * \return Always return true since we are on the Host in this case.
        */
@@ -78,6 +78,11 @@ namespace resources
       {
         return true;
       }
+      /*
+       * \brief Compares two (Host) resources to see if they are NOT equal.
+       *
+       * \return Always return false. Host resources are always the same.
+       */
       bool operator!=(Host const&)
       {
         return true;

--- a/include/camp/resource/omp_target.hpp
+++ b/include/camp/resource/omp_target.hpp
@@ -192,7 +192,7 @@ namespace resources
         }
         return ret;
       }
-      bool compare (camp::resources::Omp r)
+      bool compare (camp::resources::Resource r)
       {
         //if(get_stream() == r.get_stream()) {
         //  return true;

--- a/include/camp/resource/omp_target.hpp
+++ b/include/camp/resource/omp_target.hpp
@@ -192,6 +192,13 @@ namespace resources
         }
         return ret;
       }
+      bool compare (camp::resources::Omp r)
+      {
+        //if(get_stream() == r.get_stream()) {
+        //  return true;
+        //}
+        return false;
+      }
 
     private:
       char *addr;

--- a/include/camp/resource/omp_target.hpp
+++ b/include/camp/resource/omp_target.hpp
@@ -192,12 +192,10 @@ namespace resources
         }
         return ret;
       }
-      bool compare (camp::resources::Resource r)
+      bool compare (Omp* o)
       {
-        //if(get_stream() == r.get_stream()) {
-        //  return true;
-        //}
-        return false;
+        return (dev == o->dev);
+        //TODO: do i need to compare addr???
       }
 
     private:

--- a/include/camp/resource/omp_target.hpp
+++ b/include/camp/resource/omp_target.hpp
@@ -193,7 +193,7 @@ namespace resources
         return ret;
       }
       /*
-       * \brief Compares two (Omp) resources to see if they are the same or not.
+       * \brief Compares two (Omp) resources to see if they are equal.
        *
        * \return True or false depending on if this is the same dev int and addr ptr.
        */
@@ -201,7 +201,11 @@ namespace resources
       {
         return (dev == o.dev && addr == o.addr);
       }
-
+      /*
+       * \brief Compares two (Omp) resources to see if they are NOT equal.
+       *
+       * \return True or false depending on result of == operator.
+       */
       bool operator!=(Omp const& o)
       {
         return !(*this == o);

--- a/include/camp/resource/omp_target.hpp
+++ b/include/camp/resource/omp_target.hpp
@@ -201,10 +201,11 @@ namespace resources
       {
         return (dev == o.dev && addr == o.addr);
       }
+      
       /*
        * \brief Compares two (Omp) resources to see if they are NOT equal.
        *
-       * \return True or false depending on result of == operator.
+       * \return Negation of == operator
        */
       bool operator!=(Omp const& o)
       {

--- a/include/camp/resource/omp_target.hpp
+++ b/include/camp/resource/omp_target.hpp
@@ -192,10 +192,19 @@ namespace resources
         }
         return ret;
       }
-      bool compare (Omp* o)
+      /*
+       * \brief Compares two (Omp) resources to see if they are the same or not.
+       *
+       * \return True or false depending on if this is the same dev int and addr ptr.
+       */
+      bool operator==(Omp const& o)
       {
-        return (dev == o->dev);
-        //TODO: do i need to compare addr???
+        return (dev == o.dev && addr == o.addr);
+      }
+
+      bool operator!=(Omp const& o)
+      {
+        return !(*this == o);
       }
 
     private:

--- a/include/camp/resource/omp_target.hpp
+++ b/include/camp/resource/omp_target.hpp
@@ -197,7 +197,7 @@ namespace resources
        *
        * \return True or false depending on if this is the same dev int and addr ptr.
        */
-      bool operator==(Omp const& o)
+      bool operator==(Omp const& o) const
       {
         return (dev == o.dev && addr == o.addr);
       }
@@ -207,7 +207,7 @@ namespace resources
        *
        * \return Negation of == operator
        */
-      bool operator!=(Omp const& o)
+      bool operator!=(Omp const& o) const
       {
         return !(*this == o);
       }

--- a/include/camp/resource/sycl.hpp
+++ b/include/camp/resource/sycl.hpp
@@ -199,10 +199,23 @@ namespace resources
 
       sycl::queue *get_queue() { return qu; }
 
-      bool compare (Sycl* s)
+      /*
+       * \brief Compares two (Sycl) resources to see if they are equal.
+       *
+       * \return True or false depending on if this is the same queue.
+       */
+      bool operator==(Sycl const& s)
       {
-        if (!s) return false;
-        return (get_queue() == s->get_queue());
+        return (get_queue() == s.get_queue());
+      }
+      /*
+       * \brief Compares two (Sycl) resources to see if they are NOT equal.
+       *
+       * \return True or false depending on the result of the == operator.
+       */
+      bool operator!=(Sycl const& s)
+      {
+        return !(*this == s);
       }
 
     private:

--- a/include/camp/resource/sycl.hpp
+++ b/include/camp/resource/sycl.hpp
@@ -197,7 +197,8 @@ namespace resources
         }
       }
 
-      sycl::queue *get_queue() const { return qu; }
+      sycl::queue *get_queue() { return qu; }
+      sycl::queue const *get_queue() const { return qu; }
 
       /*
        * \brief Compares two (Sycl) resources to see if they are equal.

--- a/include/camp/resource/sycl.hpp
+++ b/include/camp/resource/sycl.hpp
@@ -198,6 +198,13 @@ namespace resources
       }
 
       sycl::queue *get_queue() { return qu; }
+      bool compare (camp::resources::Sycl r)
+      {
+        if(get_queue() == r.get_queue()) {
+          return true;
+        }
+        return false;
+      }
 
     private:
       sycl::queue *qu;

--- a/include/camp/resource/sycl.hpp
+++ b/include/camp/resource/sycl.hpp
@@ -208,6 +208,7 @@ namespace resources
       {
         return (get_queue() == s.get_queue());
       }
+      
       /*
        * \brief Compares two (Sycl) resources to see if they are NOT equal.
        *

--- a/include/camp/resource/sycl.hpp
+++ b/include/camp/resource/sycl.hpp
@@ -211,7 +211,7 @@ namespace resources
       /*
        * \brief Compares two (Sycl) resources to see if they are NOT equal.
        *
-       * \return True or false depending on the result of the == operator.
+       * \return Negation of == operator
        */
       bool operator!=(Sycl const& s)
       {

--- a/include/camp/resource/sycl.hpp
+++ b/include/camp/resource/sycl.hpp
@@ -199,12 +199,10 @@ namespace resources
 
       sycl::queue *get_queue() { return qu; }
 
-      bool compare (camp::resources::Resource r)
+      bool compare (Sycl* s)
       {
-        //if(get_queue() == r.get_queue()) {
-        //  return true;
-        //}
-        return false;
+        if (!s) return false;
+        return (get_queue() == s->get_queue());
       }
 
     private:

--- a/include/camp/resource/sycl.hpp
+++ b/include/camp/resource/sycl.hpp
@@ -197,14 +197,14 @@ namespace resources
         }
       }
 
-      sycl::queue *get_queue() { return qu; }
+      sycl::queue *get_queue() const { return qu; }
 
       /*
        * \brief Compares two (Sycl) resources to see if they are equal.
        *
        * \return True or false depending on if this is the same queue.
        */
-      bool operator==(Sycl const& s)
+      bool operator==(Sycl const& s) const
       {
         return (get_queue() == s.get_queue());
       }
@@ -214,7 +214,7 @@ namespace resources
        *
        * \return Negation of == operator
        */
-      bool operator!=(Sycl const& s)
+      bool operator!=(Sycl const& s) const
       {
         return !(*this == s);
       }

--- a/include/camp/resource/sycl.hpp
+++ b/include/camp/resource/sycl.hpp
@@ -198,11 +198,12 @@ namespace resources
       }
 
       sycl::queue *get_queue() { return qu; }
-      bool compare (camp::resources::Sycl r)
+
+      bool compare (camp::resources::Resource r)
       {
-        if(get_queue() == r.get_queue()) {
-          return true;
-        }
+        //if(get_queue() == r.get_queue()) {
+        //  return true;
+        //}
         return false;
       }
 

--- a/test/resource.cpp
+++ b/test/resource.cpp
@@ -75,14 +75,7 @@ TEST(CampResource, Compare)
 
   ASSERT_TRUE(h1 == h1);
   ASSERT_TRUE(h1 == h2);
-  auto assert_resources_equal = [](auto const& r1, auto const& r2) {
-    ASSERT_TRUE(r1 == r2);
-    ASSERT_TRUE(r2 == r1);
-    ASSERT_FALSE(r1 != r2);
-    ASSERT_FALSE(r2 != r1);
-  };
-  assert_resources_equal(h1, h2);
-  assert_resources_equal(h3, h);
+  ASSERT_TRUE(h3 == h);
   ASSERT_TRUE(h == h3);
 
   ASSERT_FALSE(h != h3);
@@ -104,7 +97,7 @@ TEST(CampResource, Compare)
   ASSERT_FALSE(r1 == r2);
   ASSERT_FALSE(r2 == r1);
   ASSERT_FALSE(r2 == r3);
-  ASSERT_FALSE(r1 == h2);
+  ASSERT_FALSE(h2 == r2);
 
   ASSERT_FALSE(s != r3);
   ASSERT_FALSE(r3 != s);

--- a/test/resource.cpp
+++ b/test/resource.cpp
@@ -71,7 +71,18 @@ TEST(CampResource, Reassignment)
   c2 = Host();
   ASSERT_EQ(typeid(c2), typeid(h2));
 }
+/*
+TEST(CampResource, Compare)
+{
+  Resource h1{Host()};
+  Resource c1{Cuda()};
+  Resource h2{Host()};
+  Resource c2{Cuda()};
 
+  ASSERT_TRUE(h1 == h1);
+  ASSERT_FALSE(c1 == c2);
+}
+*/
 TEST(CampResource, StreamSelect)
 {
   cudaStream_t stream1, stream2;

--- a/test/resource.cpp
+++ b/test/resource.cpp
@@ -35,7 +35,7 @@ TEST(CampResource, ConvertFails)
 {
   Resource h1{Host()};
   h1.get<Host>();
-  ASSERT_THROW(h1.get<Host2>(), std::runtime_error);
+  //ASSERT_THROW(h1.get<Host2>(), std::runtime_error);
   ASSERT_FALSE(h1.try_get<Host2>());
 }
 TEST(CampResource, GetPlatform)

--- a/test/resource.cpp
+++ b/test/resource.cpp
@@ -83,16 +83,18 @@ TEST(CampResource, Compare)
     defined(CAMP_HAVE_OMP_OFFLOAD)
   ASSERT_TRUE(r1 == r1);
   ASSERT_TRUE(r2 == r2);
-
+  ASSERT_TRUE(s == s);
+  ASSERT_TRUE(h == h);
   ASSERT_TRUE(r1 != r2);
   ASSERT_TRUE(r2 != r1);
   ASSERT_TRUE(r1 != h1);
+  ASSERT_TRUE(r3 != h3);
 
   ASSERT_FALSE(r1 == r2);
   ASSERT_FALSE(r2 == r1);
   ASSERT_FALSE(r2 == r3);
   ASSERT_FALSE(h2 == r2);
-
+  ASSERT_FALSE(h3 == r3);
   ASSERT_FALSE(r1 != r1);
 #endif
 }

--- a/test/resource.cpp
+++ b/test/resource.cpp
@@ -71,7 +71,7 @@ TEST(CampResource, Reassignment)
   c2 = Host();
   ASSERT_EQ(typeid(c2), typeid(h2));
 }
-/*
+
 TEST(CampResource, Compare)
 {
   Resource h1{Host()};
@@ -80,9 +80,14 @@ TEST(CampResource, Compare)
   Resource c2{Cuda()};
 
   ASSERT_TRUE(h1 == h1);
+  ASSERT_TRUE(h1 == h2);
+  ASSERT_TRUE(c1 == c1);
+  ASSERT_TRUE(c2 == c2);
+
   ASSERT_FALSE(c1 == c2);
+  ASSERT_FALSE(c2 == c1);
 }
-*/
+
 TEST(CampResource, StreamSelect)
 {
   cudaStream_t stream1, stream2;

--- a/test/resource.cpp
+++ b/test/resource.cpp
@@ -75,7 +75,14 @@ TEST(CampResource, Compare)
 
   ASSERT_TRUE(h1 == h1);
   ASSERT_TRUE(h1 == h2);
-  ASSERT_TRUE(h3 == h);
+  auto assert_resources_equal = [](auto const& r1, auto const& r2) {
+    ASSERT_TRUE(r1 == r2);
+    ASSERT_TRUE(r2 == r1);
+    ASSERT_FALSE(r1 != r2);
+    ASSERT_FALSE(r2 != r1);
+  };
+  assert_resources_equal(h1, h2);
+  assert_resources_equal(h3, h);
   ASSERT_TRUE(h == h3);
 
   ASSERT_TRUE(r1 == r1);

--- a/test/resource.cpp
+++ b/test/resource.cpp
@@ -75,11 +75,7 @@ TEST(CampResource, Compare)
 
   ASSERT_TRUE(h1 == h1);
   ASSERT_TRUE(h1 == h2);
-  //ASSERT_TRUE(h3 == h);
-  //ASSERT_TRUE(h == h3);
-
-  //ASSERT_FALSE(h != h3);
-  //ASSERT_FALSE(h3 != h);
+  
   ASSERT_FALSE(h1 != h2);
 
 #if defined(CAMP_HAVE_CUDA) || \
@@ -87,8 +83,6 @@ TEST(CampResource, Compare)
     defined(CAMP_HAVE_OMP_OFFLOAD)
   ASSERT_TRUE(r1 == r1);
   ASSERT_TRUE(r2 == r2);
-  //ASSERT_TRUE(r3 == s);
-  //ASSERT_TRUE(s == r3);
 
   ASSERT_TRUE(r1 != r2);
   ASSERT_TRUE(r2 != r1);
@@ -99,8 +93,6 @@ TEST(CampResource, Compare)
   ASSERT_FALSE(r2 == r3);
   ASSERT_FALSE(h2 == r2);
 
-  //ASSERT_FALSE(s != r3);
-  //ASSERT_FALSE(r3 != s);
   ASSERT_FALSE(r1 != r1);
 #endif
 }

--- a/test/resource.cpp
+++ b/test/resource.cpp
@@ -51,6 +51,48 @@ TEST(CampResource, GetPlatform)
   ASSERT_EQ(static_cast<const Resource>(Omp()).get_platform(), Platform::omp_target);
 #endif
 }
+TEST(CampResource, Compare)
+{
+  Resource h1{Host()};
+  Resource h2{Host()};
+
+  ASSERT_TRUE(h1 == h1);
+  ASSERT_TRUE(h1 == h2);
+
+#ifdef CAMP_HAVE_CUDA
+  Resource c1{Cuda()};
+  Resource c2{Cuda()};
+
+  ASSERT_TRUE(c1 == c1);
+  ASSERT_TRUE(c2 == c2);
+
+  ASSERT_FALSE(c1 == c2);
+  ASSERT_FALSE(c2 == c1);
+  ASSERT_FALSE(c1 == h1);
+#endif
+#ifdef CAMP_HAVE_HIP
+  Resource hi1{Hip()};
+  Resource hi2{Hip()};
+
+  ASSERT_TRUE(hi1 == hi1);
+  ASSERT_TRUE(hi2 == hi2);
+
+  ASSERT_FALSE(hi1 == hi2);
+  ASSERT_FALSE(hi2 == hi1);
+  ASSERT_FALSE(hi1 == h1);
+#endif
+#ifdef CAMP_HAVE_OMP_OFFLOAD
+  Resource o1{Omp()};
+  Resource o2{Omp()};
+
+  ASSERT_TRUE(o1 == o1);
+  ASSERT_TRUE(o2 == o2);
+
+  ASSERT_FALSE(o1 == o2);
+  ASSERT_FALSE(o2 == o1);
+  ASSERT_FALSE(o2 == h2);
+#endif
+}
 TEST(CampResource, ConvertWorks)
 {
   Resource h1{Host()};
@@ -72,21 +114,6 @@ TEST(CampResource, Reassignment)
   ASSERT_EQ(typeid(c2), typeid(h2));
 }
 
-TEST(CampResource, Compare)
-{
-  Resource h1{Host()};
-  Resource c1{Cuda()};
-  Resource h2{Host()};
-  Resource c2{Cuda()};
-
-  ASSERT_TRUE(h1 == h1);
-  ASSERT_TRUE(h1 == h2);
-  ASSERT_TRUE(c1 == c1);
-  ASSERT_TRUE(c2 == c2);
-
-  ASSERT_FALSE(c1 == c2);
-  ASSERT_FALSE(c2 == c1);
-}
 
 TEST(CampResource, StreamSelect)
 {

--- a/test/resource.cpp
+++ b/test/resource.cpp
@@ -21,8 +21,8 @@
 using namespace camp::resources;
 
 // compatible but different resource for conversion test
-struct Host2 : Host {
-};
+//struct Host2 : Host {
+//};
 
 TEST(CampResource, Construct) { Resource h1{Host()}; }
 TEST(CampResource, Copy)
@@ -36,7 +36,7 @@ TEST(CampResource, ConvertFails)
   Resource h1{Host()};
   h1.get<Host>();
   //ASSERT_THROW(h1.get<Host2>(), std::runtime_error);
-  ASSERT_FALSE(h1.try_get<Host2>());
+  //ASSERT_FALSE(h1.try_get<Host2>());
 }
 TEST(CampResource, GetPlatform)
 {

--- a/test/resource.cpp
+++ b/test/resource.cpp
@@ -21,8 +21,8 @@
 using namespace camp::resources;
 
 // compatible but different resource for conversion test
-//struct Host2 : Host {
-//};
+struct Host2 : Host {
+};
 
 TEST(CampResource, Construct) { Resource h1{Host()}; }
 TEST(CampResource, Copy)
@@ -35,8 +35,8 @@ TEST(CampResource, ConvertFails)
 {
   Resource h1{Host()};
   h1.get<Host>();
-  //ASSERT_THROW(h1.get<Host2>(), std::runtime_error);
-  //ASSERT_FALSE(h1.try_get<Host2>());
+  ASSERT_THROW(h1.get<Host2>(), std::runtime_error);
+  ASSERT_FALSE(h1.try_get<Host2>());
 }
 TEST(CampResource, GetPlatform)
 {
@@ -75,11 +75,11 @@ TEST(CampResource, Compare)
 
   ASSERT_TRUE(h1 == h1);
   ASSERT_TRUE(h1 == h2);
-  ASSERT_TRUE(h3 == h);
-  ASSERT_TRUE(h == h3);
+  //ASSERT_TRUE(h3 == h);
+  //ASSERT_TRUE(h == h3);
 
-  ASSERT_FALSE(h != h3);
-  ASSERT_FALSE(h3 != h);
+  //ASSERT_FALSE(h != h3);
+  //ASSERT_FALSE(h3 != h);
   ASSERT_FALSE(h1 != h2);
 
 #if defined(CAMP_HAVE_CUDA) || \
@@ -87,8 +87,8 @@ TEST(CampResource, Compare)
     defined(CAMP_HAVE_OMP_OFFLOAD)
   ASSERT_TRUE(r1 == r1);
   ASSERT_TRUE(r2 == r2);
-  ASSERT_TRUE(r3 == s);
-  ASSERT_TRUE(s == r3);
+  //ASSERT_TRUE(r3 == s);
+  //ASSERT_TRUE(s == r3);
 
   ASSERT_TRUE(r1 != r2);
   ASSERT_TRUE(r2 != r1);
@@ -99,8 +99,8 @@ TEST(CampResource, Compare)
   ASSERT_FALSE(r2 == r3);
   ASSERT_FALSE(h2 == r2);
 
-  ASSERT_FALSE(s != r3);
-  ASSERT_FALSE(r3 != s);
+  //ASSERT_FALSE(s != r3);
+  //ASSERT_FALSE(r3 != s);
   ASSERT_FALSE(r1 != r1);
 #endif
 }

--- a/test/resource.cpp
+++ b/test/resource.cpp
@@ -59,16 +59,21 @@ TEST(CampResource, Compare)
   ASSERT_TRUE(h1 == h1);
   ASSERT_TRUE(h1 == h2);
 
+  ASSERT_FALSE(h1 != h2);
+
 #ifdef CAMP_HAVE_CUDA
   Resource c1{Cuda()};
   Resource c2{Cuda()};
 
   ASSERT_TRUE(c1 == c1);
   ASSERT_TRUE(c2 == c2);
+  ASSERT_TRUE(c1 != c2);
+  ASSERT_TRUE(c1 != h1);
 
   ASSERT_FALSE(c1 == c2);
   ASSERT_FALSE(c2 == c1);
   ASSERT_FALSE(c1 == h1);
+  ASSERT_FALSE(c1 != c1);
 #endif
 #ifdef CAMP_HAVE_HIP
   Resource hi1{Hip()};
@@ -76,10 +81,13 @@ TEST(CampResource, Compare)
 
   ASSERT_TRUE(hi1 == hi1);
   ASSERT_TRUE(hi2 == hi2);
+  ASSERT_TRUE(hi1 != hi2);
+  ASSERT_TRUE(hi1 != h1);
 
   ASSERT_FALSE(hi1 == hi2);
   ASSERT_FALSE(hi2 == hi1);
   ASSERT_FALSE(hi1 == h1);
+  ASSERT_FALSE(hi1 != hi1);
 #endif
 #ifdef CAMP_HAVE_OMP_OFFLOAD
   Resource o1{Omp()};
@@ -87,10 +95,13 @@ TEST(CampResource, Compare)
 
   ASSERT_TRUE(o1 == o1);
   ASSERT_TRUE(o2 == o2);
+  ASSERT_TRUE(o1 != o2);
+  ASSERT_TRUE(o1 != h1);
 
   ASSERT_FALSE(o1 == o2);
   ASSERT_FALSE(o2 == o1);
   ASSERT_FALSE(o2 == h2);
+  ASSERT_FALSE(o1 != o1);
 #endif
 }
 TEST(CampResource, ConvertWorks)

--- a/test/resource.cpp
+++ b/test/resource.cpp
@@ -76,9 +76,13 @@ TEST(CampResource, Compare)
   ASSERT_TRUE(h1 == h1);
   ASSERT_TRUE(h1 == h2);
   ASSERT_TRUE(h3 == h);
+  ASSERT_TRUE(h == h3);
+
   ASSERT_TRUE(r1 == r1);
   ASSERT_TRUE(r2 == r2);
   ASSERT_TRUE(r3 == s);
+  ASSERT_TRUE(s == r3);
+
   ASSERT_TRUE(r1 != r2);
   ASSERT_TRUE(r2 != r1);
   ASSERT_TRUE(r1 != h1);
@@ -87,6 +91,11 @@ TEST(CampResource, Compare)
   ASSERT_FALSE(r2 == r1);
   ASSERT_FALSE(r2 == r3);
   ASSERT_FALSE(r1 == h2);
+
+  ASSERT_FALSE(h != h3);
+  ASSERT_FALSE(h3 != h);
+  ASSERT_FALSE(s != r3);
+  ASSERT_FALSE(r3 != s);
   ASSERT_FALSE(h1 != h2);
   ASSERT_FALSE(r1 != r1);
 }

--- a/test/resource.cpp
+++ b/test/resource.cpp
@@ -78,6 +78,13 @@ TEST(CampResource, Compare)
   ASSERT_TRUE(h3 == h);
   ASSERT_TRUE(h == h3);
 
+  ASSERT_FALSE(h != h3);
+  ASSERT_FALSE(h3 != h);
+  ASSERT_FALSE(h1 != h2);
+
+#if defined(CAMP_HAVE_CUDA) || \
+    defined(CAMP_HAVE_HIP) || \
+    defined(CAMP_HAVE_OMP_OFFLOAD)
   ASSERT_TRUE(r1 == r1);
   ASSERT_TRUE(r2 == r2);
   ASSERT_TRUE(r3 == s);
@@ -92,12 +99,10 @@ TEST(CampResource, Compare)
   ASSERT_FALSE(r2 == r3);
   ASSERT_FALSE(r1 == h2);
 
-  ASSERT_FALSE(h != h3);
-  ASSERT_FALSE(h3 != h);
   ASSERT_FALSE(s != r3);
   ASSERT_FALSE(r3 != s);
-  ASSERT_FALSE(h1 != h2);
   ASSERT_FALSE(r1 != r1);
+#endif
 }
 TEST(CampResource, ConvertWorks)
 {

--- a/test/resource.cpp
+++ b/test/resource.cpp
@@ -57,60 +57,38 @@ TEST(CampResource, Compare)
   Resource h2{Host()};
   Host h; Resource h3{h};
 
+#ifdef CAMP_HAVE_CUDA
+  Resource r1{Cuda()};
+  Resource r2{Cuda()};
+  Cuda s; Resource r3{s};
+#endif
+#ifdef CAMP_HAVE_HIP
+  Resource r1{Hip()};
+  Resource r2{Hip()};
+  Hip s; Resource r3{s};
+#endif
+#ifdef CAMP_HAVE_OMP_OFFLOAD
+  Resource r1{Omp()};
+  Resource r2{Omp()};
+  Omp s; Resource r3{s};
+#endif
+
   ASSERT_TRUE(h1 == h1);
   ASSERT_TRUE(h1 == h2);
   ASSERT_TRUE(h3 == h);
+  ASSERT_TRUE(r1 == r1);
+  ASSERT_TRUE(r2 == r2);
+  ASSERT_TRUE(r3 == s);
+  ASSERT_TRUE(r1 != r2);
+  ASSERT_TRUE(r2 != r1);
+  ASSERT_TRUE(r1 != h1);
 
+  ASSERT_FALSE(r1 == r2);
+  ASSERT_FALSE(r2 == r1);
+  ASSERT_FALSE(r2 == r3);
+  ASSERT_FALSE(r1 == h2);
   ASSERT_FALSE(h1 != h2);
-
-#ifdef CAMP_HAVE_CUDA
-  Resource c1{Cuda()};
-  Resource c2{Cuda()};
-  Cuda c; Resource c3{c};
-
-  ASSERT_TRUE(c1 == c1);
-  ASSERT_TRUE(c2 == c2);
-  ASSERT_TRUE(c3 == c);
-  ASSERT_TRUE(c1 != c2);
-  ASSERT_TRUE(c1 != h1);
-
-  ASSERT_FALSE(c1 == c2);
-  ASSERT_FALSE(c2 == c1);
-  ASSERT_FALSE(c1 == h1);
-  ASSERT_FALSE(c1 != c1);
-#endif
-#ifdef CAMP_HAVE_HIP
-  Resource hip1{Hip()};
-  Resource hip2{Hip()};
-  Hip hip; Resource hip3{hip};
-
-  ASSERT_TRUE(hip1 == hip1);
-  ASSERT_TRUE(hip2 == hip2);
-  ASSERT_TRUE(hip3 == hip);
-  ASSERT_TRUE(hip1 != hip2);
-  ASSERT_TRUE(hip1 != h1);
-
-  ASSERT_FALSE(hip1 == hip2);
-  ASSERT_FALSE(hip2 == hip1);
-  ASSERT_FALSE(hip1 == h2);
-  ASSERT_FALSE(hip1 != hip1);
-#endif
-#ifdef CAMP_HAVE_OMP_OFFLOAD
-  Resource o1{Omp()};
-  Resource o2{Omp()};
-  Omp o; Resource o3{o};
-
-  ASSERT_TRUE(o1 == o1);
-  ASSERT_TRUE(o2 == o2);
-  ASSERT_TRUE(o3 == o);
-  ASSERT_TRUE(o1 != o2);
-  ASSERT_TRUE(o1 != h1);
-
-  ASSERT_FALSE(o1 == o2);
-  ASSERT_FALSE(o2 == o1);
-  ASSERT_FALSE(o2 == h2);
-  ASSERT_FALSE(o1 != o1);
-#endif
+  ASSERT_FALSE(r1 != r1);
 }
 TEST(CampResource, ConvertWorks)
 {

--- a/test/resource.cpp
+++ b/test/resource.cpp
@@ -55,18 +55,22 @@ TEST(CampResource, Compare)
 {
   Resource h1{Host()};
   Resource h2{Host()};
+  Host h; Resource h3{h};
 
   ASSERT_TRUE(h1 == h1);
   ASSERT_TRUE(h1 == h2);
+  ASSERT_TRUE(h3 == h);
 
   ASSERT_FALSE(h1 != h2);
 
 #ifdef CAMP_HAVE_CUDA
   Resource c1{Cuda()};
   Resource c2{Cuda()};
+  Cuda c; Resource c3{c};
 
   ASSERT_TRUE(c1 == c1);
   ASSERT_TRUE(c2 == c2);
+  ASSERT_TRUE(c3 == c);
   ASSERT_TRUE(c1 != c2);
   ASSERT_TRUE(c1 != h1);
 
@@ -76,25 +80,29 @@ TEST(CampResource, Compare)
   ASSERT_FALSE(c1 != c1);
 #endif
 #ifdef CAMP_HAVE_HIP
-  Resource hi1{Hip()};
-  Resource hi2{Hip()};
+  Resource hip1{Hip()};
+  Resource hip2{Hip()};
+  Hip hip; Resource hip3{hip};
 
-  ASSERT_TRUE(hi1 == hi1);
-  ASSERT_TRUE(hi2 == hi2);
-  ASSERT_TRUE(hi1 != hi2);
-  ASSERT_TRUE(hi1 != h1);
+  ASSERT_TRUE(hip1 == hip1);
+  ASSERT_TRUE(hip2 == hip2);
+  ASSERT_TRUE(hip3 == hip);
+  ASSERT_TRUE(hip1 != hip2);
+  ASSERT_TRUE(hip1 != h1);
 
-  ASSERT_FALSE(hi1 == hi2);
-  ASSERT_FALSE(hi2 == hi1);
-  ASSERT_FALSE(hi1 == h1);
-  ASSERT_FALSE(hi1 != hi1);
+  ASSERT_FALSE(hip1 == hip2);
+  ASSERT_FALSE(hip2 == hip1);
+  ASSERT_FALSE(hip1 == h2);
+  ASSERT_FALSE(hip1 != hip1);
 #endif
 #ifdef CAMP_HAVE_OMP_OFFLOAD
   Resource o1{Omp()};
   Resource o2{Omp()};
+  Omp o; Resource o3{o};
 
   ASSERT_TRUE(o1 == o1);
   ASSERT_TRUE(o2 == o2);
+  ASSERT_TRUE(o3 == o);
   ASSERT_TRUE(o1 != o2);
   ASSERT_TRUE(o1 != h1);
 


### PR DESCRIPTION
This compare function will compare 2 different resources. 

I need this because Umpire would like to add a resource aware pool, but in order to do that we need to know if the resources that are being passed into the pool per allocate call are the same or different. (We handle each case differently.) 

- [x] Double check that my Omp compare is sufficient (see TODO statement)
- [x] Add Doxygen comments to compare functions
- [x] Test this with my resource aware pool prototype - this will act as another check to see if the compare function behave as expected.