### PR TITLE
Fix array test with c++14

### DIFF
--- a/test/array.cpp
+++ b/test/array.cpp
@@ -362,17 +362,17 @@ CAMP_TEST_BEGIN(array, to_array)
 
 CAMP_TEST_BEGIN(array, tuple_size)
 {
-   constexpr std::size_t size = std::tuple_size<camp::array<double, 7>>::value;
-   constexpr std::size_t size_v = std::tuple_size_v<camp::array<double, 11>>;
+   constexpr std::size_t size7 = std::tuple_size<camp::array<double, 7>>::value;
+   constexpr std::size_t size11 = std::tuple_size<camp::array<double, 11>>::value;
 
-   return size == 7 &&
-          size_v == 11;
+   return size7 == 7 &&
+          size11 == 11;
 } CAMP_TEST_END(array, tuple_size)
 
 CAMP_TEST_BEGIN(array, tuple_element)
 {
-   constexpr bool element0 = std::is_same_v<double, std::tuple_element_t<0, camp::array<double, 5>>>;
-   constexpr bool element4 = std::is_same_v<double, std::tuple_element_t<4, camp::array<double, 5>>>;
+   constexpr bool element0 = std::is_same<double, std::tuple_element_t<0, camp::array<double, 5>>>::value;
+   constexpr bool element4 = std::is_same<double, std::tuple_element_t<4, camp::array<double, 5>>>::value;
 
    return element0 &&
           element4;


### PR DESCRIPTION
The tests that I allowed to run with c++14 had some things that required c++17. Not sure why I was able to merge if the tests didn't compile.