### PR TITLE
feature: method to get reference to tuple elements satisfying type_trait

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,11 +34,11 @@ if(NOT DEFINED BLT_CXX_STD)
   standard")
   message("Using C++ standard: ${BLT_CXX_STD}")
 else() #check BLT_CXX_STD is high enough by disallowing the only invalid option
-  set(_unsupported_cxx "c++98" "c++11" "c++14")
+  set(_unsupported_cxx "c++98" "c++11")
   if (BLT_CXX_STD IN_LIST _unsupported_cxx)
     message(FATAL_ERROR "CAMP and the RAJA framework no
     longer support ${_unsupported_cxx}, select a c++
-    standard of 17 or higher")
+    standard of 14 or higher")
   endif()
 endif(NOT DEFINED BLT_CXX_STD)
 set(CMAKE_CXX_EXTENSIONS OFF)

--- a/include/camp/tuple.hpp
+++ b/include/camp/tuple.hpp
@@ -624,60 +624,63 @@ CAMP_HOST_DEVICE constexpr auto tuple_cat_pair(L&& l, R&& r) noexcept
                         camp::idx_seq_from_t<R>{});
 }
 
-template<template <typename> typename TypeTrait,
-         typename LHS,
-         typename... Params>
-CAMP_HOST_DEVICE constexpr
-concepts::enable_if_t<camp::tuple<LHS&, Params...>, TypeTrait<LHS>>
-get_refs_to_elements_by_type_trait_impl_helper(LHS& lhs,
-                            camp::tuple<Params...> RHS)
+namespace detail
 {
-  return camp::tuple_cat_pair(camp::tuple<LHS&>(lhs),
-                              RHS);
-}
-
-template<template <typename> typename TypeTrait,
-         typename LHS,
-         typename... Params>
-CAMP_HOST_DEVICE constexpr
-concepts::enable_if_t<camp::tuple<Params...>, concepts::negate<TypeTrait<LHS>>>
-get_refs_to_elements_by_type_trait_impl_helper(
-    LHS&,
-    camp::tuple<Params...> RHS)
-{
-  return RHS;
-}
-
-template<camp::idx_t param_size,
-         template <typename> typename TypeTrait,
-         typename TupleType>
-CAMP_HOST_DEVICE constexpr camp::tuple<>
-get_refs_to_elements_by_type_trait_impl(TupleType&,
-                                        camp::num<0>)
-{
-  return camp::tuple<> {};
-}
-
-template<camp::idx_t param_size,
-         template <typename> typename TypeTrait,
-         typename TupleType,
-         camp::idx_t idx>
-CAMP_HOST_DEVICE constexpr auto
-get_refs_to_elements_by_type_trait_impl(TupleType& param,
-                                        camp::num<idx>)
-{
-  return get_refs_to_elements_by_type_trait_impl_helper<TypeTrait>(
-      camp::get<param_size - idx>(param),
-      get_refs_to_elements_by_type_trait_impl<param_size, TypeTrait>(
-          param, camp::num<idx - 1> {}));
+  template<template <typename> typename TypeTrait,
+          typename LHS,
+          typename... Params>
+  CAMP_HOST_DEVICE constexpr
+  concepts::enable_if_t<camp::tuple<LHS&, Params...>, TypeTrait<LHS>>
+  get_refs_to_elements_by_type_trait_impl_helper(LHS& lhs,
+                              camp::tuple<Params...> RHS)
+  {
+    return camp::tuple_cat_pair(camp::tuple<LHS&>(lhs),
+                                RHS);
   }
+
+  template<template <typename> typename TypeTrait,
+           typename LHS,
+           typename... Params>
+  CAMP_HOST_DEVICE constexpr
+  concepts::enable_if_t<camp::tuple<Params...>, concepts::negate<TypeTrait<LHS>>>
+  get_refs_to_elements_by_type_trait_impl_helper(
+      LHS&,
+      camp::tuple<Params...> RHS)
+  {
+    return RHS;
+  }
+
+  template<camp::idx_t param_size,
+           template <typename> typename TypeTrait,
+           typename TupleType>
+  CAMP_HOST_DEVICE constexpr camp::tuple<>
+  get_refs_to_elements_by_type_trait_impl(TupleType&,
+                                          camp::num<0>)
+  {
+    return camp::tuple<> {};
+  }
+
+  template<camp::idx_t param_size,
+           template <typename> typename TypeTrait,
+           typename TupleType,
+           camp::idx_t idx>
+  CAMP_HOST_DEVICE constexpr auto
+  get_refs_to_elements_by_type_trait_impl(TupleType& param,
+                                          camp::num<idx>)
+  {
+    return get_refs_to_elements_by_type_trait_impl_helper<TypeTrait>(
+        camp::get<param_size - idx>(param),
+        get_refs_to_elements_by_type_trait_impl<param_size, TypeTrait>(
+            param, camp::num<idx - 1> {}));
+  }
+} // namespace detail
 
 template <template <typename> typename TypeTrait, typename... Elements>
 CAMP_HOST_DEVICE constexpr auto
 get_refs_to_elements_by_type_trait(tuple<Elements...>& tup)
 {
-  return get_refs_to_elements_by_type_trait_impl<
-            sizeof...(Elements),TypeTrait >(tup, camp::num<sizeof...(Elements)> {});
+  return detail::get_refs_to_elements_by_type_trait_impl<
+            sizeof...(Elements), TypeTrait>(tup, camp::num<sizeof...(Elements)>{});
 }
 
 CAMP_SUPPRESS_HD_WARN

