### PR TITLE
remove use of CL namespace to remove compiler warnings

### DIFF
--- a/include/camp/resource/sycl.hpp
+++ b/include/camp/resource/sycl.hpp
@@ -19,13 +19,11 @@ http://github.com/llnl/camp
 #include "camp/resource/event.hpp"
 #include "camp/resource/platform.hpp"
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 
 #include <map>
 #include <array>
 #include <mutex>
-
-using namespace cl;
 
 namespace camp
 {


### PR DESCRIPTION
Newer Intel compilers have deprecated the use of the `CL` namespace. This change squashes a bunch of compiler warnings in RAJA and other user libraries.

@kab163 and @long58 let's merge this after the doc PR is merged (hopefully that will be soon), then merge the CMake version PR after that. Then, I think it makes sense to do a camp patch release and pull that into RAJA, Umpire, etc. so we are coordinated.