### PR TITLE
Add a Resource ID

### DIFF
--- a/docs/sphinx/user_guide/feature/resource.rst
+++ b/docs/sphinx/user_guide/feature/resource.rst
@@ -171,11 +171,11 @@ While it is possible for two device resources to be different since each resourc
 device stream, all ``Host`` Camp resources will be the same since there is only one `stream of execution` 
 for the Host.
 
-Resource IDs
-^^^^^^^^^^^^
+Resource Hashes
+^^^^^^^^^^^^^^^
 
-Resource IDs make using resources in data structures like unordered maps possible. Each unique stream will get a unique ID.
-This means that each unique device stream (or queue) will receive a unique ID. This makes Camp generic and typed resources hashable 
-and able to be used as keys in a map, for example. However, since all Host resource IDs will be the same (because there is only 
-one `stream of execution` on the Host) the Host resources can NOT be used as a key in an unordered map. Using the Host resource
-as a key would not make sense because, for instance, ``std::unordered_map<Host, Value> map`` would only ever have one entry.
+Resource hashes make using resources as keys in data structures like unordered maps possible. Each resource corresponding to 
+a unique stream or queue will get a unique hash. However, since all Host resource IDs will be the same (because there is only 
+one `stream of execution` on the Host), users should be cautious when using the Host resource as a key. For example, 
+``std::unordered_map<Host, Value> map`` would only ever have one entry.
+

--- a/docs/sphinx/user_guide/feature/resource.rst
+++ b/docs/sphinx/user_guide/feature/resource.rst
@@ -174,11 +174,8 @@ for the Host.
 Resource IDs
 ^^^^^^^^^^^^
 
-Resource IDs make using Resources in data structures like maps possible. Each unique stream will get a unique ID.
-This means that all Host Resource IDs will be the same since there is only one `stream of execution` on the Host.
-However, each unique device stream (or queue) will receive a unique ID. This makes Camp Resources hashable and able
-to be used as keys in a map, for example.
-
-However, note that the ordering of Resource IDs is not meaningful semantically. In other words, a Cuda resource is
-"greater than" a Host resource due to how the platform is encoded, not for any other reason. This makes for
-consistent ordering for deterministic behavior.
+Resource IDs make using resources in data structures like unordered maps possible. Each unique stream will get a unique ID.
+This means that each unique device stream (or queue) will receive a unique ID. This makes Camp generic and typed resources hashable 
+and able to be used as keys in a map, for example. However, since all Host resource IDs will be the same (because there is only 
+one `stream of execution` on the Host) the Host resources can NOT be used as a key in an unordered map. Using the Host resource
+as a key would not make sense because, for instance, ``std::unordered_map<Host, Value> map`` would only ever have one entry.

--- a/docs/sphinx/user_guide/feature/resource.rst
+++ b/docs/sphinx/user_guide/feature/resource.rst
@@ -175,7 +175,7 @@ Resource Hashes
 ^^^^^^^^^^^^^^^
 
 Resource hashes make using resources as keys in data structures like unordered maps possible. Each resource corresponding to 
-a unique device stream or queue will get a hash. However, since all Host resource IDs will be the same (because there is only 
+a unique device stream or queue will get a hash. However, since all Host resources will be the same (because there is only 
 one `stream of execution` on the Host), users should be cautious when using the Host resource as a key. For example, 
 ``std::unordered_map<Host, Value> map`` would only ever have one entry.
 

--- a/docs/sphinx/user_guide/feature/resource.rst
+++ b/docs/sphinx/user_guide/feature/resource.rst
@@ -171,3 +171,14 @@ While it is possible for two device resources to be different since each resourc
 device stream, all ``Host`` Camp resources will be the same since there is only one `stream of execution` 
 for the Host.
 
+Resource IDs
+^^^^^^^^^^^^
+
+Resource IDs make using Resources in data structures like maps possible. Each unique stream will get a unique ID.
+This means that all Host Resource IDs will be the same since there is only one `stream of execution` on the Host.
+However, each unique device stream (or queue) will receive a unique ID. This makes Camp Resources hashable and able
+to be used as keys in a map, for example.
+
+However, note that the ordering of Resource IDs is not meaningful semantically. In other words, a Cuda resource is
+"greater than" a Host resource due to how the platform is encoded, not for any other reason. This makes for
+consistent ordering for deterministic behavior.

--- a/docs/sphinx/user_guide/feature/resource.rst
+++ b/docs/sphinx/user_guide/feature/resource.rst
@@ -175,7 +175,7 @@ Resource Hashes
 ^^^^^^^^^^^^^^^
 
 Resource hashes make using resources as keys in data structures like unordered maps possible. Each resource corresponding to 
-a unique stream or queue will get a unique hash. However, since all Host resource IDs will be the same (because there is only 
+a unique device stream or queue will get a hash. However, since all Host resource IDs will be the same (because there is only 
 one `stream of execution` on the Host), users should be cautious when using the Host resource as a key. For example, 
 ``std::unordered_map<Host, Value> map`` would only ever have one entry.
 

--- a/include/camp/resource.hpp
+++ b/include/camp/resource.hpp
@@ -122,6 +122,10 @@ namespace resources
         return !(*this == r);
       }
 
+      size_t get_id() const {
+        return m_value->get_id();
+      }
+
     private:
       class ContextInterface
       {
@@ -130,6 +134,7 @@ namespace resources
         virtual Platform get_platform() const = 0;
 
         virtual bool compare(Resource const& r) const = 0;
+        virtual size_t get_id() const = 0;
 
         virtual void *allocate(size_t size, MemoryAccess ma = MemoryAccess::Device) = 0;
         virtual void *calloc(size_t size, MemoryAccess ma = MemoryAccess::Device) = 0;
@@ -151,6 +156,7 @@ namespace resources
         Platform get_platform() const override { return m_modelVal.get_platform(); }
 
         bool compare(Resource const& r) const override { return m_modelVal == r.get<T>(); }
+        size_t get_id() const override { return m_modelVal.get_id(); }
 
         void *allocate(size_t size, MemoryAccess ma = MemoryAccess::Device) override { return m_modelVal.template allocate<char>(size, ma); }
         void *calloc(size_t size, MemoryAccess ma = MemoryAccess::Device) override { return m_modelVal.calloc(size, ma); }

--- a/include/camp/resource.hpp
+++ b/include/camp/resource.hpp
@@ -93,10 +93,6 @@ namespace resources
       void wait_for(Event *e) { m_value->wait_for(e); }
       void wait() { m_value->wait(); }
 
-      size_t get_id() const {
-        return m_value->get_id();
-      }
-
       /*
        * \brief Compares two Resources to see if they are equal. Two Resources are equal if they
        * have the same ID (same platform and same stream/queue).
@@ -119,8 +115,6 @@ namespace resources
       }
 
       /*
-       * \brief Less-than comparison operator.
-       *
        * \return True if this resource's ID is less than the other's.
        */
       bool operator<(Resource const& r) const
@@ -129,8 +123,6 @@ namespace resources
       }
 
       /*
-       * \brief Greater-than comparison operator.
-       *
        * \return True if this resource's ID is greater than the other's.
        */
       bool operator>(Resource const& r) const
@@ -139,8 +131,6 @@ namespace resources
       }
 
       /*
-       * \brief Less-than-or-equal comparison operator.
-       *
        * \return True if this resource's ID is less than or equal to the other's.
        */
       bool operator<=(Resource const& r) const
@@ -149,8 +139,6 @@ namespace resources
       }
 
       /*
-       * \brief Greater-than-or-equal comparison operator.
-       *
        * \return True if this resource's ID is greater than or equal to the other's.
        */
       bool operator>=(Resource const& r) const
@@ -159,6 +147,25 @@ namespace resources
       }
 
     private:
+
+      friend struct std::hash<camp::resources::Resource>;  
+  
+      /*
+       * \brief Retrieves the unique identifier for this Resource.
+       * 
+       * The ID is an implementation-defined value that uniquely identifies
+       * the combination of platform type and underlying stream/queue. Resources
+       * with the same ID represent the same execution context and can be
+       * considered equivalent for scheduling and synchronization purposes.
+       * 
+       * \return A size_t value uniquely identifying this Resource's 
+       * platform and stream/queue combination.
+       *
+       */ 
+      size_t get_id() const {
+        return m_value->get_id();
+      }
+
       class ContextInterface
       {
       public:
@@ -304,4 +311,26 @@ namespace resources
   }  // namespace v1
 }  // namespace resources
 }  // namespace camp
+
+/*
+ * \brief Specialization of std::hash for camp::resources::Resource.
+ * 
+ * Provides a hash function for Resource objects, enabling their use as keys
+ * in unordered associative containers (std::unordered_map, std::unordered_set, etc.).
+ * The hash is based on the Resource's unique identifier, which represents the
+ * combination of platform type and underlying stream/queue. Resources with 
+ * identical execution contexts (same platform and stream/queue) will produce
+ * the same hash value.
+ * 
+ * \return A size_t hash value computed from the Resource's internal ID.
+ */
+namespace std {
+  template <>
+  struct hash<camp::resources::Resource> {
+    std::size_t operator()(const camp::resources::Resource& r) const {
+      return std::hash<size_t>{}(r.get_id());
+    }
+  };
+}
+
 #endif /* __CAMP_RESOURCE_HPP */

