### PR TITLE
Implement SyclEvent

### DIFF
--- a/include/camp/resource/sycl.hpp
+++ b/include/camp/resource/sycl.hpp
@@ -34,16 +34,28 @@ namespace resources
     class SyclEvent
     {
     public:
-      // TODO: make this actually work
-      SyclEvent(sycl::queue& CAMP_UNUSED_ARG(qu)) { m_event = sycl::event(); }
+      explicit SyclEvent(sycl::event e)
+        : m_event(std::move(e))
+      {}
+
+      // TODO: see what overhead an empty submit has
+      SyclEvent(sycl::queue& qu)
+        : m_event(qu.submit([&](::sycl::handler& CAMP_UNUSED_ARG(h)) {}))
+      {}
 
       SyclEvent(Sycl& res);
 
-      bool check() const { return true; }
+      bool check() const
+      {
+        return m_event.get_info<sycl::info::event::command_execution_status>()
+            == sycl::info::event_command_status::complete;
+      }
 
-      void wait() const { getSyclEvent_t().wait(); }
+      void wait() const { m_event.wait(); }
 
-      sycl::event getSyclEvent_t() const { return m_event; }
+      sycl::event& getSyclEvent_t() { return m_event; }
+
+      sycl::event const& getSyclEvent_t() const { return m_event; }
 
     private:
       sycl::event m_event;
@@ -356,7 +368,7 @@ namespace resources
 
     inline SyclEvent::SyclEvent(Sycl &res)
       : SyclEvent(res.get_queue())
-    { }
+    {}
 
   }  // namespace v1
 

--- a/include/camp/resource/sycl.hpp
+++ b/include/camp/resource/sycl.hpp
@@ -40,8 +40,12 @@ namespace resources
 
       // TODO: see what overhead an empty submit has
       SyclEvent(sycl::queue& qu)
-        : m_event(qu.submit([&](::sycl::handler& CAMP_UNUSED_ARG(h)) {}))
-      {}
+      {
+        if (!qu.is_in_order()) {
+          ::camp::throw_re("Queue is not in_order.");
+        }
+        m_event = qu.submit([&](::sycl::handler& CAMP_UNUSED_ARG(h)) {});
+      }
 
       SyclEvent(Sycl& res);
 

--- a/include/camp/resource/sycl.hpp
+++ b/include/camp/resource/sycl.hpp
@@ -277,7 +277,9 @@ namespace resources
       {
         auto* sycl_event = e->try_get<SyclEvent>();
         if (sycl_event) {
-          (sycl_event->getSyclEvent_t()).wait();
+          qu.submit([&](::sycl::handler& h) {
+            h.depends_on(sycl_event->getSyclEvent_t());
+          });
         } else {
           e->wait();
         }

--- a/include/camp/resource/sycl.hpp
+++ b/include/camp/resource/sycl.hpp
@@ -51,7 +51,7 @@ namespace resources
             == sycl::info::event_command_status::complete;
       }
 
-      void wait() const { m_event.wait(); }
+      void wait() const { sycl::event(m_event).wait(); }
 
       sycl::event& getSyclEvent_t() { return m_event; }
 

--- a/include/camp/resource/sycl.hpp
+++ b/include/camp/resource/sycl.hpp
@@ -55,14 +55,14 @@ namespace resources
             == sycl::info::event_command_status::complete;
       }
 
-      void wait() const { sycl::event(m_event).wait(); }
+      void wait() const { m_event.wait(); } // sycl::event::wait is non-const
 
       sycl::event& getSyclEvent_t() { return m_event; }
 
       sycl::event const& getSyclEvent_t() const { return m_event; }
 
     private:
-      sycl::event m_event;
+      mutable sycl::event m_event; // mutable as use non-const member function
     };
 
     class Sycl

--- a/test/resource.cpp
+++ b/test/resource.cpp
@@ -659,6 +659,63 @@ TEST(CampResource, Wait)
 }
 
 template <typename Res>
+void test_event_wait()
+{
+  auto r = Res();
+  const auto typed_event = r.get_event();
+  const Event event = r.get_event_erased();
+  typed_event.wait();
+  event.wait();
+}
+
+//
+TEST(CampEvent, Wait)
+{
+  test_event_wait<Host>();
+#ifdef CAMP_HAVE_CUDA
+  test_event_wait<Cuda>();
+#endif
+#ifdef CAMP_HAVE_HIP
+  test_event_wait<Hip>();
+#endif
+#ifdef CAMP_HAVE_OMP_OFFLOAD
+  test_event_wait<Omp>();
+#endif
+#ifdef CAMP_HAVE_SYCL
+  test_event_wait<Sycl>();
+#endif
+}
+
+template <typename Res>
+void test_event_check()
+{
+  auto r = Res();
+  const auto typed_event = r.get_event();
+  const Event event = r.get_event_erased();
+  // checking in a loop should always eventually return true
+  while (!typed_event.check()) {}
+  while (!event.check()) {}
+}
+
+//
+TEST(CampEvent, Check)
+{
+  test_event_check<Host>();
+#ifdef CAMP_HAVE_CUDA
+  test_event_check<Cuda>();
+#endif
+#ifdef CAMP_HAVE_HIP
+  test_event_check<Hip>();
+#endif
+#ifdef CAMP_HAVE_OMP_OFFLOAD
+  test_event_check<Omp>();
+#endif
+#ifdef CAMP_HAVE_SYCL
+  test_event_check<Sycl>();
+#endif
+}
+
+template <typename Res>
 void test_concrete_resource_trait()
 {
   ASSERT_TRUE(is_concrete_resource<Res>::value);


### PR DESCRIPTION
Add an implementation for `SyclEvent`.

This gets an event from the queue by calling submit but not actually submitting any work. Hopefully this gets an event without causing any significant overheads and is well defined behavior.

Note that this will not work for out of order queues. So now the `SyclEvent` constructor throws an exception if you try to create an event from an out of order queue. We only make in order queues due to our semantic guarantees, but someone could make a `Sycl` resource via `SyclFromQueue` from an out of order queue. 

Depends on #182 .