### PR TITLE
Feature/smith84/cuda 13 support

### DIFF
--- a/include/camp/helpers.hpp
+++ b/include/camp/helpers.hpp
@@ -300,7 +300,7 @@ namespace experimental
   // 13 cudaMemLocation it is a struct.
 
   //! Convert CUDA cudaMemLocationType to string
-  inline const char* to_string(cudaMemLocationType t)
+  constexpr std::string_view to_string(cudaMemLocationType t)
   {
     switch (t) {
       case cudaMemLocationTypeInvalid:
@@ -320,11 +320,11 @@ namespace experimental
   inline std::ostream& print_cudaMemLocation(std::ostream& os,
 					     const cudaMemLocation& loc)
   {
-    os << "{" <<  to_string(loc.type) << "," << loc.id << "}";
+    os << "{" <<  to_string(loc.type) << ", " << loc.id << "}";
     return os;
   }
 
-  //! Specialization for printing of cudaMemLocation&
+  //! Specialization for printing cudaMemLocation&
   //
   // Invoking CUDA methods via CAMP_CUDA_API_INVOKE_AND_CHECK() may
   // have cudaMemLocation arguments which require I/O for error

--- a/include/camp/helpers.hpp
+++ b/include/camp/helpers.hpp
@@ -304,13 +304,13 @@ namespace experimental
   {
     switch (t) {
       case cudaMemLocationTypeInvalid:
-	return "Invalid";
+	return "cudaMemLocationTypeInvalid";
       case cudaMemLocationTypeDevice:
-	return "Device";
+	return "cudaMemLocationTypeDevice";
       case cudaMemLocationTypeHost:
-	return "Host";
+	return "cudaMemLocationTypeHost";
       case cudaMemLocationTypeHostNuma:
-	return "HostNuma";
+	return "cudaMemLocationTypeHostNuma";
       default:
 	return "Unknown";
     }
@@ -320,8 +320,7 @@ namespace experimental
   inline std::ostream& print_cudaMemLocation(std::ostream& os,
 					     const cudaMemLocation& loc)
   {
-    os << "cudaMemLocation{type=" << to_string(loc.type)
-       << ", id=" << loc.id << "}";
+    os << "{" <<  to_string(loc.type) << "," << loc.id << "}";
     return os;
   }
 

--- a/include/camp/helpers.hpp
+++ b/include/camp/helpers.hpp
@@ -288,11 +288,25 @@ namespace experimental
   }
 
 
+
 #ifdef CAMP_ENABLE_CUDA
+  
+// SGS Question should the specialization for CUDA 13 cudaMemLocation printing be here?
+// SGS Question Is camp requiring C++20 as well so use "requires std::is_same_v()" simplify non-const / const specialization?
+//  template <typename T>
+//  struct StreamInsertHelper<T&>
+//  requires std::is_same_v<std::remove_cv_t<T>, cudaMemLocation>
+//  {
+//    T& m_val;
+//
+//    std::ostream& operator()(std::ostream& str) const {
+//      return print_cudaMemLocation(str, m_val);
+//    }
+//  };
 
 #if CUDART_VERSION >= 13000
 
-  //! Convert CUDA (cudaMemLocationTypes to string
+  //! Convert CUDA cudaMemLocationType to string
   inline const char* to_string(cudaMemLocationType t)
   {
     switch (t) {
@@ -318,24 +332,10 @@ namespace experimental
     return os;
   }
 
-#if __cplusplus >= 202002L
-  // SGS RAJA is moving to 2020, is CAMP requiring 2020 as well?
-
-  // Specialization for cudaMemLocation
-  // CUDA does not supply an operator<< for cudaMemLocation
-  // Special the StreamInsertHelper rather than operator<< to avoid polluting std namespace.
-  template <typename T>
-  struct StreamInsertHelper<T&>
-  requires std::is_same_v<std::remove_cv_t<T>, cudaMemLocation>
-  {
-    T& m_val;
-
-    std::ostream& operator()(std::ostream& str) const {
-      return print_cudaMemLocation(str, m_val);
-    }
-  };
-#else
-  // Specialization for non-const cudaMemLocation&
+  //! Specialization for printing of cudaMemLocation&
+  //
+  // CUDA does not supply an operator<< for cudaMemLocation.
+  // Specialize the StreamInsertHelper rather than operator<< to avoid conflicts.
   template <>
   struct StreamInsertHelper<cudaMemLocation&> {
     cudaMemLocation& m_val;
@@ -345,7 +345,10 @@ namespace experimental
     }
   };
 
-  // Specialization for const cudaMemLocation&
+  //! Specialization for printing of const cudaMemLocation&
+  //
+  // CUDA does not supply an operator<< for cudaMemLocation.
+  // Specialize the StreamInsertHelper rather than operator<< to avoid conflicts.
   template <>
   struct StreamInsertHelper<const cudaMemLocation&> {
     const cudaMemLocation& m_val;
@@ -354,8 +357,6 @@ namespace experimental
       return print_cudaMemLocation(str, m_val);
     }
   };
-#endif // __cplusplus >= 202002L
-
 #endif // CUDART_VERSION >= 13000
 
   //! Get the argument names for the given cuda API function name.

--- a/include/camp/helpers.hpp
+++ b/include/camp/helpers.hpp
@@ -290,6 +290,74 @@ namespace experimental
 
 #ifdef CAMP_ENABLE_CUDA
 
+#if CUDART_VERSION >= 13000
+
+  //! Convert CUDA (cudaMemLocationTypes to string
+  inline const char* to_string(cudaMemLocationType t)
+  {
+    switch (t) {
+      case cudaMemLocationTypeInvalid:
+	return "Invalid";
+      case cudaMemLocationTypeDevice:
+	return "Device";
+      case cudaMemLocationTypeHost:
+	return "Host";
+      case cudaMemLocationTypeHostNuma:
+	return "HostNuma";
+      default:
+	return "Unknown";
+    }
+  }
+
+  //! Print helper for cudaMemLocation
+  inline std::ostream& print_cudaMemLocation(std::ostream& os,
+					     const cudaMemLocation& loc)
+  {
+    os << "cudaMemLocation{type=" << to_string(loc.type)
+       << ", id=" << loc.id << "}";
+    return os;
+  }
+
+#if __cplusplus >= 202002L
+  // SGS RAJA is moving to 2020, is CAMP requiring 2020 as well?
+
+  // Specialization for cudaMemLocation
+  // CUDA does not supply an operator<< for cudaMemLocation
+  // Special the StreamInsertHelper rather than operator<< to avoid polluting std namespace.
+  template <typename T>
+  struct StreamInsertHelper<T&>
+  requires std::is_same_v<std::remove_cv_t<T>, cudaMemLocation>
+  {
+    T& m_val;
+
+    std::ostream& operator()(std::ostream& str) const {
+      return print_cudaMemLocation(str, m_val);
+    }
+  };
+#else
+  // Specialization for non-const cudaMemLocation&
+  template <>
+  struct StreamInsertHelper<cudaMemLocation&> {
+    cudaMemLocation& m_val;
+
+    std::ostream& operator()(std::ostream& str) const {
+      return print_cudaMemLocation(str, m_val);
+    }
+  };
+
+  // Specialization for const cudaMemLocation&
+  template <>
+  struct StreamInsertHelper<const cudaMemLocation&> {
+    const cudaMemLocation& m_val;
+
+    std::ostream& operator()(std::ostream& str) const {
+      return print_cudaMemLocation(str, m_val);
+    }
+  };
+#endif // __cplusplus >= 202002L
+
+#endif // CUDART_VERSION >= 13000
+
   //! Get the argument names for the given cuda API function name.
   //
   //  Returns a space separated string of the arguments to the given function.

--- a/include/camp/helpers.hpp
+++ b/include/camp/helpers.hpp
@@ -291,8 +291,17 @@ namespace experimental
 
 #ifdef CAMP_ENABLE_CUDA
   
-// SGS Question should the specialization for CUDA 13 cudaMemLocation printing be here?
+// SGS Question should the specialization for CUDA 13 cudaMemLocation
+// I/O be in Camp?  And should the method be defined here?
+//  
+// Invoking CUDA methods via CAMP_CUDA_API_INVOKE_AND_CHECK() may have
+// cudaMemLocation arguments which require I/O for error reporting
+// messages.  In CUDA < 13 these were simple enum values but in CUDA
+// 13 cudaMemLocation is a struct.
+//  
 // SGS Question Is camp requiring C++20 as well so use "requires std::is_same_v()" simplify non-const / const specialization?
+//  
+// Could simplify the two methods to be :  
 //  template <typename T>
 //  struct StreamInsertHelper<T&>
 //  requires std::is_same_v<std::remove_cv_t<T>, cudaMemLocation>
@@ -334,8 +343,11 @@ namespace experimental
 
   //! Specialization for printing of cudaMemLocation&
   //
-  // CUDA does not supply an operator<< for cudaMemLocation.
-  // Specialize the StreamInsertHelper rather than operator<< to avoid conflicts.
+  // Invoking CUDA methods via CAMP_CUDA_API_INVOKE_AND_CHECK() may
+  // have cudaMemLocation arguments which require I/O for error
+  // reporting messages.  CUDA does not supply an operator<< for
+  // cudaMemLocation.  Specialize the StreamInsertHelper rather than
+  // operator<< to avoid conflicts.
   template <>
   struct StreamInsertHelper<cudaMemLocation&> {
     cudaMemLocation& m_val;
@@ -347,8 +359,11 @@ namespace experimental
 
   //! Specialization for printing of const cudaMemLocation&
   //
-  // CUDA does not supply an operator<< for cudaMemLocation.
-  // Specialize the StreamInsertHelper rather than operator<< to avoid conflicts.
+  // Invoking CUDA methods via CAMP_CUDA_API_INVOKE_AND_CHECK() may
+  // have cudaMemLocation arguments which require I/O for error
+  // reporting messages.  CUDA does not supply an operator<< for
+  // cudaMemLocation.  Specialize the StreamInsertHelper rather than
+  // operator<< to avoid conflicts.
   template <>
   struct StreamInsertHelper<const cudaMemLocation&> {
     const cudaMemLocation& m_val;

--- a/include/camp/helpers.hpp
+++ b/include/camp/helpers.hpp
@@ -291,29 +291,13 @@ namespace experimental
 
 #ifdef CAMP_ENABLE_CUDA
   
-// SGS Question should the specialization for CUDA 13 cudaMemLocation
-// I/O be in Camp?  And should the method be defined here?
-//  
-// Invoking CUDA methods via CAMP_CUDA_API_INVOKE_AND_CHECK() may have
-// cudaMemLocation arguments which require I/O for error reporting
-// messages.  In CUDA < 13 these were simple enum values but in CUDA
-// 13 cudaMemLocation is a struct.
-//  
-// SGS Question Is camp requiring C++20 as well so use "requires std::is_same_v()" simplify non-const / const specialization?
-//  
-// Could simplify the two methods to be :  
-//  template <typename T>
-//  struct StreamInsertHelper<T&>
-//  requires std::is_same_v<std::remove_cv_t<T>, cudaMemLocation>
-//  {
-//    T& m_val;
-//
-//    std::ostream& operator()(std::ostream& str) const {
-//      return print_cudaMemLocation(str, m_val);
-//    }
-//  };
-
 #if CUDART_VERSION >= 13000
+  // Specialization of camp I/O for CUDA 13 cudaMemLocation.
+  //
+  // Invoking CUDA methods via CAMP_CUDA_API_INVOKE_AND_CHECK() may have
+  // cudaMemLocation arguments which require I/O for error reporting
+  // messages.  In CUDA < 13 these were simple int enum values but in CUDA
+  // 13 cudaMemLocation it is a struct.
 
   //! Convert CUDA cudaMemLocationType to string
   inline const char* to_string(cudaMemLocationType t)

--- a/include/camp/helpers.hpp
+++ b/include/camp/helpers.hpp
@@ -333,7 +333,7 @@ namespace experimental
   // operator<< to avoid conflicts.
   template <>
   struct StreamInsertHelper<cudaMemLocation&> {
-    cudaMemLocation& m_val;
+    const cudaMemLocation& m_val;
 
     std::ostream& operator()(std::ostream& str) const {
       return print_cudaMemLocation(str, m_val);


### PR DESCRIPTION
Specialization of camp I/O for CUDA 13 cudaMemLocation.

Invoking CUDA methods via CAMP_CUDA_API_INVOKE_AND_CHECK() may have cudaMemLocation arguments which require I/O for error reporting messages.  In CUDA < 13 these were simple int enum values but in CUDA  13 cudaMemLocation it is a struct.