### PR TITLE
Helpers to Print Function Args on Error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,8 @@ cmake-build-*/
 docker-*-build/
 /Debug/
 ./extern/googletest/*
+
+# install directories
+install/
+install-*/
+install_*/

--- a/include/camp/defines.hpp
+++ b/include/camp/defines.hpp
@@ -10,6 +10,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <string>
 
 #include <camp/config.hpp>
 
@@ -28,6 +29,9 @@ namespace camp
 #define CAMP_UNUSED_ARG(X)
 
 #define CAMP_ALLOW_UNUSED_LOCAL(X) (void)(X)
+
+#define CAMP_STRINGIFY_HELPER(...) #__VA_ARGS__
+#define CAMP_STRINGIFY(...) CAMP_STRINGIFY_HELPER(__VA_ARGS__)
 
 #if defined(__clang__)
 #define CAMP_COMPILER_CLANG
@@ -175,8 +179,13 @@ using nullptr_t = decltype(nullptr);
     using type = typename X<Lambda::template expr, Rest...>::type; \
   }
 
+
 /// Throw a runtime_error, avoid including exception everywhere
+[[noreturn]]
 CAMP_DLL_EXPORT void throw_re(const char *s);
+///
+[[noreturn]]
+CAMP_DLL_EXPORT void throw_re(std::string s);
 
 #ifdef CAMP_ENABLE_CUDA
 
@@ -184,10 +193,44 @@ CAMP_DLL_EXPORT void throw_re(const char *s);
 
 #define campCudaErrchkDiscardReturn(ans) (void)::camp::cudaAssert((ans), #ans, __FILE__, __LINE__)
 
+[[deprecated]]
 CAMP_DLL_EXPORT cudaError_t cudaAssert(cudaError_t code,
-                              const char *call,
-                              const char *file,
-                              int line);
+                                       const char *call,
+                                       const char *file,
+                                       int line);
+
+/// Invoke the given CUDA API function and report CUDA error codes.
+///
+/// NOTE: This prints arguments to the given function so the arguments
+///       are evaluated twice on an error.
+#define CAMP_CUDA_API_INVOKE_AND_CHECK_IMPLEMENTATION(func, ...)             \
+    /* Avoid shadowing by adding 56792578 to variable names */               \
+    cudaError_t code_56792578 = func(__VA_ARGS__);                           \
+    if (code_56792578 != cudaSuccess &&                                      \
+        code_56792578 != cudaErrorNotReady) /* [[unlikely]] */               \
+    {                                                                        \
+      static constexpr auto func_name_56792578 = CAMP_STRINGIFY(func);       \
+      static constexpr auto arg_names_56792578 =                             \
+          ::camp::experimental::cuda_get_api_arg_names(func_name_56792578);  \
+      ::camp::reportError(                                                   \
+          "CUDA",                                                            \
+          cudaGetErrorString(code_56792578),                                 \
+          func_name_56792578,                                                \
+          arg_names_56792578,                                                \
+          std::forward_as_tuple(__VA_ARGS__),                                \
+          __FILE__, __LINE__);                                               \
+    }
+///
+#define CAMP_CUDA_API_INVOKE_AND_CHECK_RETURN(...)                           \
+  [&](){                                                                     \
+    CAMP_CUDA_API_INVOKE_AND_CHECK_IMPLEMENTATION(__VA_ARGS__)               \
+    return code_56792578;                                                    \
+  }()
+///
+#define CAMP_CUDA_API_INVOKE_AND_CHECK(...)                                  \
+  do {                                                                       \
+    CAMP_CUDA_API_INVOKE_AND_CHECK_IMPLEMENTATION(__VA_ARGS__)               \
+  } while (false)
 
 #endif  //#ifdef CAMP_ENABLE_CUDA
 
