### PR TITLE
Copyright update

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,3 +1,10 @@
+##############################################################################
+# Copyright (c) 2018-25, Lawrence Livermore National Security, LLC
+# and Camp project contributors. See the camp/LICENSE file for details.
+#
+# SPDX-License-Identifier: (BSD-3-Clause)
+###############################################################################
+
 cmake_minimum_required (VERSION 3.10)
 
 project (camp

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ###############################################################################
-# Copyright (c) 2016-21, Lawrence Livermore National Security, LLC
-# and RAJA project contributors. See the RAJA/COPYRIGHT file for details.
+# Copyright (c) 2018-25, Lawrence Livermore National Security, LLC
+# and Camp project contributors. See the camp/LICENSE file for details.
 #
 # SPDX-License-Identifier: (BSD-3-Clause)
 ###############################################################################

--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,9 @@
-Copyright (c) 2018, Lawrence Livermore National Security, LLC. Produced at the Lawrence Livermore National Laboratory
-Written by Tom Scogland <scogland1@llnl.gov>
-CODE-756261
-All rights reserved.
+Copyright (c) 2018-2025, Lawrence Livermore National Security, LLC.
+Produced at the Lawrence Livermore National Laboratory.
+All rights reserved. See details in the camp/LICENSE file.
+
+Unlimited Open Source - BSD Distribution
+LLNL-CODE-756261
 
 This file is part of camp.  For details, see http://github.com/llnl/camp.
 Please also read the NOTICE at the root of the camp repository.

--- a/LLVM_LICENSE
+++ b/LLVM_LICENSE
@@ -1,5 +1,5 @@
-Some derivative works from the LLVM Project may be found in camp.
-The full text of that license is included below.
+Some derivative works from the LLVM Project exist in camp. The following
+licence is referenced in afftected files.
 
 ==============================================================================
 The LLVM Project is under the Apache License v2.0 with LLVM Exceptions:

--- a/LLVM_LICENSE
+++ b/LLVM_LICENSE
@@ -1,5 +1,5 @@
 Some derivative works from the LLVM Project exist in camp. The following
-licence is referenced in afftected files.
+license is referenced in affected files.
 
 ==============================================================================
 The LLVM Project is under the Apache License v2.0 with LLVM Exceptions:

--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
+[comment]: # (#################################################################)
+[comment]: # (Copyright 2018-25, Lawrence Livermore National Security, LLC)
+[comment]: # (and Camp project contributors. See the camp/LICENSE file)
+[comment]: # (for details.)
+[comment]: # 
+[comment]: # (# SPDX-License-Identifier: BSD-3-Clause)
+[comment]: # (#################################################################)
+
 # <img src="/share/camp/logo/camp2-gradient.png" width="128" valign="middle" alt="Camp"/>
 
 ## CAMP Concepts And Meta-Programming library

--- a/cmake/FindSphinx.cmake
+++ b/cmake/FindSphinx.cmake
@@ -1,6 +1,6 @@
 ###############################################################################
-# Copyright (c) 2016-24, Lawrence Livermore National Security, LLC
-# and other RAJA project contributors. See the RAJA/LICENSE file for details.
+# Copyright (c) 2018-25, Lawrence Livermore National Security, LLC
+# and Camp project contributors. See the camp/LICENSE file for details.
 #
 # SPDX-License-Identifier: (BSD-3-Clause)
 ###############################################################################

--- a/cmake/campConfig.cmake.in
+++ b/cmake/campConfig.cmake.in
@@ -1,3 +1,10 @@
+###############################################################################
+# Copyright (c) 2018-25, Lawrence Livermore National Security, LLC
+# and Camp project contributors. See the camp/LICENSE file for details.
+#
+# SPDX-License-Identifier: (BSD-3-Clause)
+###############################################################################
+
 @PACKAGE_INIT@
 
 set(camp_INSTALL_PREFIX "@CMAKE_INSTALL_PREFIX@" CACHE FILEPATH "camp install prefix path")

--- a/cmake/load_blt.cmake
+++ b/cmake/load_blt.cmake
@@ -1,3 +1,10 @@
+###############################################################################
+# Copyright (c) 2018-25, Lawrence Livermore National Security, LLC
+# and Camp project contributors. See the camp/LICENSE file for details.
+#
+# SPDX-License-Identifier: (BSD-3-Clause)
+###############################################################################
+
 if (NOT BLT_LOADED)
   if (DEFINED BLT_SOURCE_DIR)
     if (NOT EXISTS ${BLT_SOURCE_DIR}/SetupBLT.cmake)

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -1,11 +1,8 @@
 ###############################################################################
-# Copyright (c) 2016-18, Lawrence Livermore National Security, LLC.
-# Produced at the Lawrence Livermore National Laboratory
-# Maintained by Tom Scogland <scogland1@llnl.gov>
-# CODE-756261, All rights reserved.
-# This file is part of Camp.
-# For details about use and distribution, please read LICENSE and NOTICE from
-# http://github.com/llnl/camp
+# Copyright (c) 2018-25, Lawrence Livermore National Security, LLC
+# and Camp project contributors. See the camp/LICENSE file for details.
+#
+# SPDX-License-Identifier: (BSD-3-Clause)
 ###############################################################################
 
 if (CAMP_ENABLE_DOCUMENTATION)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -79,7 +79,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'Camp'
-copyright = u'2016-2024, Lawrence Livermore National Security, LLNS'
+copyright = u'2018-2025, Lawrence Livermore National Security, LLNS'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,6 +1,6 @@
 .. ##
-.. ## Copyright (c) 2016-24, Lawrence Livermore National Security, LLC
-.. ## and RAJA project contributors. See the Camp/LICENSE file
+.. ## Copyright (c) 2018-25, Lawrence Livermore National Security, LLC
+.. ## and Camp project contributors. See the camp/LICENSE file
 .. ## for details.
 .. ##
 .. ## SPDX-License-Identifier: (BSD-3-Clause)

--- a/docs/sphinx/camp_license.rst
+++ b/docs/sphinx/camp_license.rst
@@ -1,6 +1,6 @@
 .. ##
-.. ## Copyright (c) 2016-24, Lawrence Livermore National Security, LLC
-.. ## and Camp project contributors. See the Camp/LICENSE file
+.. ## Copyright (c) 2018-25, Lawrence Livermore National Security, LLC
+.. ## and Camp project contributors. See the camp/LICENSE file
 .. ## for details.
 .. ##
 .. ## SPDX-License-Identifier: (BSD-3-Clause)
@@ -12,7 +12,7 @@
 Camp Copyright and License Information
 ======================================
 
-Copyright (c) 2018-24, Lawrence Livermore National Security, LLC.
+Copyright (c) 2018-25, Lawrence Livermore National Security, LLC.
 
 Produced at the Lawrence Livermore National Laboratory.
 

--- a/docs/sphinx/dev_guide/index.rst
+++ b/docs/sphinx/dev_guide/index.rst
@@ -1,5 +1,5 @@
-.. # Copyright (c) 2017-2024, Lawrence Livermore National Security, LLC and
-.. # other Camp Project Developers. See the top-level LICENSE file for details
+.. # Copyright (c) 2018-2025, Lawrence Livermore National Security, LLC and
+.. # other Camp project contributors. See the camp/LICENSE file for details.
 .. # 
 .. # SPDX-License-Identifier: (BSD-3-Clause)
 

--- a/docs/sphinx/user_guide/feature/array.rst
+++ b/docs/sphinx/user_guide/feature/array.rst
@@ -1,3 +1,7 @@
+.. # Copyright (c) 2018-2025, Lawrence Livermore National Security, LLC and
+.. # other Camp project contributors. See the camp/LICENSE file for details.
+.. #
+.. # SPDX-License-Identifier: (BSD-3-Clause)
 
 .. _array-label:
 

--- a/docs/sphinx/user_guide/feature/list.rst
+++ b/docs/sphinx/user_guide/feature/list.rst
@@ -1,3 +1,7 @@
+.. # Copyright (c) 2018-2025, Lawrence Livermore National Security, LLC and
+.. # other Camp project contributors. See the camp/LICENSE file for details.
+.. #
+.. # SPDX-License-Identifier: (BSD-3-Clause)
 
 .. _list-label:
 

--- a/docs/sphinx/user_guide/feature/number.rst
+++ b/docs/sphinx/user_guide/feature/number.rst
@@ -1,3 +1,7 @@
+.. # Copyright (c) 2018-2025, Lawrence Livermore National Security, LLC and
+.. # other Camp project contributors. See the camp/LICENSE file for details.
+.. #
+.. # SPDX-License-Identifier: (BSD-3-Clause)
 
 .. _number-label:
 

--- a/docs/sphinx/user_guide/feature/resource.rst
+++ b/docs/sphinx/user_guide/feature/resource.rst
@@ -1,3 +1,8 @@
+.. # Copyright (c) 2018-2025, Lawrence Livermore National Security, LLC and
+.. # other Camp project contributors. See the camp/LICENSE file for details.
+.. #
+.. # SPDX-License-Identifier: (BSD-3-Clause)
+
 .. _resources-label:
 
 =========

--- a/docs/sphinx/user_guide/feature/tuple.rst
+++ b/docs/sphinx/user_guide/feature/tuple.rst
@@ -1,3 +1,7 @@
+.. # Copyright (c) 2018-2025, Lawrence Livermore National Security, LLC and
+.. # other Camp project contributors. See the camp/LICENSE file for details.
+.. #
+.. # SPDX-License-Identifier: (BSD-3-Clause)
 
 .. _tuple-label:
 

--- a/docs/sphinx/user_guide/features.rst
+++ b/docs/sphinx/user_guide/features.rst
@@ -1,10 +1,7 @@
-.. ##
-.. ## Copyright (c) 2016-24, Lawrence Livermore National Security, LLC
-.. ## and RAJA project contributors. See the Camp/LICENSE file
-.. ## for details.
-.. ##
-.. ## SPDX-License-Identifier: (BSD-3-Clause)
-.. ##
+.. # Copyright (c) 2018-2025, Lawrence Livermore National Security, LLC and
+.. # other Camp project contributors. See the camp/LICENSE file for details.
+.. #
+.. # SPDX-License-Identifier: (BSD-3-Clause)
 
 .. _features-label:
 

--- a/docs/sphinx/user_guide/getting_started.rst
+++ b/docs/sphinx/user_guide/getting_started.rst
@@ -1,3 +1,8 @@
+.. # Copyright (c) 2018-2025, Lawrence Livermore National Security, LLC and
+.. # other Camp project contributors. See the camp/LICENSE file for details.
+.. #
+.. # SPDX-License-Identifier: (BSD-3-Clause)
+
 .. _getting_started-label:
 
 *************************

--- a/docs/sphinx/user_guide/index.rst
+++ b/docs/sphinx/user_guide/index.rst
@@ -1,10 +1,7 @@
-.. ##
-.. ## Copyright (c) 2016-24, Lawrence Livermore National Security, LLC
-.. ## and RAJA project contributors. See the Camp/LICENSE file
-.. ## for details.
-.. ##
-.. ## SPDX-License-Identifier: (BSD-3-Clause)
-.. ##
+.. # Copyright (c) 2018-2025, Lawrence Livermore National Security, LLC and
+.. # other Camp project contributors. See the camp/LICENSE file for details.
+.. #
+.. # SPDX-License-Identifier: (BSD-3-Clause)
 
 ################
 Camp User Guide

--- a/docs/sphinx/user_guide/using_camp.rst
+++ b/docs/sphinx/user_guide/using_camp.rst
@@ -1,3 +1,8 @@
+.. # Copyright (c) 2018-2025, Lawrence Livermore National Security, LLC and
+.. # other Camp project contributors. See the camp/LICENSE file for details.
+.. #
+.. # SPDX-License-Identifier: (BSD-3-Clause)
+
 .. _using_camp-label: 
 
 **********

--- a/include/camp/array.hpp
+++ b/include/camp/array.hpp
@@ -1,30 +1,19 @@
-/*
-Copyright (c) 2024, Lawrence Livermore National Security, LLC.
-Produced at the Lawrence Livermore National Laboratory
-Maintained by Tom Scogland <scogland1@llnl.gov>
-CODE-756261, All rights reserved.
-This file is part of camp.
-For details about use and distribution, please read LICENSE and NOTICE from
-http://github.com/llnl/camp
-*/
-
-/*
-The implementation of camp::array follows the C++ standard but borrows from the
-implementation of std::array from the LLVM project at the following location:
-https://github.com/llvm/llvm-project/blob/main/libcxx/include/array
-The license information from that file is included below.
-
-//===----------------------------------------------------------------------===//
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2018-25, Lawrence Livermore National Security, LLC
+// and Camp project contributors. See the camp/LICENSE file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// The implementation of camp::array follows the C++ standard but borrows 
+// from the implementation of std::array in the LLVM project at:
+// https://github.com/llvm/llvm-project/blob/main/libcxx/include/array
+//
+// The license information from that file is included below.
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-//
-//===----------------------------------------------------------------------===//
-
-See the LLVM_LICENSE file at http://github.com/llnl/camp for the full license
-text.
-*/
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 
 #ifndef camp_array_HPP__
 #define camp_array_HPP__

--- a/include/camp/camp.hpp
+++ b/include/camp/camp.hpp
@@ -1,12 +1,9 @@
-/*
-Copyright (c) 2016-18, Lawrence Livermore National Security, LLC.
-Produced at the Lawrence Livermore National Laboratory
-Maintained by Tom Scogland <scogland1@llnl.gov>
-CODE-756261, All rights reserved.
-This file is part of camp.
-For details about use and distribution, please read LICENSE and NOTICE from
-http://github.com/llnl/camp
-*/
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2018-25, Lawrence Livermore National Security, LLC
+// and Camp project contributors. See the camp/LICENSE file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 
 #ifndef __CAMP_HPP
 #define __CAMP_HPP

--- a/include/camp/concepts.hpp
+++ b/include/camp/concepts.hpp
@@ -1,12 +1,9 @@
-/*
-Copyright (c) 2016-18, Lawrence Livermore National Security, LLC.
-Produced at the Lawrence Livermore National Laboratory
-Maintained by Tom Scogland <scogland1@llnl.gov>
-CODE-756261, All rights reserved.
-This file is part of camp.
-For details about use and distribution, please read LICENSE and NOTICE from
-http://github.com/llnl/camp
-*/
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2018-25, Lawrence Livermore National Security, LLC
+// and Camp project contributors. See the camp/LICENSE file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 
 #ifndef CAMP_CONCEPTS_HPP
 #define CAMP_CONCEPTS_HPP

--- a/include/camp/config.in.hpp
+++ b/include/camp/config.in.hpp
@@ -1,3 +1,10 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2018-25, Lawrence Livermore National Security, LLC
+// and Camp project contributors. See the camp/LICENSE file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
 // Define CAMP_CONFIG_OVERRIDE to change this on a per-file basis
 #if !defined(CAMP_CONFIG_OVERRIDE)
 #cmakedefine CAMP_ENABLE_OPENMP

--- a/include/camp/defines.hpp
+++ b/include/camp/defines.hpp
@@ -1,12 +1,9 @@
-/*
-Copyright (c) 2016-18, Lawrence Livermore National Security, LLC.
-Produced at the Lawrence Livermore National Laboratory
-Maintained by Tom Scogland <scogland1@llnl.gov>
-CODE-756261, All rights reserved.
-This file is part of camp.
-For details about use and distribution, please read LICENSE and NOTICE from
-http://github.com/llnl/camp
-*/
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2018-25, Lawrence Livermore National Security, LLC
+// and Camp project contributors. See the camp/LICENSE file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 
 #ifndef CAMP_DEFINES_HPP
 #define CAMP_DEFINES_HPP

--- a/include/camp/detail/sfinae.hpp
+++ b/include/camp/detail/sfinae.hpp
@@ -1,12 +1,9 @@
-/*
-Copyright (c) 2016-18, Lawrence Livermore National Security, LLC.
-Produced at the Lawrence Livermore National Laboratory
-Maintained by Tom Scogland <scogland1@llnl.gov>
-CODE-756261, All rights reserved.
-This file is part of camp.
-For details about use and distribution, please read LICENSE and NOTICE from
-http://github.com/llnl/camp
-*/
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2018-25, Lawrence Livermore National Security, LLC
+// and Camp project contributors. See the camp/LICENSE file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 
 #ifndef CAMP_DETAIL_SFINAE_HPP
 #define CAMP_DETAIL_SFINAE_HPP

--- a/include/camp/detail/test.hpp
+++ b/include/camp/detail/test.hpp
@@ -1,12 +1,9 @@
-/*
-Copyright (c) 2016-18, Lawrence Livermore National Security, LLC.
-Produced at the Lawrence Livermore National Laboratory
-Maintained by Tom Scogland <scogland1@llnl.gov>
-CODE-756261, All rights reserved.
-This file is part of camp.
-For details about use and distribution, please read LICENSE and NOTICE from
-http://github.com/llnl/camp
-*/
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2018-25, Lawrence Livermore National Security, LLC
+// and Camp project contributors. See the camp/LICENSE file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 
 #ifndef __CAMP_DETAIL_TEST_HPP
 #define __CAMP_DETAIL_TEST_HPP

--- a/include/camp/helpers.hpp
+++ b/include/camp/helpers.hpp
@@ -1,12 +1,9 @@
-/*
-Copyright (c) 2016-18, Lawrence Livermore National Security, LLC.
-Produced at the Lawrence Livermore National Laboratory
-Maintained by Tom Scogland <scogland1@llnl.gov>
-CODE-756261, All rights reserved.
-This file is part of camp.
-For details about use and distribution, please read LICENSE and NOTICE from
-http://github.com/llnl/camp
-*/
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2018-25, Lawrence Livermore National Security, LLC
+// and Camp project contributors. See the camp/LICENSE file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 
 #ifndef CAMP_HELPERS_HPP
 #define CAMP_HELPERS_HPP

--- a/include/camp/lambda.hpp
+++ b/include/camp/lambda.hpp
@@ -1,12 +1,9 @@
-/*
-Copyright (c) 2016-18, Lawrence Livermore National Security, LLC.
-Produced at the Lawrence Livermore National Laboratory
-Maintained by Tom Scogland <scogland1@llnl.gov>
-CODE-756261, All rights reserved.
-This file is part of camp.
-For details about use and distribution, please read LICENSE and NOTICE from
-http://github.com/llnl/camp
-*/
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2018-25, Lawrence Livermore National Security, LLC
+// and Camp project contributors. See the camp/LICENSE file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 
 #ifndef CAMP_LAMBDA_HPP
 #define CAMP_LAMBDA_HPP

--- a/include/camp/list.hpp
+++ b/include/camp/list.hpp
@@ -1,12 +1,9 @@
-/*
-Copyright (c) 2016-18, Lawrence Livermore National Security, LLC.
-Produced at the Lawrence Livermore National Laboratory
-Maintained by Tom Scogland <scogland1@llnl.gov>
-CODE-756261, All rights reserved.
-This file is part of camp.
-For details about use and distribution, please read LICENSE and NOTICE from
-http://github.com/llnl/camp
-*/
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2018-25, Lawrence Livermore National Security, LLC
+// and Camp project contributors. See the camp/LICENSE file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 
 #ifndef __CAMP_list_hpp
 #define __CAMP_list_hpp

--- a/include/camp/list/at.hpp
+++ b/include/camp/list/at.hpp
@@ -1,12 +1,9 @@
-/*
-Copyright (c) 2016-18, Lawrence Livermore National Security, LLC.
-Produced at the Lawrence Livermore National Laboratory
-Maintained by Tom Scogland <scogland1@llnl.gov>
-CODE-756261, All rights reserved.
-This file is part of camp.
-For details about use and distribution, please read LICENSE and NOTICE from
-http://github.com/llnl/camp
-*/
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2018-25, Lawrence Livermore National Security, LLC
+// and Camp project contributors. See the camp/LICENSE file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 
 #ifndef __CAMP_list_at_hpp
 #define __CAMP_list_at_hpp

--- a/include/camp/list/find_if.hpp
+++ b/include/camp/list/find_if.hpp
@@ -1,12 +1,9 @@
-/*
-Copyright (c) 2016-18, Lawrence Livermore National Security, LLC.
-Produced at the Lawrence Livermore National Laboratory
-Maintained by Tom Scogland <scogland1@llnl.gov>
-CODE-756261, All rights reserved.
-This file is part of camp.
-For details about use and distribution, please read LICENSE and NOTICE from
-http://github.com/llnl/camp
-*/
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2018-25, Lawrence Livermore National Security, LLC
+// and Camp project contributors. See the camp/LICENSE file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 
 #ifndef CAMP_LIST_FIND_IF_HPP
 #define CAMP_LIST_FIND_IF_HPP

--- a/include/camp/list/list.hpp
+++ b/include/camp/list/list.hpp
@@ -1,12 +1,9 @@
-/*
-Copyright (c) 2016-18, Lawrence Livermore National Security, LLC.
-Produced at the Lawrence Livermore National Laboratory
-Maintained by Tom Scogland <scogland1@llnl.gov>
-CODE-756261, All rights reserved.
-This file is part of camp.
-For details about use and distribution, please read LICENSE and NOTICE from
-http://github.com/llnl/camp
-*/
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2018-25, Lawrence Livermore National Security, LLC
+// and Camp project contributors. See the camp/LICENSE file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 
 #ifndef CAMP_LIST_LIST_HPP
 #define CAMP_LIST_LIST_HPP

--- a/include/camp/make_unique.hpp
+++ b/include/camp/make_unique.hpp
@@ -1,12 +1,10 @@
-/*
-Copyright (c) 2016-18, Lawrence Livermore National Security, LLC.
-Produced at the Lawrence Livermore National Laboratory
-Maintained by Tom Scogland <scogland1@llnl.gov>
-CODE-756261, All rights reserved.
-This file is part of camp.
-For details about use and distribution, please read LICENSE and NOTICE from
-http://github.com/llnl/camp
-*/
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2018-25, Lawrence Livermore National Security, LLC
+// and Camp project contributors. See the camp/LICENSE file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
 #ifndef __CAMP_make_unique_hpp
 #define __CAMP_make_unique_hpp
 

--- a/include/camp/map.hpp
+++ b/include/camp/map.hpp
@@ -1,12 +1,9 @@
-/*
-Copyright (c) 2016-18, Lawrence Livermore National Security, LLC.
-Produced at the Lawrence Livermore National Laboratory
-Maintained by Tom Scogland <scogland1@llnl.gov>
-CODE-756261, All rights reserved.
-This file is part of camp.
-For details about use and distribution, please read LICENSE and NOTICE from
-http://github.com/llnl/camp
-*/
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2018-25, Lawrence Livermore National Security, LLC
+// and Camp project contributors. See the camp/LICENSE file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 
 #ifndef CAMP_LIST_MAP_HPP
 #define CAMP_LIST_MAP_HPP

--- a/include/camp/number.hpp
+++ b/include/camp/number.hpp
@@ -1,12 +1,9 @@
-/*
-Copyright (c) 2016-18, Lawrence Livermore National Security, LLC.
-Produced at the Lawrence Livermore National Laboratory
-Maintained by Tom Scogland <scogland1@llnl.gov>
-CODE-756261, All rights reserved.
-This file is part of camp.
-For details about use and distribution, please read LICENSE and NOTICE from
-http://github.com/llnl/camp
-*/
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2018-25, Lawrence Livermore National Security, LLC
+// and Camp project contributors. See the camp/LICENSE file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 
 #ifndef CAMP_NUMBER_HPP
 #define CAMP_NUMBER_HPP

--- a/include/camp/number/if.hpp
+++ b/include/camp/number/if.hpp
@@ -1,12 +1,9 @@
-/*
-Copyright (c) 2016-18, Lawrence Livermore National Security, LLC.
-Produced at the Lawrence Livermore National Laboratory
-Maintained by Tom Scogland <scogland1@llnl.gov>
-CODE-756261, All rights reserved.
-This file is part of camp.
-For details about use and distribution, please read LICENSE and NOTICE from
-http://github.com/llnl/camp
-*/
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2018-25, Lawrence Livermore National Security, LLC
+// and Camp project contributors. See the camp/LICENSE file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 
 #ifndef CAMP_NUMBER_IF_HPP
 #define CAMP_NUMBER_IF_HPP

--- a/include/camp/number/number.hpp
+++ b/include/camp/number/number.hpp
@@ -1,12 +1,9 @@
-/*
-Copyright (c) 2016-18, Lawrence Livermore National Security, LLC.
-Produced at the Lawrence Livermore National Laboratory
-Maintained by Tom Scogland <scogland1@llnl.gov>
-CODE-756261, All rights reserved.
-This file is part of camp.
-For details about use and distribution, please read LICENSE and NOTICE from
-http://github.com/llnl/camp
-*/
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2018-25, Lawrence Livermore National Security, LLC
+// and Camp project contributors. See the camp/LICENSE file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 
 #ifndef CAMP_NUMBER_NUMBER_HPP
 #define CAMP_NUMBER_NUMBER_HPP

--- a/include/camp/resource.hpp
+++ b/include/camp/resource.hpp
@@ -1,12 +1,9 @@
-/*
-Copyright (c) 2016-18, Lawrence Livermore National Security, LLC.
-Produced at the Lawrence Livermore National Laboratory
-Maintained by Tom Scogland <scogland1@llnl.gov>
-CODE-756261, All rights reserved.
-This file is part of camp.
-For details about use and distribution, please read LICENSE and NOTICE from
-http://github.com/llnl/camp
-*/
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2018-25, Lawrence Livermore National Security, LLC
+// and Camp project contributors. See the camp/LICENSE file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 
 #ifndef __CAMP_RESOURCE_HPP
 #define __CAMP_RESOURCE_HPP

--- a/include/camp/resource/cuda.hpp
+++ b/include/camp/resource/cuda.hpp
@@ -1,12 +1,9 @@
-/*
-Copyright (c) 2016-18, Lawrence Livermore National Security, LLC.
-Produced at the Lawrence Livermore National Laboratory
-Maintained by Tom Scogland <scogland1@llnl.gov>
-CODE-756261, All rights reserved.
-This file is part of camp.
-For details about use and distribution, please read LICENSE and NOTICE from
-http://github.com/llnl/camp
-*/
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2018-25, Lawrence Livermore National Security, LLC
+// and Camp project contributors. See the camp/LICENSE file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 
 #ifndef __CAMP_CUDA_HPP
 #define __CAMP_CUDA_HPP

--- a/include/camp/resource/event.hpp
+++ b/include/camp/resource/event.hpp
@@ -1,12 +1,9 @@
-/*
-Copyright (c) 2016-18, Lawrence Livermore National Security, LLC.
-Produced at the Lawrence Livermore National Laboratory
-Maintained by Tom Scogland <scogland1@llnl.gov>
-CODE-756261, All rights reserved.
-This file is part of camp.
-For details about use and distribution, please read LICENSE and NOTICE from
-http://github.com/llnl/camp
-*/
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2018-25, Lawrence Livermore National Security, LLC
+// and Camp project contributors. See the camp/LICENSE file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 
 #ifndef __CAMP_EVENT_HPP
 #define __CAMP_EVENT_HPP

--- a/include/camp/resource/hip.hpp
+++ b/include/camp/resource/hip.hpp
@@ -1,12 +1,9 @@
-/*
-Copyright (c) 2016-18, Lawrence Livermore National Security, LLC.
-Produced at the Lawrence Livermore National Laboratory
-Maintained by Tom Scogland <scogland1@llnl.gov>
-CODE-756261, All rights reserved.
-This file is part of camp.
-For details about use and distribution, please read LICENSE and NOTICE from
-http://github.com/llnl/camp
-*/
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2018-25, Lawrence Livermore National Security, LLC
+// and Camp project contributors. See the camp/LICENSE file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 
 #ifndef __CAMP_HIP_HPP
 #define __CAMP_HIP_HPP

--- a/include/camp/resource/host.hpp
+++ b/include/camp/resource/host.hpp
@@ -1,12 +1,9 @@
-/*
-Copyright (c) 2016-18, Lawrence Livermore National Security, LLC.
-Produced at the Lawrence Livermore National Laboratory
-Maintained by Tom Scogland <scogland1@llnl.gov>
-CODE-756261, All rights reserved.
-This file is part of camp.
-For details about use and distribution, please read LICENSE and NOTICE from
-http://github.com/llnl/camp
-*/
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2018-25, Lawrence Livermore National Security, LLC
+// and Camp project contributors. See the camp/LICENSE file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 
 #ifndef __CAMP_HOST_HPP
 #define __CAMP_HOST_HPP

--- a/include/camp/resource/omp_target.hpp
+++ b/include/camp/resource/omp_target.hpp
@@ -1,12 +1,9 @@
-/*
-Copyright (c) 2016-18, Lawrence Livermore National Security, LLC.
-Produced at the Lawrence Livermore National Laboratory
-Maintained by Tom Scogland <scogland1@llnl.gov>
-CODE-756261, All rights reserved.
-This file is part of camp.
-For details about use and distribution, please read LICENSE and NOTICE from
-http://github.com/llnl/camp
-*/
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2018-25, Lawrence Livermore National Security, LLC
+// and Camp project contributors. See the camp/LICENSE file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 
 #ifndef __CAMP_OMP_TARGET_HPP
 #define __CAMP_OMP_TARGET_HPP

--- a/include/camp/resource/platform.hpp
+++ b/include/camp/resource/platform.hpp
@@ -1,12 +1,9 @@
-/*
-Copyright (c) 2016-18, Lawrence Livermore National Security, LLC.
-Produced at the Lawrence Livermore National Laboratory
-Maintained by Tom Scogland <scogland1@llnl.gov>
-CODE-756261, All rights reserved.
-This file is part of camp.
-For details about use and distribution, please read LICENSE and NOTICE from
-http://github.com/llnl/camp
-*/
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2018-25, Lawrence Livermore National Security, LLC
+// and Camp project contributors. See the camp/LICENSE file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 
 #ifndef __CAMP_PLATFORM_HPP
 #define __CAMP_PLATFORM_HPP

--- a/include/camp/resource/sycl.hpp
+++ b/include/camp/resource/sycl.hpp
@@ -1,12 +1,9 @@
-/*
-Copyright (c) 2016-18, Lawrence Livermore National Security, LLC.
-Produced at the Lawrence Livermore National Laboratory
-Maintained by Tom Scogland <scogland1@llnl.gov>
-CODE-756261, All rights reserved.
-This file is part of camp.
-For details about use and distribution, please read LICENSE and NOTICE from
-http://github.com/llnl/camp
-*/
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2018-25, Lawrence Livermore National Security, LLC
+// and Camp project contributors. See the camp/LICENSE file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 
 #ifndef __CAMP_SYCL_HPP
 #define __CAMP_SYCL_HPP

--- a/include/camp/size.hpp
+++ b/include/camp/size.hpp
@@ -1,12 +1,9 @@
-/*
-Copyright (c) 2016-18, Lawrence Livermore National Security, LLC.
-Produced at the Lawrence Livermore National Laboratory
-Maintained by Tom Scogland <scogland1@llnl.gov>
-CODE-756261, All rights reserved.
-This file is part of camp.
-For details about use and distribution, please read LICENSE and NOTICE from
-http://github.com/llnl/camp
-*/
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2018-25, Lawrence Livermore National Security, LLC
+// and Camp project contributors. See the camp/LICENSE file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 
 #ifndef __CAMP_SIZE_HPP
 #define __CAMP_SIZE_HPP

--- a/include/camp/tuple.hpp
+++ b/include/camp/tuple.hpp
@@ -1,12 +1,9 @@
-/*
-Copyright (c) 2016-18, Lawrence Livermore National Security, LLC.
-Produced at the Lawrence Livermore National Laboratory
-Maintained by Tom Scogland <scogland1@llnl.gov>
-CODE-756261, All rights reserved.
-This file is part of camp.
-For details about use and distribution, please read LICENSE and NOTICE from
-http://github.com/llnl/camp
-*/
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2018-25, Lawrence Livermore National Security, LLC
+// and Camp project contributors. See the camp/LICENSE file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 
 #ifndef camp_tuple_HPP__
 #define camp_tuple_HPP__

--- a/include/camp/type_traits.hpp
+++ b/include/camp/type_traits.hpp
@@ -1,12 +1,9 @@
-/*
-Copyright (c) 2016-18, Lawrence Livermore National Security, LLC.
-Produced at the Lawrence Livermore National Laboratory
-Maintained by Tom Scogland <scogland1@llnl.gov>
-CODE-756261, All rights reserved.
-This file is part of camp.
-For details about use and distribution, please read LICENSE and NOTICE from
-http://github.com/llnl/camp
-*/
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2018-25, Lawrence Livermore National Security, LLC
+// and Camp project contributors. See the camp/LICENSE file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 
 #ifndef __CAMP_TYPE_TRAITS_HPP
 #define __CAMP_TYPE_TRAITS_HPP

--- a/include/camp/type_traits/is_same.hpp
+++ b/include/camp/type_traits/is_same.hpp
@@ -1,12 +1,9 @@
-/*
-Copyright (c) 2016-18, Lawrence Livermore National Security, LLC.
-Produced at the Lawrence Livermore National Laboratory
-Maintained by Tom Scogland <scogland1@llnl.gov>
-CODE-756261, All rights reserved.
-This file is part of camp.
-For details about use and distribution, please read LICENSE and NOTICE from
-http://github.com/llnl/camp
-*/
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2018-25, Lawrence Livermore National Security, LLC
+// and Camp project contributors. See the camp/LICENSE file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 
 #ifndef __CAMP_TYPE_TRAITS_IS_SAME_HPP
 #define __CAMP_TYPE_TRAITS_IS_SAME_HPP

--- a/include/camp/value.hpp
+++ b/include/camp/value.hpp
@@ -1,12 +1,9 @@
-/*
-Copyright (c) 2016-18, Lawrence Livermore National Security, LLC.
-Produced at the Lawrence Livermore National Laboratory
-Maintained by Tom Scogland <scogland1@llnl.gov>
-CODE-756261, All rights reserved.
-This file is part of camp.
-For details about use and distribution, please read LICENSE and NOTICE from
-http://github.com/llnl/camp
-*/
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2018-25, Lawrence Livermore National Security, LLC
+// and Camp project contributors. See the camp/LICENSE file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 
 #ifndef __CAMP_value_hpp
 #define __CAMP_value_hpp

--- a/include/camp/value/eval.hpp
+++ b/include/camp/value/eval.hpp
@@ -1,12 +1,9 @@
-/*
-Copyright (c) 2016-18, Lawrence Livermore National Security, LLC.
-Produced at the Lawrence Livermore National Laboratory
-Maintained by Tom Scogland <scogland1@llnl.gov>
-CODE-756261, All rights reserved.
-This file is part of camp.
-For details about use and distribution, please read LICENSE and NOTICE from
-http://github.com/llnl/camp
-*/
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2018-25, Lawrence Livermore National Security, LLC
+// and Camp project contributors. See the camp/LICENSE file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 
 #ifndef CAMP_VALUE_EVAL_HPP
 #define CAMP_VALUE_EVAL_HPP

--- a/scripts/gen-header-list.sh
+++ b/scripts/gen-header-list.sh
@@ -1,4 +1,12 @@
 #!/bin/sh
+
+###############################################################################
+# Copyright (c) 2018-25, Lawrence Livermore National Security, LLC
+# and Camp project contributors. See the camp/LICENSE file for details.
+#
+# SPDX-License-Identifier: (BSD-3-Clause)
+###############################################################################
+
 echo "set(camp_headers"
 find include -name '*.hpp' | grep -v '\.in\.hpp'
 echo ")"

--- a/scripts/get-deps.sh
+++ b/scripts/get-deps.sh
@@ -1,5 +1,12 @@
 #!/bin/bash -e
 
+###############################################################################
+# Copyright (c) 2018-25, Lawrence Livermore National Security, LLC
+# and Camp project contributors. See the camp/LICENSE file for details.
+#
+# SPDX-License-Identifier: (BSD-3-Clause)
+###############################################################################
+
 apt-get update || true #ignore fail here, because rocm docker is broken
 apt-get install -y --no-install-recommends curl unzip sudo
 apt-get clean

--- a/scripts/get-llvm.sh
+++ b/scripts/get-llvm.sh
@@ -1,4 +1,12 @@
 #!/bin/bash
+
+###############################################################################
+# Copyright (c) 2018-25, Lawrence Livermore National Security, LLC
+# and Camp project contributors. See the camp/LICENSE file for details.
+#
+# SPDX-License-Identifier: (BSD-3-Clause)
+###############################################################################
+
 set -eux
 
 VER=$1

--- a/scripts/make_release_tarball.sh
+++ b/scripts/make_release_tarball.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
 ###############################################################################
-# Copyright (c) 2016-24, Lawrence Livermore National Security, LLC
-# and RAJA project contributors. See the RAJA/LICENSE file for details.
+# Copyright (c) 2018-25, Lawrence Livermore National Security, LLC
+# and Camp project contributors. See the camp/LICENSE file for details.
 #
 # SPDX-License-Identifier: (BSD-3-Clause)
 ###############################################################################

--- a/scripts/update_copyright.sh
+++ b/scripts/update_copyright.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+
+###############################################################################
+# Copyright (c) 2018-25, Lawrence Livermore National Security, LLC
+# and Camp project contributors. See the camp/LICENSE file for details.
+#
+# SPDX-License-Identifier: (BSD-3-Clause)
+###############################################################################
+
+#=============================================================================
+# Change the copyright date in all files that contain the text
+# "the camp/LICENSE file", which is part of the copyright statement 
+# at the top of each Camp file. We use this to distinguish Camp files from 
+# that we do not own (e.g., other repos included as submodules), which we do
+# not want to modify. Note that this file and *.git files are omitted
+# as well.
+#
+# IMPORTANT: Since this file is not modified (it is running the shell 
+# script commands), you must EDIT THE COPYRIGHT DATES IN THE HEADER ABOVE 
+# MANUALLY.
+#
+# Edit the 'find' command below to change the set of files that will be
+# modified.
+#
+# Change the 'sed' command below to change the content that is changed
+# in each file and what it is changed to.
+#
+#=============================================================================
+#
+# If you need to modify this script, you may want to run each of these 
+# commands individually from the command line to make sure things are doing 
+# what you think they should be doing. This is why they are separated into 
+# steps here.
+# 
+#=============================================================================
+
+#=============================================================================
+# First find all the files we want to modify
+#=============================================================================
+find . -type f ! -name \*.git\*  ! -name \*update_copyright\* -exec grep -l "the camp/LICENSE file" {} \; > files2change
+
+#=============================================================================
+# Replace the old copyright dates with new dates
+#=============================================================================
+for i in `cat files2change`
+do
+    echo $i
+    cp $i $i.sed.bak
+    sed "s/Copyright (c) 2018-24/Copyright (c) 2018-25/" $i.sed.bak > $i
+done
+
+echo LICENSE
+cp LICENSE LICENSE.sed.bak
+sed "s/Copyright (c) 2018-2024/Copyright (c) 2018-2025/" LICENSE.sed.bak > LICENSE
+
+for i in README.md docs/conf.py
+do 
+    echo $i
+    cp $i $i.sed.bak
+    sed "s/2018-24/2018-25/" $i.sed.bak > $i
+done
+
+#=============================================================================
+# Remove temporary files created in the process
+#=============================================================================
+find . -name \*.sed.bak -exec rm {} \;
+rm files2change

--- a/src/errors.cpp
+++ b/src/errors.cpp
@@ -1,3 +1,10 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2018-25, Lawrence Livermore National Security, LLC
+// and Camp project contributors. See the camp/LICENSE file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
 /*
 Copyright (c) 2016-18, Lawrence Livermore National Security, LLC.
 Produced at the Lawrence Livermore National Laboratory

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,3 +1,10 @@
+##############################################################################
+# Copyright (c) 2018-25, Lawrence Livermore National Security, LLC
+# and Camp project contributors. See the camp/LICENSE file for details.
+#
+# SPDX-License-Identifier: (BSD-3-Clause)
+###############################################################################
+
 include(GoogleTest)
 
 function(camp_add_test TESTNAME)

--- a/test/Test.hpp
+++ b/test/Test.hpp
@@ -1,3 +1,10 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2018-25, Lawrence Livermore National Security, LLC
+// and Camp project contributors. See the camp/LICENSE file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
 #ifndef CAMP_TEST_HPP
 #define CAMP_TEST_HPP
 

--- a/test/accumulate.cpp
+++ b/test/accumulate.cpp
@@ -1,3 +1,10 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2018-25, Lawrence Livermore National Security, LLC
+// and Camp project contributors. See the camp/LICENSE file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
 #include <camp/camp.hpp>
 
 using namespace camp;

--- a/test/array.cpp
+++ b/test/array.cpp
@@ -1,3 +1,10 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2018-25, Lawrence Livermore National Security, LLC
+// and Camp project contributors. See the camp/LICENSE file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
 #include "camp/array.hpp"
 #include "Test.hpp"
 

--- a/test/at_key.cpp
+++ b/test/at_key.cpp
@@ -1,3 +1,10 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2018-25, Lawrence Livermore National Security, LLC
+// and Camp project contributors. See the camp/LICENSE file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
 #include <camp/camp.hpp>
 
 using namespace camp;

--- a/test/filter.cpp
+++ b/test/filter.cpp
@@ -1,3 +1,10 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2018-25, Lawrence Livermore National Security, LLC
+// and Camp project contributors. See the camp/LICENSE file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
 #include <camp/camp.hpp>
 
 using namespace camp;

--- a/test/find_if.cpp
+++ b/test/find_if.cpp
@@ -1,3 +1,10 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2018-25, Lawrence Livermore National Security, LLC
+// and Camp project contributors. See the camp/LICENSE file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
 #include <camp/camp.hpp>
 
 using namespace camp;

--- a/test/flatten.cpp
+++ b/test/flatten.cpp
@@ -1,3 +1,10 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2018-25, Lawrence Livermore National Security, LLC
+// and Camp project contributors. See the camp/LICENSE file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
 #include <camp/camp.hpp>
 
 using namespace camp;

--- a/test/index_of.cpp
+++ b/test/index_of.cpp
@@ -1,3 +1,10 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2018-25, Lawrence Livermore National Security, LLC
+// and Camp project contributors. See the camp/LICENSE file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
 #include <camp/camp.hpp>
 
 using namespace camp;

--- a/test/lambda.cpp
+++ b/test/lambda.cpp
@@ -1,3 +1,10 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2018-25, Lawrence Livermore National Security, LLC
+// and Camp project contributors. See the camp/LICENSE file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
 #include <camp/camp.hpp>
 
 using namespace camp;

--- a/test/number.cpp
+++ b/test/number.cpp
@@ -1,3 +1,10 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2018-25, Lawrence Livermore National Security, LLC
+// and Camp project contributors. See the camp/LICENSE file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
 #include <camp/camp.hpp>
 
 using namespace camp;

--- a/test/resource.cpp
+++ b/test/resource.cpp
@@ -1,16 +1,8 @@
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
-// Copyright (c) 2016-18, Lawrence Livermore National Security, LLC.
+// Copyright (c) 2018-25, Lawrence Livermore National Security, LLC
+// and Camp project contributors. See the camp/LICENSE file for details.
 //
-// Produced at the Lawrence Livermore National Laboratory
-//
-// LLNL-CODE-689114
-//
-// All rights reserved.
-//
-// This file is part of RAJA.
-//
-// For details about use and distribution, please read RAJA/LICENSE.
-//
+// SPDX-License-Identifier: (BSD-3-Clause)
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 
 #include "camp/resource.hpp"

--- a/test/size.cpp
+++ b/test/size.cpp
@@ -1,3 +1,10 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2018-25, Lawrence Livermore National Security, LLC
+// and Camp project contributors. See the camp/LICENSE file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
 #include <camp/camp.hpp>
 
 using namespace camp;

--- a/test/transform.cpp
+++ b/test/transform.cpp
@@ -1,3 +1,10 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2018-25, Lawrence Livermore National Security, LLC
+// and Camp project contributors. See the camp/LICENSE file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
 #include <camp/camp.hpp>
 
 using namespace camp;

--- a/test/tuple.cpp
+++ b/test/tuple.cpp
@@ -1,16 +1,8 @@
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
-// Copyright (c) 2016-18, Lawrence Livermore National Security, LLC.
+// Copyright (c) 2018-25, Lawrence Livermore National Security, LLC
+// and Camp project contributors. See the camp/LICENSE file for details.
 //
-// Produced at the Lawrence Livermore National Laboratory
-//
-// LLNL-CODE-689114
-//
-// All rights reserved.
-//
-// This file is part of RAJA.
-//
-// For details about use and distribution, please read RAJA/LICENSE.
-//
+// SPDX-License-Identifier: (BSD-3-Clause)
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 
 #include <type_traits>


### PR DESCRIPTION
Consistent copyright info in all files, following other RAJA Suite projects.

The inclusion of LLVM copyright info in select files is due to the fact that the array.hpp file borrows from the LLVM std::array implementation.  Inclusion of LLVM copyright info follows guidance in https://llvm.org/LICENSE.txt