### PR TITLE
[WIP]: Adding device message handling

### DIFF
--- a/include/camp/messages.hpp
+++ b/include/camp/messages.hpp
@@ -1,0 +1,172 @@
+#ifndef messages_HPP__
+#define messages_HPP__
+
+#include <algorithm>
+#include <functional>
+#include "camp/tuple.hpp"
+#include "camp/resource.hpp"
+
+namespace camp
+{
+  template <typename T>
+  T atomic_fetch_inc(T* acc)
+  {
+    T ret = *acc;
+    (*acc) += T(1) ;
+    return ret;
+  }
+
+  template <typename... Args>
+  using message = camp::tuple<std::decay_t<Args>...>;  
+
+  template <typename... Args>
+  class message_queue 
+  {
+  public:
+    using value_type     = message<Args...> ;
+    using size_type      = std::size_t;
+    using pointer        = value_type*;
+    using const_pointer  = const pointer;
+    using iterator       = pointer;
+    using const_iterator = const iterator;
+
+    message_queue() : m_capacity{0}, m_size{0}, m_buf{nullptr} 
+    {}
+    message_queue(size_type capacity, pointer buf) : 
+      m_capacity{capacity}, m_size{0}, m_buf{buf} 
+    {}
+
+    template <typename... Ts>
+    bool try_emplace(Ts&&... args)
+    {
+      auto local_size = camp::atomic_fetch_inc(&m_size);
+      if (m_buf != nullptr && local_size < m_capacity) {
+        m_buf[local_size] = camp::make_tuple<Ts...>(std::forward<Ts>(args)...);
+	return true;
+      }
+
+      return false;
+    }
+
+    pointer data() noexcept
+    {
+      return m_buf;
+    }
+
+    pointer data() const noexcept
+    {
+      return m_buf;
+    }
+
+    size_type capacity() const noexcept
+    {
+      return m_capacity;
+    }
+
+    size_type size() const noexcept
+    {
+      return std::min(m_capacity, m_size);
+    }
+
+    bool empty() const noexcept
+    {
+      return size() == 0;
+    }
+
+    iterator begin() noexcept { return data(); }
+    iterator end() noexcept   { return data()+size(); }
+
+    iterator begin() const noexcept { return data(); }
+    iterator end() const noexcept   { return data()+size(); }
+
+    iterator cbegin() const noexcept { return data(); }
+    iterator cend() const noexcept   { return data()+size(); }
+
+    void clear() noexcept
+    {
+      m_size = 0;
+    }
+  private:
+    size_type m_capacity;
+    size_type m_size;
+    pointer m_buf;
+  };
+
+  template <typename Callable>
+  class message_handler;
+
+  template <typename R, typename... Args>
+  class message_handler<R(Args...)>
+  {
+  public:
+    using msg_queue     = message_queue<Args...>;
+    using callback_type = std::function<R(Args...)>;
+
+  public:
+    template <typename Callable>
+    message_handler(const std::size_t num_messages, Callable c) 
+      : m_res{camp::resources::Host()}, 
+        m_queue{num_messages, m_res.allocate<message<Args...>>(num_messages,
+            camp::resources::MemoryAccess::Pinned)}, 
+        m_callback{c}
+    {}  
+
+    template <typename Resource, typename Callable>
+    message_handler(const std::size_t num_messages, Resource res, 
+                    Callable c) 
+      : m_res{res}, 
+        m_queue{num_messages, m_res.allocate<message<Args...>>(num_messages,
+            camp::resources::MemoryAccess::Pinned)}, 
+        m_callback{c}
+    {}  
+
+    ~message_handler() 
+    {
+      m_res.wait();
+      m_res.deallocate(m_queue.data(), camp::resources::MemoryAccess::Pinned); 
+    }
+
+    // Doesn't support copying 
+    message_handler(const message_handler&) = delete;
+    message_handler& operator=(const message_handler&) = delete;
+
+    // Move ctor/operator
+    message_handler(message_handler&&) = default;
+    message_handler& operator=(message_handler&&) = default;
+
+    template <typename... Ts>
+    bool try_post_message(Ts&&... args)
+    {
+      return m_queue.try_emplace(std::forward<Ts>(args)...); 
+    }
+
+    void clear()
+    {
+      m_res.wait();   
+      m_queue.clear();
+    }
+
+    bool test_any()
+    {
+      m_res.wait();   
+      return !m_queue.empty(); 
+    }
+
+    void wait_all()
+    {
+      if (test_any()) {
+        for (const auto& msg: m_queue) {
+          camp::apply(m_callback, msg);     
+        }
+        clear();
+      }
+    }
+
+  private:
+    camp::resources::Resource m_res;
+    msg_queue m_queue;
+    callback_type m_callback;
+  }; 
+}
+
+#endif /* messages_HPP__ */

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -56,6 +56,7 @@ function(camp_add_test TESTNAME)
 endfunction()
 
 camp_add_test(array GTEST)
+camp_add_test(messages GTEST)
 camp_add_test(resource GTEST OFFLOAD)
 camp_add_test(tuple GTEST)
 