--- a/include/camp/resource.hpp
+++ b/include/camp/resource.hpp
@@ -114,38 +114,6 @@ namespace resources
         return !(*this == r);
       }
 
-      /*
-       * \return True if this resource's ID is less than the other's.
-       */
-      bool operator<(Resource const& r) const
-      {
-        return (get_id() < r.get_id());
-      }
-
-      /*
-       * \return True if this resource's ID is greater than the other's.
-       */
-      bool operator>(Resource const& r) const
-      {
-        return (get_id() > r.get_id());
-      }
-
-      /*
-       * \return True if this resource's ID is less than or equal to the other's.
-       */
-      bool operator<=(Resource const& r) const
-      {
-        return (get_id() <= r.get_id());
-      }
-
-      /*
-       * \return True if this resource's ID is greater than or equal to the other's.
-       */
-      bool operator>=(Resource const& r) const
-      {
-        return (get_id() >= r.get_id());
-      }
-
     private:
 
       friend struct std::hash<camp::resources::Resource>;  

--- a/include/camp/resource.hpp
+++ b/include/camp/resource.hpp
@@ -101,7 +101,7 @@ namespace resources
        */
       bool operator==(Resource const& r) const
       {
-        return (get_id() == r.get_id());
+        return (get_hash() == r.get_hash());
       }
 
       /*
@@ -130,8 +130,8 @@ namespace resources
        * platform and stream/queue combination.
        *
        */ 
