### PR TITLE
bug: Fix failing sycl test and fix Docker to  run test

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -96,6 +96,7 @@ jobs:
         compiler: /opt/rocm/llvm/bin/amdclang++
       sycl:
         base_img: oneapi
+        cmake_extra: -DENABLE_SYCL=On
         compiler: dpcpp
   pool:
     vmImage: 'ubuntu-latest'

--- a/test/resource.cpp
+++ b/test/resource.cpp
@@ -356,7 +356,7 @@ TEST(CampResource, GetEvent)
         sycl::property_list(sycl::property::queue::in_order());
     sycl::context context;
     sycl::queue q(context, gpuSelector, propertyList);
-    test_get_event<Sycl, SyclEvent>(q);
+    test_get_event<Sycl, SyclEvent>(&q);
   }
 #endif
 }
@@ -403,7 +403,7 @@ TEST(CampEvent, Get)
         sycl::property_list(sycl::property::queue::in_order());
     sycl::context context;
     sycl::queue q(context, gpuSelector, propertyList);
-    test_get_typed_event<Sycl, SyclEvent>(q);
+    test_get_typed_event<Sycl, SyclEvent>(&q);
   }
 #endif
 }


### PR DESCRIPTION
resource.offload breaks RAJA sycl builds https://github.com/LLNL/RAJA/actions/runs/15746086961/job/44382460013?pr=1859.  This test is unfortunately not currently built or run as part of the Docker sycl pipeline either. 