--- a/include/camp/tuple.hpp
+++ b/include/camp/tuple.hpp
@@ -279,7 +279,7 @@ public:
       camp::list<Elements...>,
       camp::make_idx_seq_t<sizeof...(Elements)>>::type;
   using type = tuple;
-  Base base;  // Place this back into private when XLC can handle this better. 
+  Base base;  // Place this back into private when XLC can handle this better.
 
 private:
 
@@ -622,6 +622,62 @@ CAMP_HOST_DEVICE constexpr auto tuple_cat_pair(L&& l, R&& r) noexcept
                         camp::idx_seq_from_t<L>{},
                         std::forward<R>(r),
                         camp::idx_seq_from_t<R>{});
+}
+
+template<template <typename> typename TypeTrait,
+         typename LHS,
+         typename... Params>
+CAMP_HOST_DEVICE constexpr
+concepts::enable_if_t<camp::tuple<LHS&, Params...>, TypeTrait<LHS>>
+get_refs_to_elements_by_type_trait_impl_helper(LHS& lhs,
+                            camp::tuple<Params...> RHS)
+{
+  return camp::tuple_cat_pair(camp::tuple<LHS&>(lhs),
+                              RHS);
+}
+
+template<template <typename> typename TypeTrait,
+         typename LHS,
+         typename... Params>
+CAMP_HOST_DEVICE constexpr
+concepts::enable_if_t<camp::tuple<Params...>, concepts::negate<TypeTrait<LHS>>>
+get_refs_to_elements_by_type_trait_impl_helper(
+    LHS&,
+    camp::tuple<Params...> RHS)
+{
+  return RHS;
+}
+
+template<camp::idx_t param_size,
+         template <typename> typename TypeTrait,
+         typename TupleType>
+CAMP_HOST_DEVICE constexpr camp::tuple<>
+get_refs_to_elements_by_type_trait_impl(TupleType&,
+                                        camp::num<0>)
+{
+  return camp::tuple<> {};
+}
+
+template<camp::idx_t param_size,
+         template <typename> typename TypeTrait,
+         typename TupleType,
+         camp::idx_t idx>
+CAMP_HOST_DEVICE constexpr auto
+get_refs_to_elements_by_type_trait_impl(TupleType& param,
+                                        camp::num<idx>)
+{
+  return get_refs_to_elements_by_type_trait_impl_helper<TypeTrait>(
+      camp::get<param_size - idx>(param),
+      get_refs_to_elements_by_type_trait_impl<param_size, TypeTrait>(
+          param, camp::num<idx - 1> {}));
+  }
+
+template <template <typename> typename TypeTrait, typename... Elements>
+CAMP_HOST_DEVICE constexpr auto
+get_refs_to_elements_by_type_trait(tuple<Elements...>& tup)
+{
+  return get_refs_to_elements_by_type_trait_impl<
+            sizeof...(Elements),TypeTrait >(tup, camp::num<sizeof...(Elements)> {});
 }
 
 CAMP_SUPPRESS_HD_WARN