-      size_t get_id() const {
-        return m_value->get_id();
+      size_t get_hash() const {
+        return m_value->get_hash();
       }
 
       class ContextInterface
@@ -141,7 +141,7 @@ namespace resources
         virtual Platform get_platform() const = 0;
 
         virtual bool compare(Resource const& r) const = 0;
-        virtual size_t get_id() const = 0;
+        virtual size_t get_hash() const = 0;
 
         virtual void *allocate(size_t size, MemoryAccess ma = MemoryAccess::Device) = 0;
         virtual void *calloc(size_t size, MemoryAccess ma = MemoryAccess::Device) = 0;
@@ -163,7 +163,7 @@ namespace resources
         Platform get_platform() const override { return m_modelVal.get_platform(); }
 
         bool compare(Resource const& r) const override { return m_modelVal == r.get<T>(); }
-        size_t get_id() const override { return m_modelVal.get_id(); }
+        size_t get_hash() const override { return m_modelVal.get_hash(); }
 
         void *allocate(size_t size, MemoryAccess ma = MemoryAccess::Device) override { return m_modelVal.template allocate<char>(size, ma); }
         void *calloc(size_t size, MemoryAccess ma = MemoryAccess::Device) override { return m_modelVal.calloc(size, ma); }
@@ -296,7 +296,7 @@ namespace std {
   template <>
   struct hash<camp::resources::Resource> {
     std::size_t operator()(const camp::resources::Resource& r) const {
-      return std::hash<size_t>{}(r.get_id());
+      return std::hash<size_t>{}(r.get_hash());
     }
   };
 }

--- a/include/camp/resource.hpp
+++ b/include/camp/resource.hpp
@@ -101,7 +101,10 @@ namespace resources
        */
       bool operator==(Resource const& r) const
       {
-        return (get_hash() == r.get_hash());
+        if (get_platform() == r.get_platform()) {
+          return (m_value->compare(r));
+        }
+        return false;
       }
 
       /*

--- a/include/camp/resource.hpp
+++ b/include/camp/resource.hpp
@@ -93,37 +93,70 @@ namespace resources
       void wait_for(Event *e) { m_value->wait_for(e); }
       void wait() { m_value->wait(); }
 
+      size_t get_id() const {
+        return m_value->get_id();
+      }
+
       /*
-       * \brief Compares two Resources to see if they are equal. Two Resources are equal if they are
-       * on the same platform and they describe the same stream (i.e. CUDA, HIP) or queue (i.e. SYCL).
-       * (Note: This operator overload is on the generic Resource. Using the ContextModel's operator
-       * overload, we can call the specific resource's (i.e. T) operator== to compare streams or
-       * queues.)
+       * \brief Compares two Resources to see if they are equal. Two Resources are equal if they
+       * have the same ID (same platform and same stream/queue).
        *
-       * \return True or false depending on comparison with m_value if they are on the same platform.
+       * \return True if they have the same ID, false otherwise.
        */
       bool operator==(Resource const& r) const
       {
-        if(get_platform() == r.get_platform()) {
-          return (m_value->compare(r));
-        }
-        return false;
+        return (get_id() == r.get_id());
+        //return (m_value->compare(r));
       }
+
       /*
-       * \brief Compares two Resources to see if they are NOT equal. Two Resources are not equal
-       * if they are on separate platforms. Also, even if they are on the same platform, if they
-       * describe different streams (i.e. CUDA, HIP) or different queues (i.e. SYCL), then they 
-       * are not equal.
+       * \brief Compares two Resources to see if they are NOT equal.
        *
-       * \return Negation of == operator. 
+       * \return Negation of == operator.
        */
       bool operator!=(Resource const& r) const
       {
         return !(*this == r);
       }
 
-      size_t get_id() const {
-        return m_value->get_id();
+      /*
+       * \brief Less-than comparison operator.
+       *
+       * \return True if this resource's ID is less than the other's.
+       */
+      bool operator<(Resource const& r) const
+      {
+        return (get_id() < r.get_id());
+      }
+
+      /*
+       * \brief Greater-than comparison operator.
+       *
+       * \return True if this resource's ID is greater than the other's.
+       */
+      bool operator>(Resource const& r) const
+      {
+        return (get_id() > r.get_id());
+      }
+
+      /*
+       * \brief Less-than-or-equal comparison operator.
+       *
+       * \return True if this resource's ID is less than or equal to the other's.
+       */
+      bool operator<=(Resource const& r) const
+      {
+        return (get_id() <= r.get_id());
+      }
+
+      /*
+       * \brief Greater-than-or-equal comparison operator.
+       *
+       * \return True if this resource's ID is greater than or equal to the other's.
+       */
+      bool operator>=(Resource const& r) const
+      {
+        return (get_id() >= r.get_id());
       }
 
     private:

--- a/include/camp/resource.hpp
+++ b/include/camp/resource.hpp
@@ -95,9 +95,9 @@ namespace resources
 
       /*
        * \brief Compares two Resources to see if they are equal. Two Resources are equal if they
-       * have the same ID (same platform and same stream/queue).
+       * have the platform and same stream/queue
        *
-       * \return True if they have the same ID, false otherwise.
+       * \return True if they have the same platform and stream/queue, false otherwise.
        */
       bool operator==(Resource const& r) const
       {
@@ -122,14 +122,11 @@ namespace resources
       friend struct std::hash<camp::resources::Resource>;  
   
       /*
-       * \brief Retrieves the unique identifier for this Resource.
+       * \brief Retrieves the a hash for this Resource.
+       * The hash allows Resources to be used as keys in data structures
+       * like unordered maps.
        * 
-       * The ID is an implementation-defined value that uniquely identifies
-       * the combination of platform type and underlying stream/queue. Resources
-       * with the same ID represent the same execution context and can be
-       * considered equivalent for scheduling and synchronization purposes.
-       * 
-       * \return A size_t value uniquely identifying this Resource's 
+       * \return A size_t hash value for this Resource's 
        * platform and stream/queue combination.
        *
        */ 
@@ -284,16 +281,12 @@ namespace resources
 }  // namespace camp
 
 /*
- * \brief Specialization of std::hash for camp::resources::Resource.
+ * \brief Specialization of std::hash for camp::resources::Resource
  * 
  * Provides a hash function for Resource objects, enabling their use as keys
- * in unordered associative containers (std::unordered_map, std::unordered_set, etc.).
- * The hash is based on the Resource's unique identifier, which represents the
- * combination of platform type and underlying stream/queue. Resources with 
- * identical execution contexts (same platform and stream/queue) will produce
- * the same hash value.
+ * in unordered associative containers (std::unordered_map, std::unordered_set, etc.)
  * 
- * \return A size_t hash value computed from the Resource's internal ID.
+ * \return A size_t hash value
  */
 namespace std {
   template <>

--- a/include/camp/resource.hpp
+++ b/include/camp/resource.hpp
@@ -106,7 +106,6 @@ namespace resources
       bool operator==(Resource const& r) const
       {
         return (get_id() == r.get_id());
-        //return (m_value->compare(r));
       }
 
       /*

--- a/include/camp/resource.hpp
+++ b/include/camp/resource.hpp
@@ -296,7 +296,7 @@ namespace std {
   template <>
   struct hash<camp::resources::Resource> {
     std::size_t operator()(const camp::resources::Resource& r) const {
-      return std::hash<size_t>{}(r.get_hash());
+      return r.get_hash();
     }
   };
 }

--- a/include/camp/resource/cuda.hpp
+++ b/include/camp/resource/cuda.hpp
@@ -295,6 +295,24 @@ namespace resources
   }  // namespace v1
 }  // namespace resources
 }  // namespace camp
+
+/*
+ * \brief Specialization of std::hash for camp::resources::Cuda.
+ * 
+ * Provides a hash function for cuda typed resource objects, enabling their use as keys
+ * in unordered associative containers (std::unordered_map, std::unordered_set, etc.).
+ * 
+ * \return A size_t hash value computed from the cuda typed resource's internal ID.
+ */
+namespace std {
+  template <>
+  struct hash<camp::resources::Cuda> {
+    std::size_t operator()(const camp::resources::Cuda& c) const {
+      return std::hash<size_t>{}(c.get_id());
+    }
+  };
+}
+
 #endif  //#ifdef CAMP_ENABLE_CUDA
 
 #endif /* __CAMP_CUDA_HPP */

--- a/include/camp/resource/cuda.hpp
+++ b/include/camp/resource/cuda.hpp
@@ -256,9 +256,9 @@ namespace resources
       int get_device() const { return device; }
 
       /*
-       * \brief Compares two (Cuda) resources to see if they are equal.
+       * \brief Compares two (Cuda) resources to see if they are equal
        *
-       * \return True or false depending on if it is the same id (hash of stream).
+       * \return True or false depending on if it is the same stream
        */
       bool operator==(Cuda const& c) const
       {
@@ -266,7 +266,7 @@ namespace resources
       }
       
       /*
-       * \brief Compares two (Cuda) resources to see if they are NOT equal.
+       * \brief Compares two (Cuda) resources to see if they are NOT equal
        *
        * \return Negation of == operator
        */
@@ -297,12 +297,12 @@ namespace resources
 }  // namespace camp
 
 /*
- * \brief Specialization of std::hash for camp::resources::Cuda.
+ * \brief Specialization of std::hash for camp::resources::Cuda
  * 
  * Provides a hash function for cuda typed resource objects, enabling their use as keys
- * in unordered associative containers (std::unordered_map, std::unordered_set, etc.).
+ * in unordered associative containers (std::unordered_map, std::unordered_set, etc.)
  * 
- * \return A size_t hash value computed from the cuda typed resource's internal ID.
+ * \return A size_t hash value 
  */
 namespace std {
   template <>

--- a/include/camp/resource/cuda.hpp
+++ b/include/camp/resource/cuda.hpp
@@ -262,7 +262,7 @@ namespace resources
        */
       bool operator==(Cuda const& c) const
       {
-        return (get_id() == c.get_id());
+        return (get_hash() == c.get_hash());
       }
       
       /*
@@ -275,7 +275,7 @@ namespace resources
         return !(*this == c);
       }
 
-      size_t get_id() const {
+      size_t get_hash() const {
         constexpr size_t cuda_type = 1ULL << 32;
         size_t stream_hash = std::hash<void*>{}(static_cast<void*>(stream));
         return cuda_type | (stream_hash & 0xFFFFFFFF);
@@ -308,7 +308,7 @@ namespace std {
   template <>
   struct hash<camp::resources::Cuda> {
     std::size_t operator()(const camp::resources::Cuda& c) const {
-      return std::hash<size_t>{}(c.get_id());
+      return std::hash<size_t>{}(c.get_hash());
     }
   };
 }

--- a/include/camp/resource/cuda.hpp
+++ b/include/camp/resource/cuda.hpp
@@ -276,7 +276,7 @@ namespace resources
       }
 
       size_t get_hash() const {
-        constexpr size_t cuda_type = 1ULL << 32;
+        constexpr size_t cuda_type = size_t(get_platform()) << 32;
         size_t stream_hash = std::hash<void*>{}(static_cast<void*>(stream));
         return cuda_type | (stream_hash & 0xFFFFFFFF);
       }

--- a/include/camp/resource/cuda.hpp
+++ b/include/camp/resource/cuda.hpp
@@ -262,7 +262,7 @@ namespace resources
        */
       bool operator==(Cuda const& c) const
       {
-        return (get_stream() == c.get_stream());
+        return (get_id() == c.get_id());
       }
       
       /*
@@ -273,6 +273,46 @@ namespace resources
       bool operator!=(Cuda const& c) const
       {
         return !(*this == c);
+      }
+
+      /*
+       * \brief Less-than comparison operator.
+       *
+       * \return True if this resource's ID is less than the other's.
+       */
+      bool operator<(Cuda const& c) const
+      {
+        return (get_id() < c.get_id());
+      }
+
+      /*
+       * \brief Greater-than comparison operator.
+       *
+       * \return True if this resource's ID is greater than the other's.
+       */
+      bool operator>(Cuda const& c) const
+      {
+        return (get_id() > c.get_id());
+      }
+
+      /*
+       * \brief Less-than-or-equal comparison operator.
+       *
+       * \return True if this resource's ID is less than or equal to the other's.
+       */
+      bool operator<=(Cuda const& c) const
+      {
+        return (get_id() <= c.get_id());
+      }
+
+      /*
+       * \brief Greater-than-or-equal comparison operator.
+       *
+       * \return True if this resource's ID is greater than or equal to the other's.
+       */
+      bool operator>=(Cuda const& c) const
+      {
+        return (get_id() >= c.get_id());
       }
 
       size_t get_id() const {

--- a/include/camp/resource/cuda.hpp
+++ b/include/camp/resource/cuda.hpp
@@ -275,6 +275,12 @@ namespace resources
         return !(*this == c);
       }
 
+      size_t get_id() const {
+        constexpr size_t cuda_type = 1ULL << 32;
+        size_t stream_hash = std::hash<void*>{}(static_cast<void*>(stream));
+        return cuda_type | (stream_hash & 0xFFFFFFFF);
+      }
+
     private:
       cudaStream_t stream;
       int device;

--- a/include/camp/resource/cuda.hpp
+++ b/include/camp/resource/cuda.hpp
@@ -276,7 +276,7 @@ namespace resources
       }
 
       size_t get_hash() const {
-        constexpr size_t cuda_type = size_t(get_platform()) << 32;
+        const size_t cuda_type = size_t(get_platform()) << 32;
         size_t stream_hash = std::hash<void*>{}(static_cast<void*>(stream));
         return cuda_type | (stream_hash & 0xFFFFFFFF);
       }

--- a/include/camp/resource/cuda.hpp
+++ b/include/camp/resource/cuda.hpp
@@ -258,7 +258,7 @@ namespace resources
       /*
        * \brief Compares two (Cuda) resources to see if they are equal.
        *
-       * \return True or false depending on if it is the same stream.
+       * \return True or false depending on if it is the same id (hash of stream).
        */
       bool operator==(Cuda const& c) const
       {
@@ -273,38 +273,6 @@ namespace resources
       bool operator!=(Cuda const& c) const
       {
         return !(*this == c);
-      }
-
-      /*
-       * \return True if this resource's ID is less than the other's.
-       */
-      bool operator<(Cuda const& c) const
-      {
-        return (get_id() < c.get_id());
-      }
-
-      /*
-       * \return True if this resource's ID is greater than the other's.
-       */
-      bool operator>(Cuda const& c) const
-      {
-        return (get_id() > c.get_id());
-      }
-
-      /*
-       * \return True if this resource's ID is less than or equal to the other's.
-       */
-      bool operator<=(Cuda const& c) const
-      {
-        return (get_id() <= c.get_id());
-      }
-
-      /*
-       * \return True if this resource's ID is greater than or equal to the other's.
-       */
-      bool operator>=(Cuda const& c) const
-      {
-        return (get_id() >= c.get_id());
       }
 
       size_t get_id() const {

--- a/include/camp/resource/cuda.hpp
+++ b/include/camp/resource/cuda.hpp
@@ -308,7 +308,7 @@ namespace std {
   template <>
   struct hash<camp::resources::Cuda> {
     std::size_t operator()(const camp::resources::Cuda& c) const {
-      return std::hash<size_t>{}(c.get_hash());
+      return c.get_hash();
     }
   };
 }

--- a/include/camp/resource/cuda.hpp
+++ b/include/camp/resource/cuda.hpp
@@ -262,7 +262,7 @@ namespace resources
        */
       bool operator==(Cuda const& c) const
       {
-        return (get_hash() == c.get_hash());
+        return (get_stream() == c.get_stream());
       }
       
       /*

--- a/include/camp/resource/cuda.hpp
+++ b/include/camp/resource/cuda.hpp
@@ -276,8 +276,6 @@ namespace resources
       }
 
       /*
-       * \brief Less-than comparison operator.
-       *
        * \return True if this resource's ID is less than the other's.
        */
       bool operator<(Cuda const& c) const
@@ -286,8 +284,6 @@ namespace resources
       }
 
       /*
-       * \brief Greater-than comparison operator.
-       *
        * \return True if this resource's ID is greater than the other's.
        */
       bool operator>(Cuda const& c) const
@@ -296,8 +292,6 @@ namespace resources
       }
 
       /*
-       * \brief Less-than-or-equal comparison operator.
-       *
        * \return True if this resource's ID is less than or equal to the other's.
        */
       bool operator<=(Cuda const& c) const
@@ -306,8 +300,6 @@ namespace resources
       }
 
       /*
-       * \brief Greater-than-or-equal comparison operator.
-       *
        * \return True if this resource's ID is greater than or equal to the other's.
        */
       bool operator>=(Cuda const& c) const

--- a/include/camp/resource/hip.hpp
+++ b/include/camp/resource/hip.hpp
@@ -258,9 +258,9 @@ namespace resources
       int get_device() const { return device; }
 
       /*
-       * \brief Compares two (Hip) resources to see if they are equal.
+       * \brief Compares two (Hip) resources to see if they are equal
        *
-       * \return True or false depending on if this is the same id (hash of stream).
+       * \return True or false depending on if this is the same stream
        */
       bool operator==(Hip const& h) const
       {
@@ -268,7 +268,7 @@ namespace resources
       }
       
       /*
-       * \brief Compares two (Hip) resources to see if they are NOT equal.
+       * \brief Compares two (Hip) resources to see if they are NOT equal
        *
        * \return Negation of == operator
        */
@@ -299,12 +299,12 @@ namespace resources
 }  // namespace camp
 
 /*
- * \brief Specialization of std::hash for camp::resources::Hip.
+ * \brief Specialization of std::hash for camp::resources::Hip
  * 
  * Provides a hash function for hip typed resource objects, enabling their use as keys
- * in unordered associative containers (std::unordered_map, std::unordered_set, etc.).
+ * in unordered associative containers (std::unordered_map, std::unordered_set, etc.)
  * 
- * \return A size_t hash value computed from the hip typed resource's internal ID.
+ * \return A size_t hash value 
  */
 namespace std {
   template <>

--- a/include/camp/resource/hip.hpp
+++ b/include/camp/resource/hip.hpp
@@ -277,6 +277,46 @@ namespace resources
         return !(*this == h);
       }
 