@@ -198,10 +241,45 @@ CAMP_DLL_EXPORT cudaError_t cudaAssert(cudaError_t code,
 
 #define campHipErrchkDiscardReturn(ans) (void)::camp::hipAssert((ans), #ans, __FILE__, __LINE__)
 
+[[deprecated]]
 CAMP_DLL_EXPORT hipError_t hipAssert(hipError_t code,
-                            const char *call,
-                            const char *file,
-                            int line);
+                                     const char *call,
+                                     const char *file,
+                                     int line);
+
+
+/// Invoke the given HIP API function and report HIP error codes.
+///
+/// NOTE: This prints arguments to the given function so the arguments
+///       are evaluated twice on an error.
+#define CAMP_HIP_API_INVOKE_AND_CHECK_IMPLEMENTATION(func, ...)              \
+    /* Avoid shadowing by adding 56792578 to variable names */               \
+    hipError_t code_56792578 = func(__VA_ARGS__);                            \
+    if (code_56792578 != hipSuccess &&                                       \
+        code_56792578 != hipErrorNotReady) /* [[unlikely]] */                \
+    {                                                                        \
+      static constexpr auto func_name_56792578 = CAMP_STRINGIFY(func);       \
+      static constexpr auto arg_names_56792578 =                             \
+          ::camp::experimental::hip_get_api_arg_names(func_name_56792578);   \
+      ::camp::reportError(                                                   \
+          "HIP",                                                             \
+          hipGetErrorString(code_56792578),                                  \
+          func_name_56792578,                                                \
+          arg_names_56792578,                                                \
+          std::forward_as_tuple(__VA_ARGS__),                                \
+          __FILE__, __LINE__);                                               \
+    }
+///
+#define CAMP_HIP_API_INVOKE_AND_CHECK_RETURN(...)                            \
+  [&](){                                                                     \
+    CAMP_HIP_API_INVOKE_AND_CHECK_IMPLEMENTATION(__VA_ARGS__)                \
+    return code_56792578;                                                    \
+  }()
+///
+#define CAMP_HIP_API_INVOKE_AND_CHECK(...)                                   \
+  do {                                                                       \
+    CAMP_HIP_API_INVOKE_AND_CHECK_IMPLEMENTATION(__VA_ARGS__)                \
+  } while (false)
 
 #endif  //#ifdef CAMP_ENABLE_HIP
 

--- a/include/camp/helpers.hpp
+++ b/include/camp/helpers.hpp
@@ -10,7 +10,20 @@
 
 #include <cstddef>
 #include <utility>
+#include <cstddef>
+#include <cstdint>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <string_view>
+#include <array>
+#include <tuple>
+#include <utility>
+#include <algorithm>
+#include <stdexcept>
+#include <type_traits>
 
+#include "camp/config.hpp"
 #include "camp/defines.hpp"
 
 namespace camp
@@ -228,6 +241,211 @@ CAMP_HOST_DEVICE void safe_swap(T& t1, T& t2)
   using std::swap;
   swap(t1, t2);
 }