--- a/test/tuple.cpp
+++ b/test/tuple.cpp
@@ -416,6 +416,28 @@ TEST(CampTaggedTuple, MakeTagged)
   ASSERT_EQ(camp::get<s1>(t), 15);
 }
 
+template<typename Param>
+struct SearchType {};
+
+template<typename Param>
+struct OtherType {};
+
+template<typename T>
+struct IsSearchType : std::false_type {};
+
+template<typename Param>
+struct IsSearchType<SearchType<Param>> : std::true_type {};
+
+TEST(CampFilterByTypeTrait, MakeFilteredTuple)
+{
+  using BaseTupleType = camp::tuple<double, SearchType<int>, int, OtherType<int>, camp::tuple<double>, SearchType<int>>;
+  using ExpectedTupleType = camp::tuple<SearchType<int>&, SearchType<int>&>;
+  auto base_tuple = BaseTupleType{};
+  auto filtered_tuple = camp::get_refs_to_elements_by_type_trait<IsSearchType>(base_tuple);
+  constexpr int is_expected = std::is_same<decltype(filtered_tuple), ExpectedTupleType>::value;
+  ASSERT_EQ(is_expected, 1);
+}
+
 #if defined(__cplusplus) && __cplusplus >= 201703L
 TEST(CampTaggedTuple, StructuredBindings)
 {

--- a/test/tuple.cpp
+++ b/test/tuple.cpp
@@ -430,8 +430,52 @@ struct IsSearchType<SearchType<Param>> : std::true_type {};
 
 TEST(CampFilterByTypeTrait, MakeFilteredTuple)
 {
-  using BaseTupleType = camp::tuple<double, SearchType<int>, int, OtherType<int>, camp::tuple<double>, SearchType<int>>;
+  using BaseTupleType = camp::tuple<double, SearchType<int>, int, OtherType<int>,
+                                    SearchType<int>, camp::tuple<double>>;
   using ExpectedTupleType = camp::tuple<SearchType<int>&, SearchType<int>&>;
+  auto base_tuple = BaseTupleType{};
+  auto filtered_tuple = camp::get_refs_to_elements_by_type_trait<IsSearchType>(base_tuple);
+  constexpr int is_expected = std::is_same<decltype(filtered_tuple), ExpectedTupleType>::value;
+  ASSERT_EQ(is_expected, 1);
+}
+
+TEST(CampFilterByTypeTrait, SearchTypeAtEnd)
+{
+  using BaseTupleType = camp::tuple<OtherType<camp::tuple<SearchType<int>>>, OtherType<int>,
+                                    camp::tuple<SearchType<int>>, SearchType<int>>;
+  using ExpectedTupleType = camp::tuple<SearchType<int>&>;
+  auto base_tuple = BaseTupleType{};
+  auto filtered_tuple = camp::get_refs_to_elements_by_type_trait<IsSearchType>(base_tuple);
+  constexpr int is_expected = std::is_same<decltype(filtered_tuple), ExpectedTupleType>::value;
+  ASSERT_EQ(is_expected, 1);
+}
+
+TEST(CampFilterByTypeTrait, SearchTypeAtStart)
+{
+  using BaseTupleType = camp::tuple<SearchType<OtherType<double>>, OtherType<SearchType<int>>,
+                                    OtherType<int>, camp::tuple<SearchType<int>>>;
+  using ExpectedTupleType = camp::tuple<SearchType<OtherType<double>>&>;
+  auto base_tuple = BaseTupleType{};
+  auto filtered_tuple = camp::get_refs_to_elements_by_type_trait<IsSearchType>(base_tuple);
+  constexpr int is_expected = std::is_same<decltype(filtered_tuple), ExpectedTupleType>::value;
+  ASSERT_EQ(is_expected, 1);
+}
+
+TEST(CampFilterByTypeTrait, EmptyTuple)
+{
+  using BaseTupleType = camp::tuple<>;
+  using ExpectedTupleType = camp::tuple<>;
+  auto base_tuple = BaseTupleType{};
+  auto filtered_tuple = camp::get_refs_to_elements_by_type_trait<IsSearchType>(base_tuple);
+  constexpr int is_expected = std::is_same<decltype(filtered_tuple), ExpectedTupleType>::value;
+  ASSERT_EQ(is_expected, 1);
+}
+
+TEST(CampFilterByTypeTrait, UndecayedSearchTypes)
+{
+  using BaseTupleType = camp::tuple<SearchType<OtherType<double>>*, SearchType<SearchType<double>>,
+                                    OtherType<int>>;
+  using ExpectedTupleType = camp::tuple< SearchType<SearchType<double>>&>;
   auto base_tuple = BaseTupleType{};
   auto filtered_tuple = camp::get_refs_to_elements_by_type_trait<IsSearchType>(base_tuple);
   constexpr int is_expected = std::is_same<decltype(filtered_tuple), ExpectedTupleType>::value;

--- a/test/tuple.cpp
+++ b/test/tuple.cpp
@@ -471,6 +471,26 @@ TEST(CampFilterByTypeTrait, EmptyTuple)
   ASSERT_EQ(is_expected, 1);
 }
 
+TEST(CampFilterByTypeTrait, SingletonTuple)
+{
+  using BaseTupleType = camp::tuple<int>;
+  using ExpectedTupleType = camp::tuple<>;
+  auto base_tuple = BaseTupleType{};
+  auto filtered_tuple = camp::get_refs_to_elements_by_type_trait<IsSearchType>(base_tuple);
+  constexpr int is_expected = std::is_same<decltype(filtered_tuple), ExpectedTupleType>::value;
+  ASSERT_EQ(is_expected, 1);
+}
+
+TEST(CampFilterByTypeTrait, SingletonTupleTwo)
+{
+  using BaseTupleType = camp::tuple<SearchType<int>>;
+  using ExpectedTupleType = camp::tuple<SearchType<int>&>;
+  auto base_tuple = BaseTupleType{};
+  auto filtered_tuple = camp::get_refs_to_elements_by_type_trait<IsSearchType>(base_tuple);
+  constexpr int is_expected = std::is_same<decltype(filtered_tuple), ExpectedTupleType>::value;
+  ASSERT_EQ(is_expected, 1);
+}
+
 TEST(CampFilterByTypeTrait, UndecayedSearchTypes)
 {
   using BaseTupleType = camp::tuple<SearchType<OtherType<double>>*, SearchType<SearchType<double>>,


### PR DESCRIPTION
For context, this is a function I wrote for https://github.com/LLNL/RAJA/pull/1799, where we need to easily extract reference to kernel parameters that are reducers.  The interface requires passing a `tuple` typed object that the user desires to extract elements from, as well as a class-template that inherits from `std::true_type` for desired elements. Here are some alternatives I considered:
- Adding ability to return pointer to element, copy of element, or reference to element.  Right now the method only returns references to elements
- Instead of the type-trait interface, passing the template class directly as a parameter to the method.  This has a number of pitfalls, including the case where the desired template class itself is dependent upon other instantiations of template classes for its definition

I am not committed to the name `get_refs_to_elements_by_type_trait` and would like to hear alternative ideas