+      /*
+       * \brief Less-than comparison operator.
+       *
+       * \return True if this resource's ID is less than the other's.
+       */
+      bool operator<(Hip const& h) const
+      {
+        return (get_id() < h.get_id());
+      }
+
+      /*
+       * \brief Greater-than comparison operator.
+       *
+       * \return True if this resource's ID is greater than the other's.
+       */
+      bool operator>(Hip const& h) const
+      {
+        return (get_id() > h.get_id());
+      }
+
+      /*
+       * \brief Less-than-or-equal comparison operator.
+       *
+       * \return True if this resource's ID is less than or equal to the other's.
+       */
+      bool operator<=(Hip const& h) const
+      {
+        return (get_id() <= h.get_id());
+      }
+
+      /*
+       * \brief Greater-than-or-equal comparison operator.
+       *
+       * \return True if this resource's ID is greater than or equal to the other's.
+       */
+      bool operator>=(Hip const& h) const
+      {
+        return (get_id() >= h.get_id());
+      }
+
       size_t get_id() const {
         constexpr size_t hip_type = 2ULL << 32;
         size_t stream_hash = std::hash<void*>{}(static_cast<void*>(stream));

--- a/include/camp/resource/hip.hpp
+++ b/include/camp/resource/hip.hpp
@@ -277,6 +277,12 @@ namespace resources
         return !(*this == h);
       }
 
+      size_t get_id() const {
+        constexpr size_t hip_type = 2ULL << 32;
+        size_t stream_hash = std::hash<void*>{}(static_cast<void*>(stream));
+        return hip_type | (stream_hash & 0xFFFFFFFF);
+      }
+
     private:
       hipStream_t stream;
       int device;

--- a/include/camp/resource/hip.hpp
+++ b/include/camp/resource/hip.hpp
@@ -297,6 +297,24 @@ namespace resources
   }  // namespace v1
 }  // namespace resources
 }  // namespace camp
+
+/*
+ * \brief Specialization of std::hash for camp::resources::Hip.
+ * 
+ * Provides a hash function for hip typed resource objects, enabling their use as keys
+ * in unordered associative containers (std::unordered_map, std::unordered_set, etc.).
+ * 
+ * \return A size_t hash value computed from the hip typed resource's internal ID.
+ */
+namespace std {
+  template <>
+  struct hash<camp::resources::Hip> {
+    std::size_t operator()(const camp::resources::Hip& h) const {
+      return std::hash<size_t>{}(h.get_id());
+    }
+  };
+}
+
 #endif  //#ifdef CAMP_ENABLE_HIP
 
 #endif /* __CAMP_HIP_HPP */

--- a/include/camp/resource/hip.hpp
+++ b/include/camp/resource/hip.hpp
@@ -264,7 +264,7 @@ namespace resources
        */
       bool operator==(Hip const& h) const
       {
-        return (get_id() == h.get_id());
+        return (get_hash() == h.get_hash());
       }
       
       /*
@@ -277,7 +277,7 @@ namespace resources
         return !(*this == h);
       }
 
-      size_t get_id() const {
+      size_t get_hash() const {
         constexpr size_t hip_type = 2ULL << 32;
         size_t stream_hash = std::hash<void*>{}(static_cast<void*>(stream));
         return hip_type | (stream_hash & 0xFFFFFFFF);
@@ -310,7 +310,7 @@ namespace std {
   template <>
   struct hash<camp::resources::Hip> {
     std::size_t operator()(const camp::resources::Hip& h) const {
-      return std::hash<size_t>{}(h.get_id());
+      return std::hash<size_t>{}(h.get_hash());
     }
   };
 }

--- a/include/camp/resource/hip.hpp
+++ b/include/camp/resource/hip.hpp
@@ -278,8 +278,6 @@ namespace resources
       }
 
       /*
-       * \brief Less-than comparison operator.
-       *
        * \return True if this resource's ID is less than the other's.
        */
       bool operator<(Hip const& h) const
@@ -288,8 +286,6 @@ namespace resources
       }
 
       /*
-       * \brief Greater-than comparison operator.
-       *
        * \return True if this resource's ID is greater than the other's.
        */
       bool operator>(Hip const& h) const
@@ -298,8 +294,6 @@ namespace resources
       }
 
       /*
-       * \brief Less-than-or-equal comparison operator.
-       *
        * \return True if this resource's ID is less than or equal to the other's.
        */
       bool operator<=(Hip const& h) const
@@ -308,8 +302,6 @@ namespace resources
       }
 
       /*
-       * \brief Greater-than-or-equal comparison operator.
-       *
        * \return True if this resource's ID is greater than or equal to the other's.
        */
       bool operator>=(Hip const& h) const

--- a/include/camp/resource/hip.hpp
+++ b/include/camp/resource/hip.hpp
@@ -278,7 +278,7 @@ namespace resources
       }
 
       size_t get_hash() const {
-        constexpr size_t hip_type = 2ULL << 32;
+        const size_t hip_type = size_t(get_platform()) << 32;
         size_t stream_hash = std::hash<void*>{}(static_cast<void*>(stream));
         return hip_type | (stream_hash & 0xFFFFFFFF);
       }

--- a/include/camp/resource/hip.hpp
+++ b/include/camp/resource/hip.hpp
@@ -264,7 +264,7 @@ namespace resources
        */
       bool operator==(Hip const& h) const
       {
-        return (get_hash() == h.get_hash());
+        return (get_stream() == h.get_stream());
       }
       
       /*

--- a/include/camp/resource/hip.hpp
+++ b/include/camp/resource/hip.hpp
@@ -310,7 +310,7 @@ namespace std {
   template <>
   struct hash<camp::resources::Hip> {
     std::size_t operator()(const camp::resources::Hip& h) const {
-      return std::hash<size_t>{}(h.get_hash());
+      return h.get_hash();
     }
   };
 }

--- a/include/camp/resource/hip.hpp
+++ b/include/camp/resource/hip.hpp
@@ -260,11 +260,11 @@ namespace resources
       /*
        * \brief Compares two (Hip) resources to see if they are equal.
        *
-       * \return True or false depending on if this is the same stream.
+       * \return True or false depending on if this is the same id (hash of stream).
        */
       bool operator==(Hip const& h) const
       {
-        return (get_stream() == h.get_stream());
+        return (get_id() == h.get_id());
       }
       
       /*
@@ -275,38 +275,6 @@ namespace resources
       bool operator!=(Hip const& h) const
       {
         return !(*this == h);
-      }
-
-      /*
-       * \return True if this resource's ID is less than the other's.
-       */
-      bool operator<(Hip const& h) const
-      {
-        return (get_id() < h.get_id());
-      }
-
-      /*
-       * \return True if this resource's ID is greater than the other's.
-       */
-      bool operator>(Hip const& h) const
-      {
-        return (get_id() > h.get_id());
-      }
-
-      /*
-       * \return True if this resource's ID is less than or equal to the other's.
-       */
-      bool operator<=(Hip const& h) const
-      {
-        return (get_id() <= h.get_id());
-      }
-
-      /*
-       * \return True if this resource's ID is greater than or equal to the other's.
-       */
-      bool operator>=(Hip const& h) const
-      {
-        return (get_id() >= h.get_id());
       }
 
       size_t get_id() const {

--- a/include/camp/resource/host.hpp
+++ b/include/camp/resource/host.hpp
@@ -85,6 +85,11 @@ namespace resources
       {
         return false;
       }
+
+      size_t get_id() const
+      {
+        return 0; // All Host resources are the same
+      }
     };
 
   }  // namespace v1

--- a/include/camp/resource/host.hpp
+++ b/include/camp/resource/host.hpp
@@ -108,7 +108,7 @@ namespace std {
   template <>
   struct hash<camp::resources::Host> {
     std::size_t operator()(const camp::resources::Host& h) const {
-      return std::hash<size_t>{}(0);
+      return std::hash<size_t>{}(h.get_hash());
     }
   };
 }

