### PR TITLE
Make host operator== a member function

### DIFF
--- a/include/camp/resource/host.hpp
+++ b/include/camp/resource/host.hpp
@@ -68,29 +68,28 @@ namespace resources
       void deallocate(void *p, MemoryAccess = MemoryAccess::Device) { std::free(p); }
       void memcpy(void *dst, const void *src, size_t size) { std::memcpy(dst, src, size); }
       void memset(void *p, int val, size_t size) { std::memset(p, val, size); }
-    };
 
       /*
        * \brief Compares two (Host) resources to see if they are equal.
-       * (This was made in to a free function to appease MSVC and SYCL compilers)
        *
        * \return Always return true since we are on the Host in this case.
        */
-      bool operator==(Host const&, Host const&)
+      bool operator==(Host const&) const
       {
         return true;
       }
       
       /*
        * \brief Compares two (Host) resources to see if they are NOT equal.
-       * (This was made in to a free function to appease MSVC and SYCL compilers)
        *
        * \return Always return false. Host resources are always the same.
        */
-      bool operator!=(Host const&, Host const&)
+      bool operator!=(Host const&) const
       {
         return false;
       }
+    };
+
   }  // namespace v1
 }  // namespace resources
 }  // namespace camp


### PR DESCRIPTION
As I pulled in the operator== changes into Umpire, there were a bunch of linker errors about multiple definitions of the Host resource's operator== function. There were changes done to the Host resource that then needed to be undone and this change was overlooked.

This fixes that problem (and I have tested that this now works when pulling in to Umpire, no more linker errors).

Sorry I didn't catch this before!