+
+
+namespace experimental
+{
+
+//! Printing helper class to add printability to types defined outside of camp.
+//
+//  Specialize to customize printing or add printing for a type. This avoids
+//  conflicts if an operator<< is later added for the type in question.
+//  Write specializations for non-const reference and const-reference.
+template < typename T >
+struct StreamInsertHelper
+{
+  static_assert(std::is_lvalue_reference_v<T>);
+
+  T m_val;
+
+  std::ostream& operator()(std::ostream& str) const
+  {
+    return str << m_val;
+  }
+};
+
+// deduction guide for StreamInsertHelper
+template<typename T>
+StreamInsertHelper(T& val) -> StreamInsertHelper<T&>;
+template<typename T>
+StreamInsertHelper(T const& val) -> StreamInsertHelper<T const&>;
+template<typename T>
+StreamInsertHelper(T&& val) -> StreamInsertHelper<T const&>;
+template<typename T>
+StreamInsertHelper(T const&& val) -> StreamInsertHelper<T const&>;
+
+// Allow printing of StreamInsertHelper using its call operator
+template < typename T >
+inline std::ostream& operator<<(std::ostream& str, StreamInsertHelper<T> const& si)
+{
+  return si(str);
+}
+
+
+#ifdef CAMP_ENABLE_CUDA
+
+//! Get the argument names for the given cuda API function name.
+//
+//  Returns a space separated string of the arguments to the given function.
+//  Returns an empty string if func is unknown.
+constexpr std::string_view cuda_get_api_arg_names(std::string_view func)
+{
+  using storage_type = std::pair<const char*, const char*>;
+  constexpr storage_type known_functions[] {
+    {"cudaDeviceSynchronize",                         ""},
+    {"cudaGetDevice",                                 "device"},
+    {"cudaGetDeviceProperties",                       "prop device"},
+    {"cudaSetDevice",                                 "device"},
+    {"cudaStreamCreate",                              "pStream"},
+    {"cudaStreamSynchronize",                         "stream"},
+    {"cudaStreamWaitEvent",                           "stream event flags"},
+    {"cudaEventCreateWithFlags",                      "event flags"},
+    {"cudaEventSynchronize",                          "event"},
+    {"cudaEventQuery",                                "event"},
+    {"cudaEventRecord",                               "event stream"},
+    {"cudaHostAlloc",                                 "pHost size flags"},
+    {"cudaMallocHost",                                "ptr size"},
+    {"cudaMalloc",                                    "devPtr size"},
+    {"cudaMallocManaged",                             "devPtr size flags"},
+    {"cudaHostFree",                                  "ptr"},
+    {"cudaFree",                                      "devPtr"},
+    {"cudaMemset",                                    "devPtr value count"},
+    {"cudaMemcpy",                                    "dst src count kind"},
+    {"cudaMemsetAsync",                               "devPtr value count stream"},
+    {"cudaMemcpyAsync",                               "dst src count kind stream"},
+    {"cudaLaunchKernel",                              "func gridDim blockDim args sharedMem stream"},
+    {"cudaPeekAtLastError",                           ""},
+    {"cudaGetLastError",                              ""},
+    {"cudaFuncGetAttributes",                         "attr func"},
+    {"cudaOccupancyMaxPotentialBlockSize",            "minGridSize blockSize func dynamicSMemSize blockSizeLimit"},
+    {"cudaOccupancyMaxActiveBlocksPerMultiprocessor", "numBlocks func blockSize dynamicSMemSize"}
+  };
+  for (auto [api_name, api_args] : known_functions) {
+    if (func == api_name) {
+      return api_args;
+    }
+  }
+  return "";
+}
+
+#endif  //#ifdef CAMP_ENABLE_CUDA
+
+#ifdef CAMP_ENABLE_HIP
+
+//! Get the argument names for the given hip API function name.
+//
+//  Returns a space separated string of the arguments to the given function.
+//  Returns an empty string if func is unknown.
+constexpr std::string_view hip_get_api_arg_names(std::string_view func)
+{
+  using storage_type = std::pair<const char*, const char*>;
+  constexpr storage_type known_functions[] {
+    {"hipDeviceSynchronize",                         ""},
+    {"hipGetDevice",                                 "device"},
+    {"hipGetDeviceProperties",                       "prop device"},
+    {"hipGetDevicePropertiesR0600",                  "prop device"},
+    {"hipSetDevice",                                 "device"},
+    {"hipStreamCreate",                              "pStream"},
+    {"hipStreamSynchronize",                         "stream"},
+    {"hipStreamWaitEvent",                           "stream event flags"},
+    {"hipEventCreateWithFlags",                      "event flags"},
+    {"hipEventSynchronize",                          "event"},
+    {"hipEventQuery",                                "event"},
+    {"hipEventRecord",                               "event stream"},
+    {"hipHostMalloc",                                "pHost size flags"},
+    {"hipMalloc",                                    "devPtr size"},
+    {"hipMallocManaged",                             "devPtr size flags"},
+    {"hipHostFree",                                  "ptr"},
+    {"hipFree",                                      "devPtr"},
+    {"hipMemset",                                    "devPtr value count"},
+    {"hipMemcpy",                                    "dst src count kind"},
+    {"hipMemsetAsync",                               "devPtr value count stream"},
+    {"hipMemcpyAsync",                               "dst src count kind stream"},
+    {"hipLaunchKernel",                              "func gridDim blockDim args sharedMem stream"},
+    {"hipPeekAtLastError",                           ""},
+    {"hipGetLastError",                              ""},
+    {"hipFuncGetAttributes",                         "attr func"},
+    {"hipOccupancyMaxPotentialBlockSize",            "minGridSize blockSize func dynamicSMemSize blockSizeLimit"},
+    {"hipOccupancyMaxActiveBlocksPerMultiprocessor", "numBlocks func blockSize dynamicSMemSize"}
+  };
+  for (auto [api_name, api_args] : known_functions) {
+    if (func == api_name) {
+      return api_args;
+    }
+  }
+  return "";
+}
+
+#endif  //#ifdef CAMP_ENABLE_HIP
+
+
+//! Generate a string for the given args
+//
+//  This function generates a string for the given argument names and arguments.
+//  Uses StreamInsertHelper to stringify the types in args.
+template < typename Tuple, std::size_t ...Is >
+std::ostream& insertArgsString(std::ostream& str,
+                               std::string_view arg_names,
+                               Tuple&& args_tuple,
+                               std::index_sequence<Is...>)
+{
+  auto insert_arg = [&, first=true](auto&& arg) mutable {
+    if (first) {
+      first = false;
+    } else {
+      str << ", ";
+    }
+    if (!arg_names.empty()) {
+      auto arg_name_size = arg_names.find(' ');
+      str << arg_names.substr(0, arg_name_size) << "=";
+      if (arg_name_size < arg_names.size()) {
+        ++arg_name_size; // skip space
+      }
+      arg_names.remove_prefix(arg_name_size);
+    }
+    str << ::camp::experimental::StreamInsertHelper{arg};
+  };
+  ::camp::sink(insert_arg); // suppress unused warning from nvcc
+  using std::get;
+  (..., insert_arg(get<Is>(std::forward<Tuple>(args_tuple))));
+  return str;
+}
+
+}  // namespace experimental
+
+
+/// Report hip errors by throwing an exception or printing to cerr
+///
+/// This function generates an error message by getting a string for the given
+/// hip error code, function, argument names, arguments, and source location
+/// information. Uses StreamInsertHelper to stringify the types in args.
+///
+/// This function throws an exception if abort is true otherwise prints to cerr.
+template < typename Tuple >
+void reportError(std::string_view error_name,
+                 std::string_view error_description,
+                 std::string_view func_name,
+                 std::string_view arg_names,
+                 Tuple&& args_tuple,
+                 std::string_view file,
+                 int line,
+                 bool abort = true)
+{
+  std::ostringstream str;
+  str << error_name << " error: " << error_description;
+  str << " " << func_name << "(";
+  ::camp::experimental::insertArgsString(
+      str, arg_names,
+      std::forward<Tuple>(args_tuple),
+      std::make_index_sequence<std::tuple_size_v<std::decay_t<Tuple>>>{});
+  str << ") " << file << ":" << line;
+  if (abort) {
+    ::camp::throw_re(str.str());
+  } else {
+    std::cerr << str.str();
+  }
+}
+
 }  // namespace camp
 
 #endif /* CAMP_HELPERS_HPP */

