### PR TITLE
add tuple_size to camp::array

### DIFF
--- a/include/camp/array.hpp
+++ b/include/camp/array.hpp
@@ -31,7 +31,6 @@
 
 namespace camp
 {
-
 ///
 /// Provides a portable std::array-like class.
 ///

--- a/include/camp/array.hpp
+++ b/include/camp/array.hpp
@@ -22,8 +22,8 @@
 
 #include <cstddef>
 #include <stdexcept>
-#include <tuple>
 #include <type_traits>
+#include <utility>
 
 #include "camp/defines.hpp"
 #include "camp/helpers.hpp"

--- a/include/camp/array.hpp
+++ b/include/camp/array.hpp
@@ -22,6 +22,7 @@
 
 #include <cstddef>
 #include <stdexcept>
+#include <tuple>
 #include <type_traits>
 
 #include "camp/defines.hpp"
@@ -30,8 +31,6 @@
 
 namespace camp
 {
-template <typename Tuple>
-struct tuple_size;
 
 ///
 /// Provides a portable std::array-like class.
@@ -286,10 +285,6 @@ CAMP_HOST_DEVICE constexpr void swap(array<T, N>& a, array<T, N>& b) noexcept(
 {
   a.swap(b);
 }
-
-template <typename T, size_t N>
-struct tuple_size<array<T, N>> : ::camp::num<N> {
-};
 
 namespace detail
 {

--- a/include/camp/array.hpp
+++ b/include/camp/array.hpp
@@ -30,6 +30,9 @@
 
 namespace camp
 {
+template <typename Tuple>
+struct tuple_size;
+
 ///
 /// Provides a portable std::array-like class.
 ///
@@ -283,6 +286,10 @@ CAMP_HOST_DEVICE constexpr void swap(array<T, N>& a, array<T, N>& b) noexcept(
 {
   a.swap(b);
 }
+
+template <typename T, size_t N>
+struct tuple_size<array<T, N>> : ::camp::num<N> {
+};
 
 namespace detail
 {

--- a/include/camp/tuple.hpp
+++ b/include/camp/tuple.hpp
@@ -17,6 +17,7 @@
 #include <sstream>
 #include <type_traits>
 
+#include "camp/array.hpp"
 #include "camp/concepts.hpp"
 #include "camp/map.hpp"
 
@@ -50,6 +51,10 @@ using tuple_ebt_t =
 
 template <typename... Args>
 struct tuple_size<tuple<Args...>> : ::camp::num<sizeof...(Args)> {
+};
+
+template <typename T, size_t N>
+struct tuple_size<array<T, N>> : ::camp::num<N> {
 };
 
 template <typename L, typename... Args>

--- a/include/camp/tuple.hpp
+++ b/include/camp/tuple.hpp
@@ -20,7 +20,6 @@
 #include <tuple>
 #include <type_traits>
 
-#include "camp/array.hpp"
 #include "camp/concepts.hpp"
 #include "camp/map.hpp"
 

--- a/include/camp/tuple.hpp
+++ b/include/camp/tuple.hpp
@@ -774,7 +774,7 @@ struct tuple_size<camp::tuple<T...>> {
 
 template <size_t i, typename... T>
 struct tuple_element<i, camp::tuple<T...>> {
-  using type = ::camp::tuple_element_t<i, camp::tuple<T...>>;
+  using type = camp::at_v<typename camp::tuple<T...>::TList, i>;
 };
 
 /// This allows structured bindings to be used with camp::tagged_tuple
@@ -789,8 +789,7 @@ struct tuple_size<camp::tagged_tuple<TagList, Elements...>> {
 
 template <size_t i, typename TagList, typename... Elements>
 struct tuple_element<i, camp::tagged_tuple<TagList, Elements...>> {
-  using type =
-      ::camp::tuple_element_t<i, camp::tagged_tuple<TagList, Elements...>>;
+  using type = camp::at_v<typename camp::tagged_tuple<TagList, Elements...>::TList, i>;
 };
 }  // namespace std
 

--- a/include/camp/tuple.hpp
+++ b/include/camp/tuple.hpp
@@ -17,6 +17,7 @@
  */
 
 #include <sstream>
+#include <tuple>
 #include <type_traits>
 
 #include "camp/array.hpp"
@@ -36,40 +37,18 @@ template <template <typename... Ts> class Tup>
 using is_tuple = typename std::is_base_of<tuple<>, Tup<>>::type;
 
 template <typename Tuple>
-struct tuple_size;
+using tuple_size = std::tuple_size<Tuple>;
 
-template <camp::idx_t i, typename T>
-struct tuple_element {
-  using type = camp::at_v<typename T::TList, i>;
-};
+template <camp::idx_t i, typename Tuple>
+using tuple_element = std::tuple_element<i, Tuple>;
 
-template <camp::idx_t i, typename T>
-using tuple_element_t = typename tuple_element<i, T>::type;
+template <camp::idx_t i, typename Tuple>
+using tuple_element_t = typename tuple_element<i, Tuple>::type;
 
 template <typename T, typename Tuple>
 using tuple_ebt_t =
     typename tuple_element<camp::at_key<typename Tuple::TMap, T>::value,
                            Tuple>::type;
-
-template <typename... Args>
-struct tuple_size<tuple<Args...>> : ::camp::num<sizeof...(Args)> {
-};
-
-template <typename L, typename... Args>
-struct tuple_size<tagged_tuple<L, Args...>> : ::camp::num<sizeof...(Args)> {
-};
-
-template <typename T>
-struct tuple_size<const T> : num<tuple_size<T>::value> {
-};
-
-template <typename T>
-struct tuple_size<volatile T> : num<tuple_size<T>::value> {
-};
-
-template <typename T>
-struct tuple_size<const volatile T> : num<tuple_size<T>::value> {
-};
 
 namespace internal
 {

--- a/include/camp/tuple.hpp
+++ b/include/camp/tuple.hpp
@@ -19,6 +19,7 @@
 #include <sstream>
 #include <type_traits>
 
+#include "camp/array.hpp"
 #include "camp/concepts.hpp"
 #include "camp/map.hpp"
 
@@ -52,6 +53,10 @@ using tuple_ebt_t =
 
 template <typename... Args>
 struct tuple_size<tuple<Args...>> : ::camp::num<sizeof...(Args)> {
+};
+
+template <typename T, size_t N>
+struct tuple_size<array<T, N>> : ::camp::num<N> {
 };
 
 template <typename L, typename... Args>

--- a/include/camp/tuple.hpp
+++ b/include/camp/tuple.hpp
@@ -55,10 +55,6 @@ template <typename... Args>
 struct tuple_size<tuple<Args...>> : ::camp::num<sizeof...(Args)> {
 };
 
-template <typename T, size_t N>
-struct tuple_size<array<T, N>> : ::camp::num<N> {
-};
-
 template <typename L, typename... Args>
 struct tuple_size<tagged_tuple<L, Args...>> : ::camp::num<sizeof...(Args)> {
 };

--- a/include/camp/tuple.hpp
+++ b/include/camp/tuple.hpp
@@ -17,8 +17,8 @@
  */
 
 #include <sstream>
-#include <tuple>
 #include <type_traits>
+#include <utility>
 
 #include "camp/concepts.hpp"
 #include "camp/map.hpp"

--- a/test/array.cpp
+++ b/test/array.cpp
@@ -8,6 +8,7 @@
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 
 #include "camp/array.hpp"
+#include "camp/tuple.hpp"
 
 #include "Test.hpp"
 #include "gtest/gtest.h"
@@ -363,6 +364,20 @@ CAMP_TEST_BEGIN(array, tuple_element)
 CAMP_TEST_END(array, tuple_element)
 
 #if defined(__cplusplus) && __cplusplus >= 201703L
+
+CAMP_TEST_BEGIN(array, apply)
+{
+  camp::array<int, 2> a{-1, 1};
+  int a0 = 0;
+  int a1 = 0;
+  camp::apply([&](int i0, int i1){
+    a0 = i0;
+    a1 = i1;
+  }, a);
+
+  return a0 == -1 && a1 == 1 && a[0] == -1 && a[1] == 1;
+}
+CAMP_TEST_END(array, apply)
 
 CAMP_TEST_BEGIN(array, structured_binding)
 {


### PR DESCRIPTION
Add tuple_size to camp::array.  This is needed in order to use camp::apply on arrays.