--- a/test/messages.cpp
+++ b/test/messages.cpp
@@ -5,6 +5,7 @@
 // SPDX-License-Identifier: (BSD-3-Clause)
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 
+#include "camp/array.hpp"
 #include "camp/messages.hpp"
 #include "Test.hpp"
 
@@ -18,6 +19,15 @@ CAMP_TEST_BEGIN(message_handler, initialize) {
 
    return !msg.test_any();
 } CAMP_TEST_END(message_handler, initialize)
+
+CAMP_TEST_BEGIN(message_handler, initialize_with_resource) {
+   int test = 0;
+   camp::message_handler<void(int)> msg(1, camp::resources::Host(), [&](int val) {
+     test = val;   
+   });
+
+   return !msg.test_any();
+} CAMP_TEST_END(message_handler, initialize_with_resource)
 
 CAMP_TEST_BEGIN(message_handler, clear) {
    int test = 0;
@@ -36,8 +46,57 @@ CAMP_TEST_BEGIN(message_handler, try_post_message) {
    camp::message_handler<void(int)> msg(1, [&](int val) {
      test = val;   
    });
+
+   return msg.try_post_message(5);
+} CAMP_TEST_END(message_handler, try_post_message)
+
+CAMP_TEST_BEGIN(message_handler, try_post_message_overflow) {
+   int test = 0;
+   camp::message_handler<void(int)> msg(1, [&](int val) {
+     test = val;   
+   });
    msg.try_post_message(5);
+
+   return !msg.try_post_message(6);
+} CAMP_TEST_END(message_handler, try_post_message_overflow)
+
+CAMP_TEST_BEGIN(message_handler, wait_all) {
+   int test = 0;
+   camp::message_handler<void(int)> msg(1, [&](int val) {
+     test = val;   
+   });
+   msg.try_post_message(1);
    msg.wait_all();
 
-   return test == 5;
-} CAMP_TEST_END(message_handler, try_post_message)
+   return test == 1;
+} CAMP_TEST_END(message_handler, wait_all)
+
+CAMP_TEST_BEGIN(message_handler, wait_all_array) {
+   camp::array<int, 3> test = {0, 0, 0};
+   camp::message_handler<void(camp::array<int, 3>)> msg(1, 
+     [&](camp::array<int, 3> val) {
+       test[0] = val[0];   
+       test[1] = val[1];
+       test[2] = val[2];
+     }
+   );
+   camp::array<int, 3> a{1,2,3};
+   msg.try_post_message(a);
+   msg.wait_all();
+
+   return test[0] == 1 && 
+          test[1] == 2 && 
+          test[2] == 3;
+} CAMP_TEST_END(message_handler, wait_all_array)
+
+CAMP_TEST_BEGIN(message_handler, wait_all_overflow) {
+   int test = 0;
+   camp::message_handler<void(int)> msg(1, [&](int val) {
+     test = val;   
+   });
+   msg.try_post_message(1);
+   msg.try_post_message(2);
+   msg.wait_all();
+
+   return test == 1;
+} CAMP_TEST_END(message_handler, wait_all_overflow)

--- a/test/messages.cpp
+++ b/test/messages.cpp
@@ -1,0 +1,43 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2018-25, Lawrence Livermore National Security, LLC
+// and Camp project contributors. See the camp/LICENSE file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#include "camp/messages.hpp"
+#include "Test.hpp"
+
+#include "gtest/gtest.h"
+
+CAMP_TEST_BEGIN(message_handler, initialize) {
+   int test = 0;
+   camp::message_handler<void(int)> msg(1, [&](int val) {
+     test = val;   
+   });
+
+   return !msg.test_any();
+} CAMP_TEST_END(message_handler, initialize)
+
+CAMP_TEST_BEGIN(message_handler, clear) {
+   int test = 0;
+   camp::message_handler<void(int)> msg(1, [&](int val) {
+     test = val;   
+   });
+   msg.try_post_message(5);
+   msg.clear();
+   msg.wait_all();
+
+   return test == 0;
+} CAMP_TEST_END(message_handler, clear)
+
+CAMP_TEST_BEGIN(message_handler, try_post_message) {
+   int test = 0;
+   camp::message_handler<void(int)> msg(1, [&](int val) {
+     test = val;   
+   });
+   msg.try_post_message(5);
+   msg.wait_all();
+
+   return test == 5;
+} CAMP_TEST_END(message_handler, try_post_message)


### PR DESCRIPTION
This is a feature to store messages and call a callback with the message as arguments at a later time. The main goal with this feature is to work across the host and device. For example, storing a log message on device with printing out to a file after the kernel is complete.

This is currently a work in progress with open questions about the design. 

- [ ] Can there be multiple readers from the host?
- [ ] Can the host post messages while the device is posting?
- [ ] Currently, messages that go over the capacity of the buffer are lost. Is this behavior desired?
- [ ] Currently, atomic increment is supported as a host device function. This requires an `ifdef` to determine if device side vs. host side. To avoid this, it may be better to have `message_queue` have a different version based on the type of resource. Or, this may be better in another library