--- a/include/camp/resource/host.hpp
+++ b/include/camp/resource/host.hpp
@@ -108,7 +108,7 @@ namespace std {
   template <>
   struct hash<camp::resources::Host> {
     std::size_t operator()(const camp::resources::Host& h) const {
-      return std::hash<size_t>{}(h.get_hash());
+      return h.get_hash();
     }
   };
 }

--- a/include/camp/resource/host.hpp
+++ b/include/camp/resource/host.hpp
@@ -86,38 +86,6 @@ namespace resources
         return false;
       }
 
-      /*
-       * \return Since Host IDs are always zero, 0 < 0 is false
-       */
-      bool operator<(Host const&) const
-      {
-        return false;
-      }
-
-      /*
-       * \return Since Host IDs are always zero, 0 > 0 is false
-       */
-      bool operator>(Host const&) const
-      {
-        return false;
-      }
-
-      /*
-       * \return Since Host IDs are always zero, 0 <= 0 is true
-       */
-      bool operator<=(Host const&) const
-      {
-        return true;
-      }
-
-      /*
-       * \return Since Host IDs are always zero, 0 >= 0 is true
-       */
-      bool operator>=(Host const&) const
-      {
-        return true;
-      }
-
       size_t get_id() const
       {
         return 0; // All Host resources are the same

--- a/include/camp/resource/host.hpp
+++ b/include/camp/resource/host.hpp
@@ -88,7 +88,7 @@ namespace resources
 
       size_t get_hash() const
       {
-        return 0; // All Host resources are the same
+        return size_t(get_platform()) << 32; // All Host resources are the same
       }
     };
 
@@ -102,7 +102,7 @@ namespace resources
  * Provides a hash function for Host typed resource objects, enabling their use as keys
  * in unordered associative containers (std::unordered_map, std::unordered_set, etc.)
  * 
- * \return Hash value for the host (always zero)
+ * \return Hash value for the host (always the value of get_platform())
  */
 namespace std {
   template <>

--- a/include/camp/resource/host.hpp
+++ b/include/camp/resource/host.hpp
@@ -86,7 +86,7 @@ namespace resources
         return false;
       }
 
-      size_t get_id() const
+      size_t get_hash() const
       {
         return 0; // All Host resources are the same
       }
@@ -95,4 +95,21 @@ namespace resources
   }  // namespace v1
 }  // namespace resources
 }  // namespace camp
+
+/*
+ * \brief Specialization of std::hash for camp::resources::Host.
+ * 
+ * Provides a hash function for Host typed resource objects, enabling their use as keys
+ * in unordered associative containers (std::unordered_map, std::unordered_set, etc.).
+ * 
+ * \return Always zero since all Host resources are the same
+ */
+namespace std {
+  template <>
+  struct hash<camp::resources::Host> {
+    std::size_t operator()(const camp::resources::Host& h) const {
+      return std::hash<size_t>{}(0);
+    }
+  };
+}
 #endif /* __CAMP_DEVICES_HPP */

--- a/include/camp/resource/host.hpp
+++ b/include/camp/resource/host.hpp
@@ -86,6 +86,38 @@ namespace resources
         return false;
       }
 
+      /*
+       * \return Since Host IDs are always zero, 0 < 0 is false
+       */
+      bool operator<(Host const&) const
+      {
+        return false;
+      }
+
+      /*
+       * \return Since Host IDs are always zero, 0 > 0 is false
+       */
+      bool operator>(Host const&) const
+      {
+        return false;
+      }
+
+      /*
+       * \return Since Host IDs are always zero, 0 <= 0 is true
+       */
+      bool operator<=(Host const&) const
+      {
+        return true;
+      }
+
+      /*
+       * \return Since Host IDs are always zero, 0 >= 0 is true
+       */
+      bool operator>=(Host const&) const
+      {
+        return true;
+      }
+
       size_t get_id() const
       {
         return 0; // All Host resources are the same

--- a/include/camp/resource/host.hpp
+++ b/include/camp/resource/host.hpp
@@ -67,9 +67,9 @@ namespace resources
       void memset(void *p, int val, size_t size) { std::memset(p, val, size); }
 
       /*
-       * \brief Compares two (Host) resources to see if they are equal.
+       * \brief Compares two (Host) resources to see if they are equal
        *
-       * \return Always return true since we are on the Host in this case.
+       * \return Always return true since Host resources are always the same
        */
       bool operator==(Host const&) const
       {
@@ -77,9 +77,9 @@ namespace resources
       }
       
       /*
-       * \brief Compares two (Host) resources to see if they are NOT equal.
+       * \brief Compares two (Host) resources to see if they are NOT equal
        *
-       * \return Always return false. Host resources are always the same.
+       * \return Always return false. Host resources are always the same
        */
       bool operator!=(Host const&) const
       {
@@ -97,12 +97,12 @@ namespace resources
 }  // namespace camp
 
 /*
- * \brief Specialization of std::hash for camp::resources::Host.
+ * \brief Specialization of std::hash for camp::resources::Host
  * 
  * Provides a hash function for Host typed resource objects, enabling their use as keys
- * in unordered associative containers (std::unordered_map, std::unordered_set, etc.).
+ * in unordered associative containers (std::unordered_map, std::unordered_set, etc.)
  * 
- * \return Always zero since all Host resources are the same
+ * \return Hash value for the host (always zero)
  */
 namespace std {
   template <>

--- a/include/camp/resource/omp_target.hpp
+++ b/include/camp/resource/omp_target.hpp
@@ -236,7 +236,7 @@ namespace resources
        */
       bool operator==(Omp const& o) const
       {
-        return (get_hash() == o.get_hash());
+        return (dev == o.dev && addr == o.addr);
       }
       
       /*

--- a/include/camp/resource/omp_target.hpp
+++ b/include/camp/resource/omp_target.hpp
@@ -282,7 +282,7 @@ namespace std {
   template <>
   struct hash<camp::resources::Omp> {
     std::size_t operator()(const camp::resources::Omp& o) const {
-      return std::hash<size_t>{}(o.get_hash());
+      return o.get_hash();
     }
   };
 }

--- a/include/camp/resource/omp_target.hpp
+++ b/include/camp/resource/omp_target.hpp
@@ -251,7 +251,7 @@ namespace resources
 
       size_t get_id() const {
         constexpr size_t omp_type = 3ULL << 32;
-        size_t stream_hash = std::hash<void*>{}(static_cast<void*>(stream));
+        size_t stream_hash = std::hash<void*>{}(static_cast<void*>(addr));
         return omp_type | (stream_hash & 0xFFFFFFFF);
       }
 

--- a/include/camp/resource/omp_target.hpp
+++ b/include/camp/resource/omp_target.hpp
@@ -269,6 +269,23 @@ namespace resources
   }  // namespace v1
 }  // namespace resources
 }  // namespace camp
+
+/*
+ * \brief Specialization of std::hash for camp::resources::Omp.
+ * 
+ * Provides a hash function for Omp typed resource objects, enabling their use as keys
+ * in unordered associative containers (std::unordered_map, std::unordered_set, etc.).
+ * 
+ * \return A size_t hash value computed from the Omp typed resource's internal ID.
+ */
+namespace std {
+  template <>
+  struct hash<camp::resources::Omp> {
+    std::size_t operator()(const camp::resources::Omp& o) const {
+      return std::hash<size_t>{}(o.get_id());
+    }
+  };
+}
 #endif  //#ifdef CAMP_ENABLE_TARGET_OPENMP
 
 #endif /* __CAMP_OMP_TARGET_HPP */

--- a/include/camp/resource/omp_target.hpp
+++ b/include/camp/resource/omp_target.hpp
@@ -230,9 +230,9 @@ namespace resources
       char* get_depend_location() const { return addr; }
 
       /*
-       * \brief Compares two (Omp) resources to see if they are equal.
+       * \brief Compares two (Omp) resources to see if they are equal
        *
-       * \return True or false depending on if this is the same id (hash of addr ptr).
+       * \return True or false depending on if this is the same dev and addr ptr
        */
       bool operator==(Omp const& o) const
       {
@@ -240,7 +240,7 @@ namespace resources
       }
       
       /*
-       * \brief Compares two (Omp) resources to see if they are NOT equal.
+       * \brief Compares two (Omp) resources to see if they are NOT equal
        *
        * \return Negation of == operator
        */
@@ -271,12 +271,12 @@ namespace resources
 }  // namespace camp
 
 /*
- * \brief Specialization of std::hash for camp::resources::Omp.
+ * \brief Specialization of std::hash for camp::resources::Omp
  * 
  * Provides a hash function for Omp typed resource objects, enabling their use as keys
- * in unordered associative containers (std::unordered_map, std::unordered_set, etc.).
+ * in unordered associative containers (std::unordered_map, std::unordered_set, etc.)
  * 
- * \return A size_t hash value computed from the Omp typed resource's internal ID.
+ * \return A size_t hash value
  */
 namespace std {
   template <>

--- a/include/camp/resource/omp_target.hpp
+++ b/include/camp/resource/omp_target.hpp
@@ -232,11 +232,11 @@ namespace resources
       /*
        * \brief Compares two (Omp) resources to see if they are equal.
        *
-       * \return True or false depending on if this is the same dev int and addr ptr.
+       * \return True or false depending on if this is the same id (hash of addr ptr).
        */
       bool operator==(Omp const& o) const
       {
-        return (dev == o.dev && addr == o.addr);
+        return (get_id() == o.get_id());
       }
       
       /*
@@ -247,38 +247,6 @@ namespace resources
       bool operator!=(Omp const& o) const
       {
         return !(*this == o);
-      }
-
-      /*
-       * \return True if this resource's ID is less than the other's.
-       */
-      bool operator<(Omp const& o) const
-      {
-        return (get_id() < o.get_id());
-      }
-
-      /*
-       * \return True if this resource's ID is greater than the other's.
-       */
-      bool operator>(Omp const& o) const
-      {
-        return (get_id() > o.get_id());
-      }
-
-      /*
-       * \return True if this resource's ID is less than or equal to the other's.
-       */
-      bool operator<=(Omp const& o) const
-      {
-        return (get_id() <= o.get_id());
-      }
-
-      /*
-       * \return True if this resource's ID is greater than or equal to the other's.
-       */
-      bool operator>=(Omp const& o) const
-      {
-        return (get_id() >= o.get_id());
       }
 
       size_t get_id() const {

--- a/include/camp/resource/omp_target.hpp
+++ b/include/camp/resource/omp_target.hpp
@@ -249,6 +249,12 @@ namespace resources
         return !(*this == o);
       }
 
+      size_t get_id() const {
+        constexpr size_t omp_type = 3ULL << 32;
+        size_t stream_hash = std::hash<void*>{}(static_cast<void*>(stream));
+        return omp_type | (stream_hash & 0xFFFFFFFF);
+      }
+
     private:
       char *addr;
       int dev;

--- a/include/camp/resource/omp_target.hpp
+++ b/include/camp/resource/omp_target.hpp
@@ -250,7 +250,7 @@ namespace resources
       }
 
       size_t get_hash() const {
-        constexpr size_t omp_type = 3ULL << 32;
+        const size_t omp_type = size_t(get_platform()) << 32;
         size_t stream_hash = std::hash<void*>{}(static_cast<void*>(addr));
         return omp_type | (stream_hash & 0xFFFFFFFF);
       }

--- a/include/camp/resource/omp_target.hpp
+++ b/include/camp/resource/omp_target.hpp
@@ -250,8 +250,6 @@ namespace resources
       }
 
       /*
-       * \brief Less-than comparison operator.
-       *
        * \return True if this resource's ID is less than the other's.
        */
       bool operator<(Omp const& o) const