--- a/include/camp/resource.hpp
+++ b/include/camp/resource.hpp
@@ -13,6 +13,8 @@
 #include <mutex>
 #include <type_traits>
 
+#include "camp/config.hpp"
+#include "camp/defines.hpp"
 #include "camp/helpers.hpp"
 #include "camp/resource/event.hpp"
 #include "camp/resource/host.hpp"

--- a/include/camp/resource/event.hpp
+++ b/include/camp/resource/event.hpp
@@ -11,6 +11,10 @@
 #include <type_traits>
 #include <memory>
 
+#include "camp/config.hpp"
+#include "camp/defines.hpp"
+#include "camp/helpers.hpp"
+
 namespace camp
 {
 namespace resources

--- a/include/camp/resource/omp_target.hpp
+++ b/include/camp/resource/omp_target.hpp
@@ -12,6 +12,7 @@
 
 #ifdef CAMP_ENABLE_TARGET_OPENMP
 
+#include "camp/errors.hpp"
 #include "camp/resource/event.hpp"
 #include "camp/resource/platform.hpp"
 

--- a/src/errors.cpp
+++ b/src/errors.cpp
@@ -25,14 +25,14 @@ namespace camp
 {
 
 void throw_re(const char *s) { throw std::runtime_error(s); }
+void throw_re(std::string s) { throw std::runtime_error(s); }
 
 #ifdef CAMP_ENABLE_CUDA
 
-
 cudaError_t cudaAssert(cudaError_t code,
-                              const char *call,
-                              const char *file,
-                              int line)
+                       const char *call,
+                       const char *file,
+                       int line)
 {
   if (code != cudaSuccess && code != cudaErrorNotReady) {
     std::string msg;
@@ -54,9 +54,9 @@ cudaError_t cudaAssert(cudaError_t code,
 #ifdef CAMP_ENABLE_HIP
 
 hipError_t hipAssert(hipError_t code,
-                            const char *call,
-                            const char *file,
-                            int line)
+                     const char *call,
+                     const char *file,
+                     int line)
 {
   if (code != hipSuccess && code != hipErrorNotReady) {
     std::string msg;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -56,6 +56,7 @@ function(camp_add_test TESTNAME)
 endfunction()
 
 camp_add_test(array GTEST)
+camp_add_test(errors GTEST)
 camp_add_test(resource GTEST OFFLOAD)
 camp_add_test(tuple GTEST)
 

--- a/test/errors.cpp
+++ b/test/errors.cpp
@@ -1,0 +1,221 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2018-25, Lawrence Livermore National Security, LLC
+// and Camp project contributors. See the camp/LICENSE file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#include "camp/camp.hpp"
+#include "gtest/gtest.h"
+
+#include <string>
+#include <sstream>
+
+
+struct MyInt
+{
+  int i;
+};
+
+template < >
+struct ::camp::experimental::StreamInsertHelper<MyInt&>
+{
+  MyInt& m_val;
+
+  std::ostream& operator()(std::ostream& str) const
+  {
+    return str << m_val.i;
+  }
+};
+
+template < >
+struct ::camp::experimental::StreamInsertHelper<MyInt const&>
+{
+  MyInt const& m_val;
+
+  std::ostream& operator()(std::ostream& str) const
+  {
+    return str << m_val.i;
+  }
+};
+
+
+TEST(CampErrors, Throw)
+{
+  using namespace std::string_literals;
+  ASSERT_THROW(::camp::throw_re(""), std::runtime_error);
+  ASSERT_THROW(::camp::throw_re(""s), std::runtime_error);
+}
+
+TEST(CampErrors, StreamInsertHelper)
+{
+  using namespace std::string_literals;
+
+  int i = 7;
+  MyInt mi{i};
+
+  std::string expected_string = "7"s;
+
+  {
+    std::ostringstream str;
+    str << i;
+    ASSERT_EQ(str.str(), expected_string);
+  }
+
+  {
+    std::ostringstream str;
+    str << ::camp::experimental::StreamInsertHelper{i};
+    ASSERT_EQ(str.str(), expected_string);
+  }
+
+  {
+    std::ostringstream str;
+    str << ::camp::experimental::StreamInsertHelper{static_cast<const int&>(i)};
+    ASSERT_EQ(str.str(), expected_string);
+  }
+
+  {
+    std::ostringstream str;
+    str << ::camp::experimental::StreamInsertHelper{std::move(i)};
+    ASSERT_EQ(str.str(), expected_string);
+  }
+
+  {
+    std::ostringstream str;
+    str << ::camp::experimental::StreamInsertHelper{mi};
+    ASSERT_EQ(str.str(), expected_string);
+  }
+
+  {
+    std::ostringstream str;
+    str << ::camp::experimental::StreamInsertHelper{static_cast<const MyInt&>(mi)};
+    ASSERT_EQ(str.str(), expected_string);
+  }
+
+  {
+    std::ostringstream str;
+    str << ::camp::experimental::StreamInsertHelper{std::move(mi)};
+    ASSERT_EQ(str.str(), expected_string);
+  }
+}
+
+
+TEST(CampErrors, InsertArgsString)
+{
+  using namespace std::string_literals;
+
+  int i = 7;
+  MyInt mi{8};
+  std::string si = "9"s;
+
+  std::string expected_string_0 = ""s;
+
+  std::string expected_string_1 = "7"s;
+  std::string expected_string_1_args = "a=7"s;
+
+  std::string expected_string_3 = "7, 8, 9"s;
+  std::string expected_string_3_args = "a=7, bb=8, ccc=9"s;
+
+  {
+    std::ostringstream str;
+    ::camp::experimental::insertArgsString(
+        str, "", std::forward_as_tuple(), std::make_index_sequence<0>{});
+    ASSERT_EQ(str.str(), expected_string_0);
+  }
+
+  {
+    std::ostringstream str;
+    ::camp::experimental::insertArgsString(
+        str, "", std::forward_as_tuple(i), std::make_index_sequence<1>{});
+    ASSERT_EQ(str.str(), expected_string_1);
+  }
+
+  {
+    std::ostringstream str;
+    ::camp::experimental::insertArgsString(
+        str, "a", std::forward_as_tuple(i), std::make_index_sequence<1>{});
+    ASSERT_EQ(str.str(), expected_string_1_args);
+  }
+
+  {
+    std::ostringstream str;
+    ::camp::experimental::insertArgsString(
+        str, "", std::forward_as_tuple(i, mi, si), std::make_index_sequence<3>{});
+    ASSERT_EQ(str.str(), expected_string_3);
+  }
+
+  {
+    std::ostringstream str;
+    ::camp::experimental::insertArgsString(
+        str, "a bb ccc", std::forward_as_tuple(i, mi, si), std::make_index_sequence<3>{});
+    ASSERT_EQ(str.str(), expected_string_3_args);
+  }
+}
+
+TEST(CampErrors, ReportError)
+{
+  ASSERT_THROW(::camp::reportError("test", "error occurred", "func", "a b c", std::forward_as_tuple(1, "2", MyInt{3}), __FILE__, __LINE__, true), std::runtime_error);
+  ASSERT_NO_THROW(::camp::reportError("test", "error occurred", "func", "a b c", std::forward_as_tuple(1, "2", MyInt{3}), __FILE__, __LINE__, false));
+}
+
+TEST(CampErrors, APIInvokeAndCheck)
+{
+#ifdef CAMP_HAVE_CUDA
+  {
+    void* ptr = nullptr;
+    auto return_success = [](auto...){ return cudaSuccess; };
+    auto return_notReady = [](auto...){ return cudaErrorNotReady; };
+    auto return_invalid = [](auto...){ return cudaErrorInvalidValue; };
+
+    ASSERT_NO_THROW(CAMP_CUDA_API_INVOKE_AND_CHECK(return_success));
+    ASSERT_NO_THROW(CAMP_CUDA_API_INVOKE_AND_CHECK(return_success, 1));
+    ASSERT_NO_THROW(CAMP_CUDA_API_INVOKE_AND_CHECK(return_success, 1, ptr));
+    ASSERT_EQ(CAMP_CUDA_API_INVOKE_AND_CHECK_RETURN(return_success), cudaSuccess);
+    ASSERT_EQ(CAMP_CUDA_API_INVOKE_AND_CHECK_RETURN(return_success, 1), cudaSuccess);
+    ASSERT_EQ(CAMP_CUDA_API_INVOKE_AND_CHECK_RETURN(return_success, 1, ptr), cudaSuccess);
+
+    ASSERT_NO_THROW(CAMP_CUDA_API_INVOKE_AND_CHECK(return_notReady));
+    ASSERT_NO_THROW(CAMP_CUDA_API_INVOKE_AND_CHECK(return_notReady, 1));
+    ASSERT_NO_THROW(CAMP_CUDA_API_INVOKE_AND_CHECK(return_notReady, 1, ptr));
+    ASSERT_EQ(CAMP_CUDA_API_INVOKE_AND_CHECK_RETURN(return_notReady), cudaErrorNotReady);
+    ASSERT_EQ(CAMP_CUDA_API_INVOKE_AND_CHECK_RETURN(return_notReady, 1), cudaErrorNotReady);
+    ASSERT_EQ(CAMP_CUDA_API_INVOKE_AND_CHECK_RETURN(return_notReady, 1, ptr), cudaErrorNotReady);
+
+    ASSERT_THROW(CAMP_CUDA_API_INVOKE_AND_CHECK(return_invalid), std::runtime_error);
+    ASSERT_THROW(CAMP_CUDA_API_INVOKE_AND_CHECK(return_invalid, 1), std::runtime_error);
+    ASSERT_THROW(CAMP_CUDA_API_INVOKE_AND_CHECK(return_invalid, 1, ptr), std::runtime_error);
+    ASSERT_THROW((void)CAMP_CUDA_API_INVOKE_AND_CHECK_RETURN(return_invalid), std::runtime_error);
+    ASSERT_THROW((void)CAMP_CUDA_API_INVOKE_AND_CHECK_RETURN(return_invalid, 1), std::runtime_error);
+    ASSERT_THROW((void)CAMP_CUDA_API_INVOKE_AND_CHECK_RETURN(return_invalid, 1, ptr), std::runtime_error);
+  }
+#endif
+#ifdef CAMP_HAVE_HIP
+  {
+    void* ptr = nullptr;
+    auto return_success = [](auto...){ return hipSuccess; };
+    auto return_notReady = [](auto...){ return hipErrorNotReady; };
+    auto return_invalid = [](auto...){ return hipErrorInvalidValue; };
+
+    ASSERT_NO_THROW(CAMP_HIP_API_INVOKE_AND_CHECK(return_success));
+    ASSERT_NO_THROW(CAMP_HIP_API_INVOKE_AND_CHECK(return_success, 1));
+    ASSERT_NO_THROW(CAMP_HIP_API_INVOKE_AND_CHECK(return_success, 1, ptr));
+    ASSERT_EQ(CAMP_HIP_API_INVOKE_AND_CHECK_RETURN(return_success), hipSuccess);
+    ASSERT_EQ(CAMP_HIP_API_INVOKE_AND_CHECK_RETURN(return_success, 1), hipSuccess);
+    ASSERT_EQ(CAMP_HIP_API_INVOKE_AND_CHECK_RETURN(return_success, 1, ptr), hipSuccess);
+
+    ASSERT_NO_THROW(CAMP_HIP_API_INVOKE_AND_CHECK(return_notReady));
+    ASSERT_NO_THROW(CAMP_HIP_API_INVOKE_AND_CHECK(return_notReady, 1));
+    ASSERT_NO_THROW(CAMP_HIP_API_INVOKE_AND_CHECK(return_notReady, 1, ptr));
+    ASSERT_EQ(CAMP_HIP_API_INVOKE_AND_CHECK_RETURN(return_notReady), hipErrorNotReady);
+    ASSERT_EQ(CAMP_HIP_API_INVOKE_AND_CHECK_RETURN(return_notReady, 1), hipErrorNotReady);
+    ASSERT_EQ(CAMP_HIP_API_INVOKE_AND_CHECK_RETURN(return_notReady, 1, ptr), hipErrorNotReady);
+
+    ASSERT_THROW(CAMP_HIP_API_INVOKE_AND_CHECK(return_invalid), std::runtime_error);
+    ASSERT_THROW(CAMP_HIP_API_INVOKE_AND_CHECK(return_invalid, 1), std::runtime_error);
+    ASSERT_THROW(CAMP_HIP_API_INVOKE_AND_CHECK(return_invalid, 1, ptr), std::runtime_error);
+    ASSERT_THROW((void)CAMP_HIP_API_INVOKE_AND_CHECK_RETURN(return_invalid), std::runtime_error);
+    ASSERT_THROW((void)CAMP_HIP_API_INVOKE_AND_CHECK_RETURN(return_invalid, 1), std::runtime_error);
+    ASSERT_THROW((void)CAMP_HIP_API_INVOKE_AND_CHECK_RETURN(return_invalid, 1, ptr), std::runtime_error);
+  }
+#endif
+}

--- a/test/resource.cpp
+++ b/test/resource.cpp
@@ -249,23 +249,23 @@ TEST(CampResource, StreamSelect)
 #if defined(CAMP_HAVE_CUDA)
   {
     cudaStream_t stream1, stream2;
-    campCudaErrchkDiscardReturn(cudaStreamCreate(&stream1));
-    campCudaErrchkDiscardReturn(cudaStreamCreate(&stream2));
+    CAMP_CUDA_API_INVOKE_AND_CHECK(cudaStreamCreate, &stream1);
+    CAMP_CUDA_API_INVOKE_AND_CHECK(cudaStreamCreate, &stream2);
     test_select_stream(Cuda::CudaFromStream(stream1),
                        Cuda::CudaFromStream(stream2));
-    campCudaErrchkDiscardReturn(cudaStreamDestroy(stream1));
-    campCudaErrchkDiscardReturn(cudaStreamDestroy(stream2));
+    CAMP_CUDA_API_INVOKE_AND_CHECK(cudaStreamDestroy, stream1);
+    CAMP_CUDA_API_INVOKE_AND_CHECK(cudaStreamDestroy, stream2);
   }
 #endif
 #if defined(CAMP_HAVE_HIP)
   {
     hipStream_t stream1, stream2;
-    campHipErrchkDiscardReturn(hipStreamCreate(&stream1));
-    campHipErrchkDiscardReturn(hipStreamCreate(&stream2));
+    CAMP_HIP_API_INVOKE_AND_CHECK(hipStreamCreate, &stream1);
+    CAMP_HIP_API_INVOKE_AND_CHECK(hipStreamCreate, &stream2);
     test_select_stream(Hip::HipFromStream(stream1),
                        Hip::HipFromStream(stream2));
-    campHipErrchkDiscardReturn(hipStreamDestroy(stream1));
-    campHipErrchkDiscardReturn(hipStreamDestroy(stream2));
+    CAMP_HIP_API_INVOKE_AND_CHECK(hipStreamDestroy, stream1);
+    CAMP_HIP_API_INVOKE_AND_CHECK(hipStreamDestroy, stream2);
   }
 #endif
 #ifdef CAMP_HAVE_OMP_OFFLOAD
@@ -330,17 +330,17 @@ TEST(CampResource, GetEvent)
 #if defined(CAMP_HAVE_CUDA)
   {
     cudaStream_t s;
-    campCudaErrchkDiscardReturn(cudaStreamCreate(&s));
+    CAMP_CUDA_API_INVOKE_AND_CHECK(cudaStreamCreate, &s);
     test_get_event<Cuda, CudaEvent>(s);
-    campCudaErrchkDiscardReturn(cudaStreamDestroy(s));
+    CAMP_CUDA_API_INVOKE_AND_CHECK(cudaStreamDestroy, s);
   }
 #endif
 #if defined(CAMP_HAVE_HIP)
   {
     hipStream_t s;
-    campHipErrchkDiscardReturn(hipStreamCreate(&s));
+    CAMP_HIP_API_INVOKE_AND_CHECK(hipStreamCreate, &s);
     test_get_event<Hip, HipEvent>(s);
-    campHipErrchkDiscardReturn(hipStreamDestroy(s));
+    CAMP_HIP_API_INVOKE_AND_CHECK(hipStreamDestroy, s);
   }
 #endif
 #ifdef CAMP_HAVE_OMP_OFFLOAD
@@ -377,17 +377,17 @@ TEST(CampEvent, Get)
 #if defined(CAMP_HAVE_CUDA)
   {
     cudaStream_t s;
-    campCudaErrchkDiscardReturn(cudaStreamCreate(&s));
+    CAMP_CUDA_API_INVOKE_AND_CHECK(cudaStreamCreate, &s);
     test_get_typed_event<Cuda, CudaEvent>(s);
-    campCudaErrchkDiscardReturn(cudaStreamDestroy(s));
+    CAMP_CUDA_API_INVOKE_AND_CHECK(cudaStreamDestroy, s);
   }
 #endif
 #if defined(CAMP_HAVE_HIP)
   {
     hipStream_t s;
-    campHipErrchkDiscardReturn(hipStreamCreate(&s));
+    CAMP_HIP_API_INVOKE_AND_CHECK(hipStreamCreate, &s);
     test_get_typed_event<Hip, HipEvent>(s);
-    campHipErrchkDiscardReturn(hipStreamDestroy(s));
+    CAMP_HIP_API_INVOKE_AND_CHECK(hipStreamDestroy, s);
   }
 #endif
 #ifdef CAMP_HAVE_OMP_OFFLOAD

--- a/test/tuple.cpp
+++ b/test/tuple.cpp
@@ -467,6 +467,7 @@ TEST(CampFilterByTypeTrait, EmptyTuple)
   using ExpectedTupleType = camp::tuple<>;
   auto base_tuple = BaseTupleType{};
   auto filtered_tuple = camp::get_refs_to_elements_by_type_trait<IsSearchType>(base_tuple);
+  ::camp::sink(filtered_tuple); // suppress unused warning from nvcc
   constexpr int is_expected = std::is_same<decltype(filtered_tuple), ExpectedTupleType>::value;
   ASSERT_EQ(is_expected, 1);
 }
@@ -477,6 +478,7 @@ TEST(CampFilterByTypeTrait, SingletonTuple)
   using ExpectedTupleType = camp::tuple<>;
   auto base_tuple = BaseTupleType{};
   auto filtered_tuple = camp::get_refs_to_elements_by_type_trait<IsSearchType>(base_tuple);
+  ::camp::sink(filtered_tuple); // suppress unused warning from nvcc
   constexpr int is_expected = std::is_same<decltype(filtered_tuple), ExpectedTupleType>::value;
   ASSERT_EQ(is_expected, 1);
 }


### PR DESCRIPTION
Add some helper functions that can print function arguments on error.
Change the macros used to check for cuda and hip errors to use these for better error messages.