### PR TITLE
Allow std tuple_size and tuple_element before C++17

### DIFF
--- a/include/camp/array.hpp
+++ b/include/camp/array.hpp
@@ -274,7 +274,6 @@ namespace camp {
 #endif
 } // namespace camp
 
-#if defined(__cplusplus) && __cplusplus >= 201703L
 // For structured bindings
 namespace std {
    template <class T, std::size_t N>
@@ -288,7 +287,6 @@ namespace std {
       using type = T;
    };
 }
-#endif
 
 #endif // !defined(CAMP_ARRAY_H)
 

--- a/include/camp/tuple.hpp
+++ b/include/camp/tuple.hpp
@@ -691,7 +691,6 @@ auto operator<<(std::ostream& os, camp::tuple<Args...> const& tup)
   return os << ")";
 }
 
-#if defined(__cplusplus) && __cplusplus >= 201703L
 namespace std {
   /// This allows structured bindings to be used with camp::tuple
   /// e.g. auto t = make_tuple(1, 2.0);
@@ -721,6 +720,5 @@ namespace std {
     using type = ::camp::tuple_element_t<i, camp::tagged_tuple<TagList, Elements...>>;
   };
 } // namespace std
-#endif
 
 #endif /* camp_tuple_HPP__ */

--- a/test/array.cpp
+++ b/test/array.cpp
@@ -359,7 +359,6 @@ CAMP_TEST_BEGIN(array, to_array)
           b[2] == 10;
 } CAMP_TEST_END(array, to_array)
 
-#if defined(__cplusplus) && __cplusplus >= 201703L
 
 CAMP_TEST_BEGIN(array, tuple_size)
 {
@@ -378,6 +377,8 @@ CAMP_TEST_BEGIN(array, tuple_element)
    return element0 &&
           element4;
 } CAMP_TEST_END(array, tuple_element)
+
+#if defined(__cplusplus) && __cplusplus >= 201703L
 
 CAMP_TEST_BEGIN(array, structured_binding)
 {


### PR DESCRIPTION
There's no reason to not supply them before 17.
They can still be used in code for generic tuple-like classes.