@@ -260,8 +258,6 @@ namespace resources
       }
 
       /*
-       * \brief Greater-than comparison operator.
-       *
        * \return True if this resource's ID is greater than the other's.
        */
       bool operator>(Omp const& o) const
@@ -270,8 +266,6 @@ namespace resources
       }
 
       /*
-       * \brief Less-than-or-equal comparison operator.
-       *
        * \return True if this resource's ID is less than or equal to the other's.
        */
       bool operator<=(Omp const& o) const
@@ -280,8 +274,6 @@ namespace resources
       }
 
       /*
-       * \brief Greater-than-or-equal comparison operator.
-       *
        * \return True if this resource's ID is greater than or equal to the other's.
        */
       bool operator>=(Omp const& o) const

--- a/include/camp/resource/omp_target.hpp
+++ b/include/camp/resource/omp_target.hpp
@@ -236,7 +236,7 @@ namespace resources
        */
       bool operator==(Omp const& o) const
       {
-        return (get_id() == o.get_id());
+        return (get_hash() == o.get_hash());
       }
       
       /*
@@ -249,7 +249,7 @@ namespace resources
         return !(*this == o);
       }
 
-      size_t get_id() const {
+      size_t get_hash() const {
         constexpr size_t omp_type = 3ULL << 32;
         size_t stream_hash = std::hash<void*>{}(static_cast<void*>(addr));
         return omp_type | (stream_hash & 0xFFFFFFFF);
@@ -282,7 +282,7 @@ namespace std {
   template <>
   struct hash<camp::resources::Omp> {
     std::size_t operator()(const camp::resources::Omp& o) const {
-      return std::hash<size_t>{}(o.get_id());
+      return std::hash<size_t>{}(o.get_hash());
     }
   };
 }

--- a/include/camp/resource/omp_target.hpp
+++ b/include/camp/resource/omp_target.hpp
@@ -249,6 +249,46 @@ namespace resources
         return !(*this == o);
       }
 
+      /*
+       * \brief Less-than comparison operator.
+       *
+       * \return True if this resource's ID is less than the other's.
+       */
+      bool operator<(Omp const& o) const
+      {
+        return (get_id() < o.get_id());
+      }
+
+      /*
+       * \brief Greater-than comparison operator.
+       *
+       * \return True if this resource's ID is greater than the other's.
+       */
+      bool operator>(Omp const& o) const
+      {
+        return (get_id() > o.get_id());
+      }
+
+      /*
+       * \brief Less-than-or-equal comparison operator.
+       *
+       * \return True if this resource's ID is less than or equal to the other's.
+       */
+      bool operator<=(Omp const& o) const
+      {
+        return (get_id() <= o.get_id());
+      }
+
+      /*
+       * \brief Greater-than-or-equal comparison operator.
+       *
+       * \return True if this resource's ID is greater than or equal to the other's.
+       */
+      bool operator>=(Omp const& o) const
+      {
+        return (get_id() >= o.get_id());
+      }
+
       size_t get_id() const {
         constexpr size_t omp_type = 3ULL << 32;
         size_t stream_hash = std::hash<void*>{}(static_cast<void*>(addr));

--- a/include/camp/resource/sycl.hpp
+++ b/include/camp/resource/sycl.hpp
@@ -328,7 +328,7 @@ namespace std {
   template <>
   struct hash<camp::resources::Sycl> {
     std::size_t operator()(const camp::resources::Sycl& s) const {
-      return std::hash<size_t>{}(s.get_hash());
+      return s.get_hash();
     }
   };
 }

--- a/include/camp/resource/sycl.hpp
+++ b/include/camp/resource/sycl.hpp
@@ -302,6 +302,46 @@ private:
         return !(*this == s);
       }
 
+      /*
+       * \brief Less-than comparison operator.
+       *
+       * \return True if this resource's ID is less than the other's.
+       */
+      bool operator<(Sycl const& s) const
+      {
+        return (get_id() < s.get_id());
+      }
+
+      /*
+       * \brief Greater-than comparison operator.
+       *
+       * \return True if this resource's ID is greater than the other's.
+       */
+      bool operator>(Sycl const& s) const
+      {
+        return (get_id() > s.get_id());
+      }
+
+      /*
+       * \brief Less-than-or-equal comparison operator.
+       *
+       * \return True if this resource's ID is less than or equal to the other's.
+       */
+      bool operator<=(Sycl const& s) const
+      {
+        return (get_id() <= s.get_id());
+      }
+
+      /*
+       * \brief Greater-than-or-equal comparison operator.
+       *
+       * \return True if this resource's ID is greater than or equal to the other's.
+       */
+      bool operator>=(Sycl const& s) const
+      {
+        return (get_id() >= s.get_id());
+      }
+    
       size_t get_id() const {
         constexpr size_t sycl_type = 4ULL << 32;
         size_t stream_hash = std::hash<void*>{}(static_cast<void*>(qu));

--- a/include/camp/resource/sycl.hpp
+++ b/include/camp/resource/sycl.hpp
@@ -283,9 +283,9 @@ private:
       sycl::queue const *get_queue() const { return qu; }
 
       /*
-       * \brief Compares two (Sycl) resources to see if they are equal.
+       * \brief Compares two (Sycl) resources to see if they are equal
        *
-       * \return True or false depending on if this is the same id (hash of queue).
+       * \return True or false depending on if this is the same queue
        */
       bool operator==(Sycl const& s) const
       {
@@ -293,7 +293,7 @@ private:
       }
       
       /*
-       * \brief Compares two (Sycl) resources to see if they are NOT equal.
+       * \brief Compares two (Sycl) resources to see if they are NOT equal
        *
        * \return Negation of == operator
        */
@@ -317,12 +317,12 @@ private:
 }  // namespace camp
 
 /*
- * \brief Specialization of std::hash for camp::resources::Sycl.
+ * \brief Specialization of std::hash for camp::resources::Sycl
  * 
  * Provides a hash function for Sycl typed resource objects, enabling their use as keys
- * in unordered associative containers (std::unordered_map, std::unordered_set, etc.).
+ * in unordered associative containers (std::unordered_map, std::unordered_set, etc.)
  * 
- * \return A size_t hash value computed from the Sycl typed resource's internal ID.
+ * \return A size_t hash value
  */
 namespace std {
   template <>

--- a/include/camp/resource/sycl.hpp
+++ b/include/camp/resource/sycl.hpp
@@ -289,7 +289,7 @@ private:
        */
       bool operator==(Sycl const& s) const
       {
-        return (get_id() == s.get_id());
+        return (get_hash() == s.get_hash());
       }
       
       /*
@@ -302,7 +302,7 @@ private:
         return !(*this == s);
       }
 
-      size_t get_id() const {
+      size_t get_hash() const {
         constexpr size_t sycl_type = 4ULL << 32;
         size_t stream_hash = std::hash<void*>{}(static_cast<void*>(qu));
         return sycl_type | (stream_hash & 0xFFFFFFFF);
@@ -328,7 +328,7 @@ namespace std {
   template <>
   struct hash<camp::resources::Sycl> {
     std::size_t operator()(const camp::resources::Sycl& s) const {
-      return std::hash<size_t>{}(s.get_id());
+      return std::hash<size_t>{}(s.get_hash());
     }
   };
 }

--- a/include/camp/resource/sycl.hpp
+++ b/include/camp/resource/sycl.hpp
@@ -303,8 +303,6 @@ private:
       }
 
       /*
-       * \brief Less-than comparison operator.
-       *
        * \return True if this resource's ID is less than the other's.
        */
       bool operator<(Sycl const& s) const
@@ -313,8 +311,6 @@ private:
       }
 
       /*
-       * \brief Greater-than comparison operator.
-       *
        * \return True if this resource's ID is greater than the other's.
        */
       bool operator>(Sycl const& s) const
