### PR TITLE
Add Windows shared libs CI check on azure

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -17,8 +17,8 @@ jobs:
 - job: Windows
   strategy:
     matrix:
-      # shared:
-      #   SHARED_ARGS: '-DBUILD_SHARED_LIBS=On -DCMAKE_CXX_FLAGS="/DRAJASHAREDDLL_EXPORTS" '
+      shared:
+        SHARED_ARGS: '-DBUILD_SHARED_LIBS=On'
       static:
         SHARED_ARGS: '-DBUILD_SHARED_LIBS=Off'
   pool:


### PR DESCRIPTION
The title says it all.

This will help catch issues before they percolate downstream to other projects.