@@ -323,8 +319,6 @@ private:
       }
 
       /*
-       * \brief Less-than-or-equal comparison operator.
-       *
        * \return True if this resource's ID is less than or equal to the other's.
        */
       bool operator<=(Sycl const& s) const
@@ -333,8 +327,6 @@ private:
       }
 
       /*
-       * \brief Greater-than-or-equal comparison operator.
-       *
        * \return True if this resource's ID is greater than or equal to the other's.
        */
       bool operator>=(Sycl const& s) const

--- a/include/camp/resource/sycl.hpp
+++ b/include/camp/resource/sycl.hpp
@@ -303,7 +303,7 @@ private:
       }
 
       size_t get_hash() const {
-        constexpr size_t sycl_type = 4ULL << 32;
+        const size_t sycl_type = size_t(get_platform()) << 32;
         size_t stream_hash = std::hash<void*>{}(static_cast<void*>(qu));
         return sycl_type | (stream_hash & 0xFFFFFFFF);
       }

--- a/include/camp/resource/sycl.hpp
+++ b/include/camp/resource/sycl.hpp
@@ -285,11 +285,11 @@ private:
       /*
        * \brief Compares two (Sycl) resources to see if they are equal.
        *
-       * \return True or false depending on if this is the same queue.
+       * \return True or false depending on if this is the same id (hash of queue).
        */
       bool operator==(Sycl const& s) const
       {
-        return (get_queue() == s.get_queue());
+        return (get_id() == s.get_id());
       }
       
       /*
@@ -302,38 +302,6 @@ private:
         return !(*this == s);
       }
 
-      /*
-       * \return True if this resource's ID is less than the other's.
-       */
-      bool operator<(Sycl const& s) const
-      {
-        return (get_id() < s.get_id());
-      }
-
-      /*
-       * \return True if this resource's ID is greater than the other's.
-       */
-      bool operator>(Sycl const& s) const
-      {
-        return (get_id() > s.get_id());
-      }
-
-      /*
-       * \return True if this resource's ID is less than or equal to the other's.
-       */
-      bool operator<=(Sycl const& s) const
-      {
-        return (get_id() <= s.get_id());
-      }
-
-      /*
-       * \return True if this resource's ID is greater than or equal to the other's.
-       */
-      bool operator>=(Sycl const& s) const
-      {
-        return (get_id() >= s.get_id());
-      }
-    
       size_t get_id() const {
         constexpr size_t sycl_type = 4ULL << 32;
         size_t stream_hash = std::hash<void*>{}(static_cast<void*>(qu));

--- a/include/camp/resource/sycl.hpp
+++ b/include/camp/resource/sycl.hpp
@@ -304,7 +304,7 @@ private:
 
       size_t get_id() const {
         constexpr size_t sycl_type = 4ULL << 32;
-        size_t stream_hash = std::hash<void*>{}(static_cast<void*>(stream));
+        size_t stream_hash = std::hash<void*>{}(static_cast<void*>(qu));
         return sycl_type | (stream_hash & 0xFFFFFFFF);
       }
 

--- a/include/camp/resource/sycl.hpp
+++ b/include/camp/resource/sycl.hpp
@@ -302,6 +302,12 @@ private:
         return !(*this == s);
       }
 
+      size_t get_id() const {
+        constexpr size_t sycl_type = 4ULL << 32;
+        size_t stream_hash = std::hash<void*>{}(static_cast<void*>(stream));
+        return sycl_type | (stream_hash & 0xFFFFFFFF);
+      }
+
     private:
       sycl::queue *qu;
     };

--- a/include/camp/resource/sycl.hpp
+++ b/include/camp/resource/sycl.hpp
@@ -315,6 +315,23 @@ private:
   }  // namespace v1
 }  // namespace resources
 }  // namespace camp
+
+/*
+ * \brief Specialization of std::hash for camp::resources::Sycl.
+ * 
+ * Provides a hash function for Sycl typed resource objects, enabling their use as keys
+ * in unordered associative containers (std::unordered_map, std::unordered_set, etc.).
+ * 
+ * \return A size_t hash value computed from the Sycl typed resource's internal ID.
+ */
+namespace std {
+  template <>
+  struct hash<camp::resources::Sycl> {
+    std::size_t operator()(const camp::resources::Sycl& s) const {
+      return std::hash<size_t>{}(s.get_id());
+    }
+  };
+}
 #endif  //#ifdef CAMP_ENABLE_SYCL
 
 #endif /* __CAMP_SYCL_HPP */

--- a/include/camp/resource/sycl.hpp
+++ b/include/camp/resource/sycl.hpp
@@ -289,7 +289,7 @@ private:
        */
       bool operator==(Sycl const& s) const
       {
-        return (get_hash() == s.get_hash());
+        return (get_queue() == s.get_queue());
       }
       
       /*

--- a/test/resource.cpp
+++ b/test/resource.cpp
@@ -203,6 +203,58 @@ TEST(CampResource, Compare)
 }
 
 template < typename Res >
+void test_get_id(Resource& h1, size_t TYPE_ID)
+{
+  Resource r1{Res()};
+  Res r; Resource r2{r};
+  Resource r3{Res()};
+
+  EXPECT_NE(r1.get_id(), r2.get_id());
+  EXPECT_NE(r2.get_id(), r1.get_id());
+  EXPECT_NE(r3.get_id(), r1.get_id());
+  EXPECT_NE(r2.get_id(), r3.get_id());
+  EXPECT_NE(r1.get_id(), 0);
+  EXPECT_NE(r2.get_id(), 0);
+  EXPECT_NE(r3.get_id(), 0);
+  EXPECT_NE(r1.get_id(), h1.get_id());
+  EXPECT_NE(r2.get_id(), h1.get_id());
+  EXPECT_NE(r3.get_id(), h1.get_id());
+
+  EXPECT_EQ(r1.get_id(), r1.get_id());
+  EXPECT_EQ(r2.get_id(), r2.get_id());
+  EXPECT_EQ(r3.get_id(), r3.get_id());
+
+  EXPECT_EQ((r1.get_id() & (0xFFFFFFFFULL << 32)), TYPE_ID);
+  EXPECT_EQ((r2.get_id() & (0xFFFFFFFFULL << 32)), TYPE_ID);
+  EXPECT_EQ((r3.get_id() & (0xFFFFFFFFULL << 32)), TYPE_ID);
+}
+//
+TEST(CampResource, GetID)
+{
+  Resource h1{Host()};
+  Host h; Resource h2{h};
+
+  EXPECT_EQ(h1.get_id(), h1.get_id());
+  EXPECT_EQ(h2.get_id(), h2.get_id());
+  EXPECT_EQ(h1.get_id(), h2.get_id());
+  EXPECT_EQ(h1.get_id(), 0);
+  EXPECT_EQ(h2.get_id(), 0);
+
+#ifdef CAMP_HAVE_CUDA
+  test_get_id<Cuda>(h1, (1ULL << 32));
+#endif
+#ifdef CAMP_HAVE_HIP
+  test_get_id<Hip>(h1, (2ULL << 32));
+#endif
+#ifdef CAMP_HAVE_OMP_OFFLOAD
+  test_get_id<Omp>(h1, (3ULL << 32));
+#endif
+#ifdef CAMP_HAVE_SYCL
+  test_get_id<Sycl>(h1, (4ULL << 32));
+#endif
+}
+
+template < typename Res >
 void test_reassignment()
 {
   Resource h1{Host()};

--- a/test/resource.cpp
+++ b/test/resource.cpp
@@ -147,10 +147,13 @@ TEST(CampResource, GetPlatform)
 }
 
 template < typename Res >
-void test_compare(Resource& h1)
+void test_id_compare(Resource& h1)
 {
   Resource r1{Res()};
   Res r; Resource r2{r};
+  Resource r3{Res(0)}; //should be same as r1
+
+  EXPECT_EQ(r1, r3);
 
   ASSERT_TRUE(r1 == r1);
   ASSERT_TRUE(r2 == r2);
@@ -189,67 +192,16 @@ TEST(CampResource, Compare)
   ASSERT_FALSE(h != h);
 
 #ifdef CAMP_HAVE_CUDA
-  test_compare<Cuda>(h1);
+  test_id_compare<Cuda>(h1);
 #endif
 #ifdef CAMP_HAVE_HIP
-  test_compare<Hip>(h1);
+  test_id_compare<Hip>(h1);
 #endif
 #ifdef CAMP_HAVE_OMP_OFFLOAD
-  test_compare<Omp>(h1);
+  test_id_compare<Omp>(h1);
 #endif
 #ifdef CAMP_HAVE_SYCL
-  test_compare<Sycl>(h1);
-#endif
-}
-
-template < typename Res >
-void test_get_id(Resource& h1, size_t TYPE_ID)
-{
-  Resource r1{Res()};
-  Res r; Resource r2{r};
-  Resource r3{Res()};
-  Resource r4{Res(0)}; //should be same as r1
-
-  EXPECT_EQ(r1.get_id(), r4.get_id());
-
-  EXPECT_NE(r1.get_id(), r2.get_id());
-  EXPECT_NE(r2.get_id(), r1.get_id());
-  EXPECT_NE(r3.get_id(), r1.get_id());
-  EXPECT_NE(r2.get_id(), r3.get_id());
-  EXPECT_NE(r1.get_id(), 0);
-  EXPECT_NE(r2.get_id(), 0);
-  EXPECT_NE(r3.get_id(), 0);
-  EXPECT_NE(r1.get_id(), h1.get_id());
-  EXPECT_NE(r2.get_id(), h1.get_id());
-  EXPECT_NE(r3.get_id(), h1.get_id());
-
-  EXPECT_EQ(r1.get_id(), r1.get_id());
-  EXPECT_EQ(r2.get_id(), r2.get_id());
-  EXPECT_EQ(r3.get_id(), r3.get_id());
-}
-//
-TEST(CampResource, GetID)
-{
-  Resource h1{Host()};
-  Host h; Resource h2{h};
-
-  EXPECT_EQ(h1.get_id(), h1.get_id());
-  EXPECT_EQ(h2.get_id(), h2.get_id());
-  EXPECT_EQ(h1.get_id(), h2.get_id());
-  EXPECT_EQ(h1.get_id(), 0);
-  EXPECT_EQ(h2.get_id(), 0);
-
-#ifdef CAMP_HAVE_CUDA
-  test_get_id<Cuda>(h1, (1ULL << 32));
-#endif
-#ifdef CAMP_HAVE_HIP
-  test_get_id<Hip>(h1, (2ULL << 32));
-#endif
-#ifdef CAMP_HAVE_OMP_OFFLOAD
-  test_get_id<Omp>(h1, (3ULL << 32));
-#endif
-#ifdef CAMP_HAVE_SYCL
-  test_get_id<Sycl>(h1, (4ULL << 32));
+  test_id_compare<Sycl>(h1);
 #endif
 }
 

--- a/test/resource.cpp
+++ b/test/resource.cpp
@@ -275,6 +275,19 @@ TEST(CampResource, Compare)
 #endif
 }
 
+TEST(CampResource, HostCompare)
+{
+  Host h1; Resource h2{h1};
+  Resource h3{Host().get_default()};
+
+  ASSERT_TRUE(Resource{h1} == h2);
+  ASSERT_TRUE(Resource{h1} == h3);
+  ASSERT_TRUE(h2 == h1);
+  ASSERT_TRUE(h2 == h3);
+  ASSERT_TRUE(h3 == h1);
+  ASSERT_TRUE(h3 == h2);
+}
+
 template < typename Res >
 void test_reassignment()
 {

--- a/test/resource.cpp
+++ b/test/resource.cpp
@@ -173,7 +173,7 @@ void test_map_key(Resource& h)
   rmap.insert({r2, 40}); rmultimap.insert({r2, 40});
   rmap.insert({r2, 50}); rmultimap.insert({r2, 50});
 
-  // Verify we can use Resource as a key to find entries
+  // Verify using Resource as a key to find entries works
   // Generic
   ASSERT_EQ(map.count(h), 1); ASSERT_EQ(multimap.count(h), 2);
   ASSERT_EQ(map.count(d1), 1); ASSERT_EQ(multimap.count(d1), 1);
@@ -183,7 +183,7 @@ void test_map_key(Resource& h)
   ASSERT_EQ(rmap.count(r1), 1); ASSERT_EQ(rmultimap.count(r1), 1);
   ASSERT_EQ(rmap.count(r2), 1); ASSERT_EQ(rmultimap.count(r2), 2);
 
-  // Verify equal_range works (critical for your PendingMap usage)
+  // Verify equal_range works
   // Generic
   auto range = map.equal_range(h);
   auto range2 = multimap.equal_range(d2);
@@ -194,7 +194,7 @@ void test_map_key(Resource& h)
   auto rrange2 = rmultimap.equal_range(r2);
   ASSERT_EQ(std::distance(rrange2.first, rrange2.second), 2);
 }
-
+//
 TEST(CampResource, UnorderedMapKey)
 {
 #if !defined(CAMP_HAVE_CUDA) && !defined(CAMP_HAVE_HIP) && !defined(CAMP_HAVE_OMP_OFFLOAD) && !defined(CAMP_HAVE_SYCL)

--- a/test/resource.cpp
+++ b/test/resource.cpp
@@ -223,10 +223,6 @@ void test_get_id(Resource& h1, size_t TYPE_ID)
   EXPECT_EQ(r1.get_id(), r1.get_id());
   EXPECT_EQ(r2.get_id(), r2.get_id());
   EXPECT_EQ(r3.get_id(), r3.get_id());
-
-  EXPECT_EQ((r1.get_id() & (0xFFFFFFFFULL << 32)), TYPE_ID);
-  EXPECT_EQ((r2.get_id() & (0xFFFFFFFFULL << 32)), TYPE_ID);
-  EXPECT_EQ((r3.get_id() & (0xFFFFFFFFULL << 32)), TYPE_ID);
 }
 //
 TEST(CampResource, GetID)

--- a/test/resource.cpp
+++ b/test/resource.cpp
@@ -208,6 +208,9 @@ void test_get_id(Resource& h1, size_t TYPE_ID)
   Resource r1{Res()};
   Res r; Resource r2{r};
   Resource r3{Res()};
+  Resource r4{Res(0)}; //should be same as r1
+
+  EXPECT_EQ(r1.get_id(), r4.get_id());
 
   EXPECT_NE(r1.get_id(), r2.get_id());
   EXPECT_NE(r2.get_id(), r1.get_id());

--- a/test/resource.cpp
+++ b/test/resource.cpp
@@ -148,6 +148,10 @@ TEST(CampResource, GetPlatform)
 
 TEST(CampResource, UnorderedMapKey)
 {
+#if !defined(CAMP_HAVE_CUDA) && !defined(CAMP_HAVE_HIP) && !defined(CAMP_HAVE_OMP_OFFLOAD) && !defined(CAMP_HAVE_SYCL)
+  // If only the Host is enabled, it doesn't make sense to use a map
+  GTEST_SKIP() << "No device backend available (CUDA/HIP/OMP/SYCL)";
+#else
   std::unordered_map<Resource, size_t> map;
   std::unordered_multimap<Resource, size_t> mmap;
 
@@ -164,9 +168,6 @@ TEST(CampResource, UnorderedMapKey)
 #elif defined(CAMP_HAVE_SYCL)
   Resource d1{Sycl()};
   Resource d2{Sycl()};
-#else
-  // If only the Host is enabled, it doesn't make sense to use a map
-  GTEST_SKIP() << "No device backend available (CUDA/HIP/OMP/SYCL)";
 #endif
   
   map.insert({h, 10}); mmap.insert({h, 10});
@@ -185,6 +186,7 @@ TEST(CampResource, UnorderedMapKey)
   auto range2 = mmap.equal_range(d2);
   ASSERT_EQ(std::distance(range.first, range.second), 1);
   ASSERT_EQ(std::distance(range2.first, range2.second), 2);
+#endif
 }
 
 template < typename Res >

--- a/test/resource.cpp
+++ b/test/resource.cpp
@@ -152,21 +152,21 @@ TEST(CampResource, UnorderedMapKey)
   std::unordered_multimap<Resource, size_t> mmap;
 
   Resource h{Host()};
-#ifdef CAMP_HAVE_CUDA
+#if defined(CAMP_HAVE_CUDA)
   Resource d1{Cuda()};
   Resource d2{Cuda()};
-#endif
-#ifdef CAMP_HAVE_HIP
+#elif defined(CAMP_HAVE_HIP)
   Resource d1{Hip()};
   Resource d2{Hip()};
-#endif
-#ifdef CAMP_HAVE_OMP_OFFLOAD
+#elif defined(CAMP_HAVE_OMP_OFFLOAD)
   Resource d1{Omp()};
   Resource d2{Omp()};
-#endif
-#ifdef CAMP_HAVE_SYCL
+#elif defined(CAMP_HAVE_SYCL)
   Resource d1{Sycl()};
   Resource d2{Sycl()};
+#else
+  // If only the Host is enabled, it doesn't make sense to use a map
+  GTEST_SKIP() << "No device backend available (CUDA/HIP/OMP/SYCL)";
 #endif
   
   map.insert({h, 10}); mmap.insert({h, 10});


### PR DESCRIPTION
In an effort to give Umpire a way to hash Resources for an unordered multimap, I'd like to give Camp Resources a unique hash. Since all Host resources are the same, they just return zero. However cuda/hip/omp/sycl resources will return a (non-zero) unique hash.