### PR TITLE
Event in Containers

### DIFF
--- a/include/camp/resource.hpp
+++ b/include/camp/resource.hpp
@@ -85,18 +85,47 @@ namespace resources
       template <typename T>
       T *try_get()
       {
+        if (!m_value) {
+          return nullptr;
+        }
         auto result = dynamic_cast<ContextModel<T> *>(m_value.get());
-        return result ? result->get() : nullptr;
+        if (!result) {
+          return nullptr;
+        }
+        return result->get();
       }
 
       template <typename T>
-      T get() const
+      T const*try_get() const
       {
+        if (!m_value) {
+          return nullptr;
+        }
         auto result = dynamic_cast<ContextModel<T> *>(m_value.get());
+        if (!result) {
+          return nullptr;
+        }
+        return result->get();
+      }
+
+      template <typename T>
+      T& get()
+      {
+        T* result = try_get<T>();
         if (result == nullptr) {
           ::camp::throw_re("Incompatible Resource type get cast.");
         }
-        return *result->get();
+        return *result;
+      }
+
+      template <typename T>
+      T const& get() const
+      {
+        T const* result = try_get<T>();
+        if (result == nullptr) {
+          ::camp::throw_re("Incompatible Resource type get cast.");
+        }
+        return *result;
       }
 
       Platform get_platform() const { return m_value->get_platform(); }
@@ -246,6 +275,7 @@ namespace resources
 
         void wait() override { m_modelVal.wait(); }
 
+        T const*get() const { return &m_modelVal; }
         T *get() { return &m_modelVal; }
 
       private:

--- a/include/camp/resource.hpp
+++ b/include/camp/resource.hpp
@@ -362,8 +362,9 @@ namespace resources
 
         void wait() override { m_modelVal.wait(); }
 
-        T const*get() const { return &m_modelVal; }
-        T *get() { return &m_modelVal; }
+        const T* get() const { return &m_modelVal; }
+
+        T* get() { return &m_modelVal; }
 
       private:
         T m_modelVal;

--- a/include/camp/resource.hpp
+++ b/include/camp/resource.hpp
@@ -109,7 +109,7 @@ namespace resources
       }
 
       template <typename T>
-      T& get()
+      T& get() &
       {
         T* result = try_get<T>();
         if (result == nullptr) {
@@ -119,7 +119,7 @@ namespace resources
       }
 
       template <typename T>
-      T const& get() const
+      T const& get() const&
       {
         T const* result = try_get<T>();
         if (result == nullptr) {
@@ -128,41 +128,121 @@ namespace resources
         return *result;
       }
 
-      Platform get_platform() const { return m_value->get_platform(); }
+      template <typename T>
+      T get() &&
+      {
+        T* result = try_get<T>();
+        if (result == nullptr) {
+          ::camp::throw_re("Incompatible Resource type get cast.");
+        }
+        return std::move(*result);
+      }
+
+      template <typename T>
+      T get() const&&
+      {
+        T const* result = try_get<T>();
+        if (result == nullptr) {
+          ::camp::throw_re("Incompatible Resource type get cast.");
+        }
+        return std::move(*result);
+      }
+
+      Platform get_platform() const
+      {
+        return m_value ? m_value->get_platform() : Platform::undefined;
+      }
 
       template <typename T>
       T *allocate(size_t size, MemoryAccess ma = MemoryAccess::Device)
       {
+        if (size == 0) {
+          return nullptr;
+        }
+        if (!m_value) {
+          ::camp::throw_re("Empty Resource type allocate call.");
+        }
         return (T *)m_value->allocate(size * sizeof(T), ma);
       }
 
       void *calloc(size_t size, MemoryAccess ma = MemoryAccess::Device)
       {
+        if (size == 0) {
+          return nullptr;
+        }
+        if (!m_value) {
+          ::camp::throw_re("Empty Resource type calloc call.");
+        }
         return m_value->calloc(size, ma);
       }
 
       void deallocate(void *p, MemoryAccess ma = MemoryAccess::Device)
       {
+        if (p == nullptr) {
+          return;
+        }
+        if (!m_value) {
+          ::camp::throw_re("Empty Resource type deallocate call.");
+        }
         m_value->deallocate(p, ma);
       }
 
       void memcpy(void *dst, const void *src, size_t size)
       {
+        if (size == 0) {
+          return;
+        }
+        if (!m_value) {
+          ::camp::throw_re("Empty Resource type memcpy call.");
+        }
         m_value->memcpy(dst, src, size);
       }
 
       void memset(void *p, int val, size_t size)
       {
+        if (size == 0) {
+          return;
+        }
+        if (!m_value) {
+          ::camp::throw_re("Empty Resource type memset call.");
+        }
         m_value->memset(p, val, size);
       }
 
-      Event get_event() { return m_value->get_event(); }
+      Event get_event()
+      {
+        if (!m_value) {
+          return Event{};
+        }
+        return m_value->get_event();
+      }
 
-      Event get_event_erased() { return m_value->get_event_erased(); }
+      Event get_event_erased()
+      {
+        if (!m_value) {
+          return Event{};
+        }
+        return m_value->get_event_erased();
+      }
 
-      void wait_for(Event *e) { m_value->wait_for(e); }
+      void wait_for(Event *e)
+      {
+        if (!m_value) {
+          if (e) {
+            e->wait();
+          }
+          return;
+        }
+        m_value->wait_for(e);
+      }
 
-      void wait() { m_value->wait(); }
+      void wait()
+      {
+        if (!m_value) {
+          return;
+        }
+        m_value->wait();
+      }
 
       /*
        * \brief Compares two Resources to see if they are equal. Two Resources
@@ -173,6 +253,13 @@ namespace resources
        */
       friend inline bool operator==(Resource const &lhs, Resource const &rhs)
       {
+        if (!lhs.m_value && !rhs.m_value) {
+          return true;
+        }
+        if ((!lhs.m_value && rhs.m_value) ||
+            (lhs.m_value && !rhs.m_value)) {
+          return false;
+        }
         if (lhs.get_platform() == rhs.get_platform()) {
           return lhs.m_value->compare(rhs);
         }
@@ -191,7 +278,7 @@ namespace resources
        * platform and stream/queue combination.
        *
        */
-      size_t get_hash() const { return m_value->get_hash(); }
+      size_t get_hash() const { return m_value ? m_value->get_hash() : 0u; }
 
       class ContextInterface
       {

--- a/include/camp/resource.hpp
+++ b/include/camp/resource.hpp
@@ -342,6 +342,9 @@ namespace resources
 }  // namespace resources
 }  // namespace camp
 
+namespace std
+{
+
 /*
  * \brief Specialization of std::hash for camp::resources::Resource
  *
@@ -351,8 +354,6 @@ namespace resources
  *
  * \return A size_t hash value
  */
-namespace std
-{
 template <>
 struct hash<camp::resources::Resource> {
   std::size_t operator()(const camp::resources::Resource &r) const
@@ -360,6 +361,7 @@ struct hash<camp::resources::Resource> {
     return r.get_hash();
   }
 };
+
 }  // namespace std
 
 #endif /* __CAMP_RESOURCE_HPP */

--- a/include/camp/resource.hpp
+++ b/include/camp/resource.hpp
@@ -142,20 +142,13 @@ namespace resources
        * \return True if they have the same platform and stream/queue, false
        * otherwise.
        */
-      bool operator==(Resource const &r) const
+      friend inline bool operator==(Resource const &lhs, Resource const &rhs)
       {
-        if (get_platform() == r.get_platform()) {
-          return (m_value->compare(r));
+        if (lhs.get_platform() == rhs.get_platform()) {
+          return lhs.m_value->compare(rhs);
         }
         return false;
       }
-
-      /*
-       * \brief Compares two Resources to see if they are NOT equal.
-       *
-       * \return Negation of == operator.
-       */
-      bool operator!=(Resource const &r) const { return !(*this == r); }
 
     private:
       friend struct std::hash<camp::resources::Resource>;

--- a/include/camp/resource/cuda.hpp
+++ b/include/camp/resource/cuda.hpp
@@ -64,6 +64,8 @@ namespace resources
 
       CudaEvent(Cuda &res);
 
+      Platform get_platform() const { return Platform::cuda; }
+
       bool check() const
       {
         return (CAMP_CUDA_API_INVOKE_AND_CHECK_RETURN(cudaEventQuery, m_event)
@@ -76,6 +78,20 @@ namespace resources
       }
 
       cudaEvent_t getCudaEvent_t() const { return m_event; }
+
+      /*
+       * \brief Compares two events to see if they are equal
+       *
+       * \return True or false depending on if this is the same event
+       */
+      friend inline bool operator==(CudaEvent const& lhs, CudaEvent const& rhs) = default;
+
+      size_t get_hash() const
+      {
+        const size_t platform_type = size_t(get_platform()) << 32;
+        size_t hash = std::hash<cudaEvent_t>{}(m_event);
+        return platform_type | (hash & 0xFFFFFFFF);
+      }
 
     private:
       cudaEvent_t m_event;
@@ -315,6 +331,26 @@ namespace resources
 }  // namespace resources
 }  // namespace camp
 
+namespace std
+{
+
+/*
+ * \brief Specialization of std::hash for camp::resources::CudaEvent
+ *
+ * Provides a hash function for cuda typed event objects, enabling their use
+ * as keys in unordered associative containers (std::unordered_map,
+ * std::unordered_set, etc.)
+ *
+ * \return A size_t hash value
+ */
+template <>
+struct hash<camp::resources::CudaEvent> {
+  std::size_t operator()(const camp::resources::CudaEvent &e) const
+  {
+    return e.get_hash();
+  }
+};
+
 /*
  * \brief Specialization of std::hash for camp::resources::Cuda
  *
@@ -324,8 +360,6 @@ namespace resources
  *
  * \return A size_t hash value
  */
-namespace std
-{
 template <>
 struct hash<camp::resources::Cuda> {
   std::size_t operator()(const camp::resources::Cuda &c) const
@@ -333,6 +367,7 @@ struct hash<camp::resources::Cuda> {
     return c.get_hash();
   }
 };
+
 }  // namespace std
 
 #endif  // #ifdef CAMP_ENABLE_CUDA

--- a/include/camp/resource/cuda.hpp
+++ b/include/camp/resource/cuda.hpp
@@ -286,17 +286,7 @@ namespace resources
        *
        * \return True or false depending on if it is the same stream
        */
-      bool operator==(Cuda const &c) const
-      {
-        return (get_stream() == c.get_stream());
-      }
-
-      /*
-       * \brief Compares two (Cuda) resources to see if they are NOT equal
-       *
-       * \return Negation of == operator
-       */
-      bool operator!=(Cuda const &c) const { return !(*this == c); }
+      friend inline bool operator==(Cuda const& lhs, Cuda const& rhs) = default;
 
       size_t get_hash() const
       {

--- a/include/camp/resource/cuda.hpp
+++ b/include/camp/resource/cuda.hpp
@@ -80,9 +80,10 @@ namespace resources
       cudaEvent_t getCudaEvent_t() const { return m_event; }
 
       /*
-       * \brief Compares two events to see if they are equal
+       * \brief Compares two events to see if they represent the same underlying
+       *        cuda event.
        *
-       * \return True or false depending on if this is the same event
+       * \return True if both refer to the same cuda event, false otherwise.
        */
       friend inline bool operator==(CudaEvent const& lhs, CudaEvent const& rhs) = default;
 
@@ -94,6 +95,7 @@ namespace resources
       }
 
     private:
+      // note that cudaEvent_t is an alias for a pointer and is nullable
       cudaEvent_t m_event;
 
       void init(cudaStream_t stream)

--- a/include/camp/resource/event.hpp
+++ b/include/camp/resource/event.hpp
@@ -81,7 +81,7 @@ namespace resources
       }
 
       template <typename T>
-      T& get()
+      T& get() &
       {
         T* result = try_get<T>();
         if (result == nullptr) {
@@ -91,7 +91,7 @@ namespace resources
       }
 
       template <typename T>
-      T const& get() const
+      T const& get() const&
       {
         T const* result = try_get<T>();
         if (result == nullptr) {
@@ -100,11 +100,34 @@ namespace resources
         return *result;
       }
 
-      Platform get_platform() const { return m_value->get_platform(); }
+      template <typename T>
+      T get() &&
+      {
+        T* result = try_get<T>();
+        if (result == nullptr) {
+          ::camp::throw_re("Incompatible Event type get cast.");
+        }
+        return std::move(*result);
+      }
 
-      bool check() const { return m_value->check(); }
+      template <typename T>
+      T get() const&&
+      {
+        T const* result = try_get<T>();
+        if (result == nullptr) {
+          ::camp::throw_re("Incompatible Event type get cast.");
+        }
+        return std::move(*result);
+      }
 
-      void wait() const { m_value->wait(); }
+      Platform get_platform() const
+      {
+        return m_value ? m_value->get_platform() : Platform::undefined;
+      }
+
+      bool check() const { return m_value ? m_value->check() : true; }
+
+      void wait() const { if (m_value) { m_value->wait(); } }
 
       /*
        * \brief Compares two Events to see if they are equal. Two Events
@@ -115,6 +138,13 @@ namespace resources
        */
       friend inline bool operator==(Event const &lhs, Event const &rhs)
       {
+        if (!lhs.m_value && !rhs.m_value) {
+          return true;
+        }
+        if ((!lhs.m_value && rhs.m_value) ||
+            (lhs.m_value && !rhs.m_value)) {
+          return false;
+        }
         if (lhs.get_platform() == rhs.get_platform()) {
           return lhs.m_value->compare(rhs);
         }
@@ -133,7 +163,7 @@ namespace resources
        * platform and stream/queue combination.
        *
        */
-      size_t get_hash() const { return m_value->get_hash(); }
+      size_t get_hash() const { return m_value ? m_value->get_hash() : 0u; }
 
       class EventInterface
       {

--- a/include/camp/resource/event.hpp
+++ b/include/camp/resource/event.hpp
@@ -50,7 +50,7 @@ namespace resources
                                         *>::value)>::type * = nullptr>
       Event(T &&value)
       {
-        m_value.reset(new EventModel<T>(value));
+        m_value.reset(new EventModel<type::ref::rem<T>>(value));
       }
 
       template <typename T>

--- a/include/camp/resource/event.hpp
+++ b/include/camp/resource/event.hpp
@@ -49,10 +49,6 @@ namespace resources
         m_value.reset(new EventModel<T>(value));
       }
 
-      bool check() const { return m_value->check(); }
-
-      void wait() const { m_value->wait(); }
-
       template <typename T>
       T *try_get()
       {
@@ -68,13 +64,50 @@ namespace resources
           ::camp::throw_re("Incompatible Event type get cast.");
         }
         return *result->get();
+      Platform get_platform() const { return m_value->get_platform(); }
+
+      bool check() const { return m_value->check(); }
+
+      void wait() const { m_value->wait(); }
+
+      /*
+       * \brief Compares two Resources to see if they are equal. Two Resources
+       * are equal if they have the platform and same stream/queue
+       *
+       * \return True if they have the same platform and stream/queue, false
+       * otherwise.
+       */
+      friend inline bool operator==(Event const &lhs, Event const &rhs)
+      {
+        if (lhs.get_platform() == rhs.get_platform()) {
+          return lhs.m_value->compare(rhs);
+        }
+        return false;
       }
 
     private:
+      friend struct std::hash<camp::resources::Event>;
+
+      /*
+       * \brief Retrieves the a hash for this Event.
+       * The hash allows Events to be used as keys in data structures
+       * like unordered maps.
+       *
+       * \return A size_t hash value for this Event's
+       * platform and stream/queue combination.
+       *
+       */
+      size_t get_hash() const { return m_value->get_hash(); }
+
       class EventInterface
       {
       public:
         virtual ~EventInterface() {}
+
+        virtual Platform get_platform() const = 0;
+
+        virtual bool compare(Event const &e) const = 0;
+        virtual size_t get_hash() const = 0;
 
         virtual bool check() const = 0;
         virtual void wait() const = 0;
@@ -85,6 +118,18 @@ namespace resources
       {
       public:
         EventModel(T const &modelVal) : m_modelVal(modelVal) {}
+
+        Platform get_platform() const override
+        {
+          return m_modelVal.get_platform();
+        }
+
+        bool compare(Resource const &e) const override
+        {
+          return m_modelVal == e.get<T>();
+        }
+
+        size_t get_hash() const override { return m_modelVal.get_hash(); }
 
         bool check() const override { return m_modelVal.check(); }
 
@@ -102,4 +147,27 @@ namespace resources
   }  // namespace v1
 }  // namespace resources
 }  // namespace camp
+
+namespace std
+{
+
+/*
+ * \brief Specialization of std::hash for camp::resources::Event
+ *
+ * Provides a hash function for Event objects, enabling their use as keys
+ * in unordered associative containers (std::unordered_map, std::unordered_set,
+ * etc.)
+ *
+ * \return A size_t hash value
+ */
+template <>
+struct hash<camp::resources::Event> {
+  std::size_t operator()(const camp::resources::Event &e) const
+  {
+    return e.get_hash();
+  }
+};
+
+}  // namespace std
+
 #endif /* __CAMP_EVENT_HPP */

--- a/include/camp/resource/event.hpp
+++ b/include/camp/resource/event.hpp
@@ -52,18 +52,49 @@ namespace resources
       template <typename T>
       T *try_get()
       {
+        if (!m_value) {
+          return nullptr;
+        }
         auto result = dynamic_cast<EventModel<T> *>(m_value.get());
+        if (!result) {
+          return nullptr;
+        }
         return result->get();
       }
 
       template <typename T>
-      T get()
+      T const*try_get() const
       {
+        if (!m_value) {
+          return nullptr;
+        }
         auto result = dynamic_cast<EventModel<T> *>(m_value.get());
+        if (!result) {
+          return nullptr;
+        }
+        return result->get();
+      }
+
+      template <typename T>
+      T& get()
+      {
+        T* result = try_get<T>();
         if (result == nullptr) {
           ::camp::throw_re("Incompatible Event type get cast.");
         }
-        return *result->get();
+        return *result;
+      }
+
+      template <typename T>
+      T const& get() const
+      {
+        T const* result = try_get<T>();
+        if (result == nullptr) {
+          ::camp::throw_re("Incompatible Event type get cast.");
+        }
+        return *result;
+      }
+
       Platform get_platform() const { return m_value->get_platform(); }
 
       bool check() const { return m_value->check(); }
@@ -134,6 +165,8 @@ namespace resources
         bool check() const override { return m_modelVal.check(); }
 
         void wait() const override { m_modelVal.wait(); }
+
+        T const*get() const { return &m_modelVal; }
 
         T *get() { return &m_modelVal; }
 

--- a/include/camp/resource/event.hpp
+++ b/include/camp/resource/event.hpp
@@ -202,9 +202,9 @@ namespace resources
 
         void wait() const override { m_modelVal.wait(); }
 
-        T const*get() const { return &m_modelVal; }
+        const T* get() const { return &m_modelVal; }
 
-        T *get() { return &m_modelVal; }
+        T* get() { return &m_modelVal; }
 
       private:
         T m_modelVal;

--- a/include/camp/resource/event.hpp
+++ b/include/camp/resource/event.hpp
@@ -13,9 +13,13 @@
 #include <memory>
 #include <type_traits>
 
+#include "camp/concepts.hpp"
 #include "camp/config.hpp"
 #include "camp/defines.hpp"
 #include "camp/helpers.hpp"
+
+// last to ensure we don't hide breakage in the others
+#include "camp/resource/platform.hpp"
 
 namespace camp
 {

--- a/include/camp/resource/event.hpp
+++ b/include/camp/resource/event.hpp
@@ -130,11 +130,12 @@ namespace resources
       void wait() const { if (m_value) { m_value->wait(); } }
 
       /*
-       * \brief Compares two Events to see if they are equal. Two Events
-       * are equal if they have the platform and same event
+       * \brief Compares two Events to see if they represent the same underlying
+       *        typed event. Two Events are equal if they have the platform and
+       *        equivalent typed events.
        *
-       * \return True if they have the same platform and event, false
-       * otherwise.
+       * \return True if they have the same platform and equivalent underlying
+       *         typed events, false otherwise.
        */
       friend inline bool operator==(Event const &lhs, Event const &rhs)
       {

--- a/include/camp/resource/event.hpp
+++ b/include/camp/resource/event.hpp
@@ -159,7 +159,7 @@ namespace resources
           return m_modelVal.get_platform();
         }
 
-        bool compare(Resource const &e) const override
+        bool compare(Event const &e) const override
         {
           return m_modelVal == e.get<T>();
         }

--- a/include/camp/resource/event.hpp
+++ b/include/camp/resource/event.hpp
@@ -106,10 +106,10 @@ namespace resources
       void wait() const { m_value->wait(); }
 
       /*
-       * \brief Compares two Resources to see if they are equal. Two Resources
-       * are equal if they have the platform and same stream/queue
+       * \brief Compares two Events to see if they are equal. Two Events
+       * are equal if they have the platform and same event
        *
-       * \return True if they have the same platform and stream/queue, false
+       * \return True if they have the same platform and event, false
        * otherwise.
        */
       friend inline bool operator==(Event const &lhs, Event const &rhs)

--- a/include/camp/resource/event.hpp
+++ b/include/camp/resource/event.hpp
@@ -45,6 +45,7 @@ namespace resources
       template <
           typename T,
           typename std::enable_if<
+              !std::is_same_v<typename std::decay_t<T>, Event> &&
               !(std::is_convertible<typename std::decay<T>::type *,
                                     ::camp::resources::detail::EventProxyBase
                                         *>::value)>::type * = nullptr>

--- a/include/camp/resource/hip.hpp
+++ b/include/camp/resource/hip.hpp
@@ -64,6 +64,8 @@ namespace resources
 
       HipEvent(Hip &res);
 
+      Platform get_platform() const { return Platform::hip; }
+
       bool check() const
       {
         return (CAMP_HIP_API_INVOKE_AND_CHECK_RETURN(hipEventQuery, m_event)
@@ -76,6 +78,20 @@ namespace resources
       }
 
       hipEvent_t getHipEvent_t() const { return m_event; }
+
+      /*
+       * \brief Compares two events to see if they are equal
+       *
+       * \return True or false depending on if this is the same event
+       */
+      friend inline bool operator==(HipEvent const& lhs, HipEvent const& rhs) = default;
+
+      size_t get_hash() const
+      {
+        const size_t platform_type = size_t(get_platform()) << 32;
+        size_t hash = std::hash<hipEvent_t>{}(m_event);
+        return platform_type | (hash & 0xFFFFFFFF);
+      }
 
     private:
       hipEvent_t m_event;
@@ -316,6 +332,26 @@ namespace resources
 }  // namespace resources
 }  // namespace camp
 
+namespace std
+{
+
+/*
+ * \brief Specialization of std::hash for camp::resources::HipEvent
+ *
+ * Provides a hash function for hip typed event objects, enabling their use
+ * as keys in unordered associative containers (std::unordered_map,
+ * std::unordered_set, etc.)
+ *
+ * \return A size_t hash value
+ */
+template <>
+struct hash<camp::resources::HipEvent> {
+  std::size_t operator()(const camp::resources::HipEvent &e) const
+  {
+    return e.get_hash();
+  }
+};
+
 /*
  * \brief Specialization of std::hash for camp::resources::Hip
  *
@@ -325,8 +361,6 @@ namespace resources
  *
  * \return A size_t hash value
  */
-namespace std
-{
 template <>
 struct hash<camp::resources::Hip> {
   std::size_t operator()(const camp::resources::Hip &h) const
@@ -334,6 +368,7 @@ struct hash<camp::resources::Hip> {
     return h.get_hash();
   }
 };
+
 }  // namespace std
 
 #endif  // #ifdef CAMP_ENABLE_HIP

--- a/include/camp/resource/hip.hpp
+++ b/include/camp/resource/hip.hpp
@@ -288,17 +288,7 @@ namespace resources
        *
        * \return True or false depending on if this is the same stream
        */
-      bool operator==(Hip const &h) const
-      {
-        return (get_stream() == h.get_stream());
-      }
-
-      /*
-       * \brief Compares two (Hip) resources to see if they are NOT equal
-       *
-       * \return Negation of == operator
-       */
-      bool operator!=(Hip const &h) const { return !(*this == h); }
+      friend inline bool operator==(Hip const& lhs, Hip const& rhs) = default;
 
       size_t get_hash() const
       {

--- a/include/camp/resource/hip.hpp
+++ b/include/camp/resource/hip.hpp
@@ -80,9 +80,10 @@ namespace resources
       hipEvent_t getHipEvent_t() const { return m_event; }
 
       /*
-       * \brief Compares two events to see if they are equal
+       * \brief Compares two events to see if they represent the same underlying
+       *        hip event.
        *
-       * \return True or false depending on if this is the same event
+       * \return True if both refer to the same hip event, false otherwise.
        */
       friend inline bool operator==(HipEvent const& lhs, HipEvent const& rhs) = default;
 
@@ -94,6 +95,7 @@ namespace resources
       }
 
     private:
+      // note that cudaEvent_t is an alias for a pointer and is nullable
       hipEvent_t m_event;
 
       void init(hipStream_t stream)

--- a/include/camp/resource/host.hpp
+++ b/include/camp/resource/host.hpp
@@ -28,9 +28,24 @@ namespace resources
     public:
       HostEvent() {}
 
+      Platform get_platform() const { return Platform::host; }
+
       bool check() const { return true; }
 
       void wait() const {}
+
+      /*
+       * \brief Compares two events to see if they are equal
+       *
+       * \return True or false depending on if this is the same event
+       */
+      friend inline bool operator==(CudaEvent const& lhs, CudaEvent const& rhs) = default;
+
+      size_t get_hash() const
+      {
+        const size_t platform_type = size_t(get_platform()) << 32;
+        return platform_type;
+      }
     };
 
     class Host
@@ -110,6 +125,26 @@ namespace resources
 }  // namespace resources
 }  // namespace camp
 
+namespace std
+{
+
+/*
+ * \brief Specialization of std::hash for camp::resources::HostEvent
+ *
+ * Provides a hash function for host typed event objects, enabling their use
+ * as keys in unordered associative containers (std::unordered_map,
+ * std::unordered_set, etc.)
+ *
+ * \return Hash value for the host (always the value of get_platform())
+ */
+template <>
+struct hash<camp::resources::HostEvent> {
+  std::size_t operator()(const camp::resources::HostEvent &e) const
+  {
+    return e.get_hash();
+  }
+};
+
 /*
  * \brief Specialization of std::hash for camp::resources::Host
  *
@@ -119,8 +154,6 @@ namespace resources
  *
  * \return Hash value for the host (always the value of get_platform())
  */
-namespace std
-{
 template <>
 struct hash<camp::resources::Host> {
   std::size_t operator()(const camp::resources::Host &h) const
@@ -128,5 +161,6 @@ struct hash<camp::resources::Host> {
     return h.get_hash();
   }
 };
+
 }  // namespace std
 #endif /* __CAMP_DEVICES_HPP */

--- a/include/camp/resource/host.hpp
+++ b/include/camp/resource/host.hpp
@@ -39,7 +39,7 @@ namespace resources
        *
        * \return True or false depending on if this is the same event
        */
-      friend inline bool operator==(CudaEvent const& lhs, CudaEvent const& rhs) = default;
+      friend inline bool operator==(HostEvent const& lhs, HostEvent const& rhs) = default;
 
       size_t get_hash() const
       {

--- a/include/camp/resource/host.hpp
+++ b/include/camp/resource/host.hpp
@@ -90,14 +90,10 @@ namespace resources
        *
        * \return Always return true since Host resources are always the same
        */
-      bool operator==(Host const &) const { return true; }
-
-      /*
-       * \brief Compares two (Host) resources to see if they are NOT equal
-       *
-       * \return Always return false. Host resources are always the same
-       */
-      bool operator!=(Host const &) const { return false; }
+      friend inline bool operator==(Host const& CAMP_UNUSED_ARG(lhs), Host const& CAMP_UNUSED_ARG(rhs))
+      {
+        return true;
+      }
 
       size_t get_hash() const
       {

--- a/include/camp/resource/host.hpp
+++ b/include/camp/resource/host.hpp
@@ -35,9 +35,10 @@ namespace resources
       void wait() const {}
 
       /*
-       * \brief Compares two events to see if they are equal
+       * \brief Compares two events to see if they represent the same underlying
+       *        host event.
        *
-       * \return True or false depending on if this is the same event
+       * \return True (Host is always synchronous so host events are trivial)
        */
       friend inline bool operator==(HostEvent const& lhs, HostEvent const& rhs) = default;
 

--- a/include/camp/resource/omp_target.hpp
+++ b/include/camp/resource/omp_target.hpp
@@ -41,6 +41,8 @@ namespace resources
         }
       }
 
+      Platform get_platform() const { return Platform::omp_target; }
+
       bool check() const
       {
         // think up a way to do something better portably
@@ -58,6 +60,21 @@ namespace resources
       }
 
       void *getEventAddr() const { return addr; }
+
+      /*
+       * \brief Compares two events to see if they are equal
+       *
+       * \return True or false depending on if this is the same event
+       */
+      friend inline bool operator==(OmpEvent const& lhs, OmpEvent const& rhs) = default;
+
+      size_t get_hash() const
+      {
+        const size_t platform_type = size_t(get_platform()) << 32;
+        size_t hash = std::hash<char *>{}(addr);
+        hash ^= std::hash<int>{}(dev) + 0x9E3779B9 + (hash << 6) + (hash >> 2);
+        return platform_type | (hash & 0xFFFFFFFF);
+      }
 
     private:
       char *addr;
@@ -282,6 +299,26 @@ namespace resources
 }  // namespace resources
 }  // namespace camp
 
+namespace std
+{
+
+/*
+ * \brief Specialization of std::hash for camp::resources::OmpEvent
+ *
+ * Provides a hash function for omp typed event objects, enabling their use
+ * as keys in unordered associative containers (std::unordered_map,
+ * std::unordered_set, etc.)
+ *
+ * \return A size_t hash value
+ */
+template <>
+struct hash<camp::resources::OmpEvent> {
+  std::size_t operator()(const camp::resources::OmpEvent& e) const
+  {
+    return e.get_hash();
+  }
+};
+
 /*
  * \brief Specialization of std::hash for camp::resources::Omp
  *
@@ -291,8 +328,6 @@ namespace resources
  *
  * \return A size_t hash value
  */
-namespace std
-{
 template <>
 struct hash<camp::resources::Omp> {
   std::size_t operator()(const camp::resources::Omp &o) const
@@ -300,6 +335,7 @@ struct hash<camp::resources::Omp> {
     return o.get_hash();
   }
 };
+
 }  // namespace std
 #endif  // #ifdef CAMP_ENABLE_TARGET_OPENMP
 

--- a/include/camp/resource/omp_target.hpp
+++ b/include/camp/resource/omp_target.hpp
@@ -253,17 +253,7 @@ namespace resources
        *
        * \return True or false depending on if this is the same dev and addr ptr
        */
-      bool operator==(Omp const &o) const
-      {
-        return (dev == o.dev && addr == o.addr);
-      }
-
-      /*
-       * \brief Compares two (Omp) resources to see if they are NOT equal
-       *
-       * \return Negation of == operator
-       */
-      bool operator!=(Omp const &o) const { return !(*this == o); }
+      friend inline bool operator==(Omp const& lhs, Omp const& rhs) = default;
 
       size_t get_hash() const
       {

--- a/include/camp/resource/omp_target.hpp
+++ b/include/camp/resource/omp_target.hpp
@@ -62,9 +62,11 @@ namespace resources
       void *getEventAddr() const { return addr; }
 
       /*
-       * \brief Compares two events to see if they are equal
+       * \brief Compares two events to see if they represent the same underlying
+       *        openmp target event.
        *
-       * \return True or false depending on if this is the same event
+       * \return True if both refer to the same address and device, false
+       *         otherwise.
        */
       friend inline bool operator==(OmpEvent const& lhs, OmpEvent const& rhs) = default;
 

--- a/include/camp/resource/sycl.hpp
+++ b/include/camp/resource/sycl.hpp
@@ -49,6 +49,8 @@ namespace resources
 
       SyclEvent(Sycl& res);
 
+      Platform get_platform() const { return Platform::sycl; }
+
       bool check() const
       {
         return m_event.get_info<sycl::info::event::command_execution_status>()
@@ -60,6 +62,20 @@ namespace resources
       sycl::event& getSyclEvent_t() { return m_event; }
 
       sycl::event const& getSyclEvent_t() const { return m_event; }
+
+      /*
+       * \brief Compares two events to see if they are equal
+       *
+       * \return True or false depending on if this is the same event
+       */
+      friend inline bool operator==(SyclEvent const& lhs, SyclEvent const& rhs) = default;
+
+      size_t get_hash() const
+      {
+        const size_t sycl_type = size_t(get_platform()) << 32;
+        size_t stream_hash = std::hash<sycl::event>{}(m_event);
+        return sycl_type | (stream_hash & 0xFFFFFFFF);
+      }
 
     private:
       mutable sycl::event m_event; // mutable as use non-const member function
@@ -374,6 +390,26 @@ namespace resources
 }  // namespace resources
 }  // namespace camp
 
+namespace std
+{
+
+/*
+ * \brief Specialization of std::hash for camp::resources::SyclEvent
+ *
+ * Provides a hash function for sycl typed event objects, enabling their use
+ * as keys in unordered associative containers (std::unordered_map,
+ * std::unordered_set, etc.)
+ *
+ * \return A size_t hash value
+ */
+template <>
+struct hash<camp::resources::SyclEvent> {
+  std::size_t operator()(const camp::resources::SyclEvent& e) const
+  {
+    return e.get_hash();
+  }
+};
+
 /*
  * \brief Specialization of std::hash for camp::resources::Sycl
  *
@@ -383,8 +419,6 @@ namespace resources
  *
  * \return A size_t hash value
  */
-namespace std
-{
 template <>
 struct hash<camp::resources::Sycl> {
   std::size_t operator()(const camp::resources::Sycl& s) const
@@ -392,6 +426,7 @@ struct hash<camp::resources::Sycl> {
     return s.get_hash();
   }
 };
+
 }  // namespace std
 #endif  // #ifdef CAMP_ENABLE_SYCL
 

--- a/include/camp/resource/sycl.hpp
+++ b/include/camp/resource/sycl.hpp
@@ -64,9 +64,10 @@ namespace resources
       sycl::event const& getSyclEvent_t() const { return m_event; }
 
       /*
-       * \brief Compares two events to see if they are equal
+       * \brief Compares two events to see if they represent the same underlying
+       *        sycl event.
        *
-       * \return True or false depending on if this is the same event
+       * \return True if both refer to equivalent sycl events, false otherwise.
        */
       friend inline bool operator==(SyclEvent const& lhs, SyclEvent const& rhs) = default;
 

--- a/include/camp/resource/sycl.hpp
+++ b/include/camp/resource/sycl.hpp
@@ -349,17 +349,7 @@ namespace resources
        *
        * \return True or false depending on if this is the same queue
        */
-      bool operator==(Sycl const& s) const
-      {
-        return (get_queue() == s.get_queue());
-      }
-
-      /*
-       * \brief Compares two (Sycl) resources to see if they are NOT equal
-       *
-       * \return Negation of == operator
-       */
-      bool operator!=(Sycl const& s) const { return !(*this == s); }
+      friend inline bool operator==(Sycl const& lhs, Sycl const& rhs) = default;
 
       size_t get_hash() const
       {

--- a/test/resource.cpp
+++ b/test/resource.cpp
@@ -259,13 +259,8 @@ void test_map_key(Resource& h)
 //
 TEST(CampResource, UnorderedMapKey)
 {
-#if !defined(CAMP_HAVE_CUDA) && !defined(CAMP_HAVE_HIP) \
-    && !defined(CAMP_HAVE_OMP_OFFLOAD) && !defined(CAMP_HAVE_SYCL)
-  // If only the Host is enabled, it doesn't make sense to use a map
-  GTEST_SKIP() << "No device backend available (CUDA/HIP/OMP/SYCL)";
-#else
-
   Resource h{Host()};
+  test_map_key<Host>(h);
 #if defined(CAMP_HAVE_CUDA)
   test_map_key<Cuda>(h);
 #elif defined(CAMP_HAVE_HIP)
@@ -274,8 +269,6 @@ TEST(CampResource, UnorderedMapKey)
   test_map_key<Omp>(h);
 #elif defined(CAMP_HAVE_SYCL)
   test_map_key<Sycl>(h);
-#endif
-
 #endif
 }
 
@@ -344,13 +337,8 @@ void test_map_key(Event& he)
 //
 TEST(CampEvent, UnorderedMapKey)
 {
-#if !defined(CAMP_HAVE_CUDA) && !defined(CAMP_HAVE_HIP) \
-    && !defined(CAMP_HAVE_OMP_OFFLOAD) && !defined(CAMP_HAVE_SYCL)
-  // If only the Host is enabled, it doesn't make sense to use a map
-  GTEST_SKIP() << "No device backend available (CUDA/HIP/OMP/SYCL)";
-#else
-
   Event he{Host().get_event_erased()};
+  test_map_key<Host>(he);
 #if defined(CAMP_HAVE_CUDA)
   test_map_key<Cuda>(he);
 #elif defined(CAMP_HAVE_HIP)
@@ -359,8 +347,6 @@ TEST(CampEvent, UnorderedMapKey)
   test_map_key<Omp>(he);
 #elif defined(CAMP_HAVE_SYCL)
   test_map_key<Sycl>(he);
-#endif
-
 #endif
 }
 

--- a/test/resource.cpp
+++ b/test/resource.cpp
@@ -172,6 +172,24 @@ TEST(CampResource, GetPlatform)
 #endif
 }
 
+TEST(CampEvent, GetPlatform)
+{
+  ASSERT_EQ(static_cast<const Event>(Host()).get_platform(), Platform::host);
+#ifdef CAMP_HAVE_CUDA
+  ASSERT_EQ(static_cast<const Event>(Cuda()).get_platform(), Platform::cuda);
+#endif
+#ifdef CAMP_HAVE_HIP
+  ASSERT_EQ(static_cast<const Event>(Hip()).get_platform(), Platform::hip);
+#endif
+#ifdef CAMP_HAVE_OMP_OFFLOAD
+  ASSERT_EQ(static_cast<const Event>(Omp()).get_platform(),
+            Platform::omp_target);
+#endif
+#ifdef CAMP_HAVE_SYCL
+  ASSERT_EQ(static_cast<const Event>(Sycl()).get_platform(), Platform::sycl);
+#endif
+}
+
 template <typename Res>
 void test_map_key(Resource& h)
 {
@@ -252,6 +270,91 @@ TEST(CampResource, UnorderedMapKey)
   test_map_key<Omp>(h);
 #elif defined(CAMP_HAVE_SYCL)
   test_map_key<Sycl>(h);
+#endif
+
+#endif
+}
+
+template <typename Res>
+void test_map_key(Event& he)
+{
+  // Generic
+  std::unordered_map<Event, size_t> map;
+  std::unordered_multimap<Event, size_t> multimap;
+  Event d1{Res().get_erased_event()};
+  Event d2{Res().get_erased_event()};
+
+  // Typed
+  auto e1{Res().get_event()};
+  auto e2{Res().get_event()};
+  std::unordered_map<decltype(e1), size_t> rmap;
+  std::unordered_multimap<decltype(e2), size_t> rmultimap;
+
+  // Generic
+  map.insert({he, 10});
+  multimap.insert({he, 10});
+  map.insert({he, 20});
+  multimap.insert({he, 20});
+  map.insert({d1, 30});
+  multimap.insert({d1, 30});
+  map.insert({d2, 40});
+  multimap.insert({d2, 40});
+  map.insert({d2, 50});
+  multimap.insert({d2, 50});
+
+  // Typed
+  rmap.insert({e1, 30});
+  rmultimap.insert({e1, 30});
+  rmap.insert({e2, 40});
+  rmultimap.insert({e2, 40});
+  rmap.insert({e2, 50});
+  rmultimap.insert({e2, 50});
+
+  // Verify using Event as a key to find entries works
+  // Generic
+  ASSERT_EQ(map.count(he), 1);
+  ASSERT_EQ(multimap.count(he), 2);
+  ASSERT_EQ(map.count(d1), 1);
+  ASSERT_EQ(multimap.count(d1), 1);
+  ASSERT_EQ(map.count(d2), 1);
+  ASSERT_EQ(multimap.count(d2), 2);
+
+  // Typed
+  ASSERT_EQ(rmap.count(e1), 1);
+  ASSERT_EQ(rmultimap.count(e1), 1);
+  ASSERT_EQ(rmap.count(e2), 1);
+  ASSERT_EQ(rmultimap.count(e2), 2);
+
+  // Verify equal_range works
+  // Generic
+  auto range = map.equal_range(he);
+  auto range2 = multimap.equal_range(d2);
+  ASSERT_EQ(std::distance(range.first, range.second), 1);
+  ASSERT_EQ(std::distance(range2.first, range2.second), 2);
+
+  // Typed
+  auto rrange2 = rmultimap.equal_range(e2);
+  ASSERT_EQ(std::distance(rrange2.first, rrange2.second), 2);
+}
+
+//
+TEST(CampEvent, UnorderedMapKey)
+{
+#if !defined(CAMP_HAVE_CUDA) && !defined(CAMP_HAVE_HIP) \
+    && !defined(CAMP_HAVE_OMP_OFFLOAD) && !defined(CAMP_HAVE_SYCL)
+  // If only the Host is enabled, it doesn't make sense to use a map
+  GTEST_SKIP() << "No device backend available (CUDA/HIP/OMP/SYCL)";
+#else
+
+  Event he{Host().get_erased_event()};
+#if defined(CAMP_HAVE_CUDA)
+  test_map_key<Cuda>(he);
+#elif defined(CAMP_HAVE_HIP)
+  test_map_key<Hip>(he);
+#elif defined(CAMP_HAVE_OMP_OFFLOAD)
+  test_map_key<Omp>(he);
+#elif defined(CAMP_HAVE_SYCL)
+  test_map_key<Sycl>(he);
 #endif
 
 #endif

--- a/test/resource.cpp
+++ b/test/resource.cpp
@@ -333,6 +333,80 @@ TEST(CampResource, HostCompare)
   ASSERT_TRUE(h3 == h2);
 }
 
+
+template <typename Res>
+void test_id_compare(Event& he)
+{
+  Event e1{Res().get_event()};
+  auto te = Res().get_event();
+  Event e2{te};
+
+  ASSERT_TRUE(e1 == e1);
+  ASSERT_TRUE(e2 == e2);
+  ASSERT_TRUE(e1 != e2);
+  ASSERT_TRUE(e2 != e1);
+  ASSERT_TRUE(te == te);
+
+  ASSERT_FALSE(e1 != e1);
+  ASSERT_FALSE(e2 != e2);
+  ASSERT_FALSE(e1 == e2);
+  ASSERT_FALSE(e2 == e1);
+  ASSERT_FALSE(te!= te);
+
+  ASSERT_TRUE(e1 != he);
+  ASSERT_TRUE(he != e1);
+
+  ASSERT_FALSE(e1 == he);
+  ASSERT_FALSE(he == e1);
+}
+
+//
+TEST(CampEvent, Compare)
+{
+  Event e1{Host().get_erased_event()};
+  auto te = Host().get_event();
+  Event e2{te};
+
+  ASSERT_TRUE(e1 == e1);
+  ASSERT_TRUE(e2 == e2);
+  ASSERT_TRUE(e1 == e2);
+  ASSERT_TRUE(e2 == e1);
+  ASSERT_TRUE(te == te);
+
+  ASSERT_FALSE(e1 != e1);
+  ASSERT_FALSE(e2 != e2);
+  ASSERT_FALSE(e1 != e2);
+  ASSERT_FALSE(e2 != e1);
+  ASSERT_FALSE(te != te);
+
+#ifdef CAMP_HAVE_CUDA
+  test_id_compare<Cuda>(e1);
+#endif
+#ifdef CAMP_HAVE_HIP
+  test_id_compare<Hip>(e1);
+#endif
+#ifdef CAMP_HAVE_OMP_OFFLOAD
+  test_id_compare<Omp>(e1);
+#endif
+#ifdef CAMP_HAVE_SYCL
+  test_id_compare<Sycl>(e1);
+#endif
+}
+
+TEST(CampEvent, HostEventCompare)
+{
+  HostEvent te = Host().get_default().get_event();
+  Event e2{Host().get_event()};
+  Event e3{Host().get_erased_event()};
+
+  ASSERT_TRUE(Event{te} == e2);
+  ASSERT_TRUE(Event{te} == e3);
+  ASSERT_TRUE(e2 == te);
+  ASSERT_TRUE(e2 == e3);
+  ASSERT_TRUE(e3 == te);
+  ASSERT_TRUE(e3 == e2);
+}
+
 template <typename Res>
 void test_reassignment()
 {

--- a/test/resource.cpp
+++ b/test/resource.cpp
@@ -281,8 +281,8 @@ void test_map_key(Event& he)
   // Generic
   std::unordered_map<Event, size_t> map;
   std::unordered_multimap<Event, size_t> multimap;
-  Event d1{Res().get_erased_event()};
-  Event d2{Res().get_erased_event()};
+  Event d1{Res().get_event_erased()};
+  Event d2{Res().get_event_erased()};
 
   // Typed
   auto e1{Res().get_event()};
@@ -346,7 +346,7 @@ TEST(CampEvent, UnorderedMapKey)
   GTEST_SKIP() << "No device backend available (CUDA/HIP/OMP/SYCL)";
 #else
 
-  Event he{Host().get_erased_event()};
+  Event he{Host().get_event_erased()};
 #if defined(CAMP_HAVE_CUDA)
   test_map_key<Cuda>(he);
 #elif defined(CAMP_HAVE_HIP)
@@ -466,7 +466,7 @@ void test_id_compare(Event& he)
 //
 TEST(CampEvent, Compare)
 {
-  Event e1{Host().get_erased_event()};
+  Event e1{Host().get_event_erased()};
   auto te = Host().get_event();
   Event e2{te};
 
@@ -500,7 +500,7 @@ TEST(CampEvent, HostEventCompare)
 {
   HostEvent te = Host().get_default().get_event();
   Event e2{Host().get_event()};
-  Event e3{Host().get_erased_event()};
+  Event e3{Host().get_event_erased()};
 
   ASSERT_TRUE(Event{te} == e2);
   ASSERT_TRUE(Event{te} == e3);

--- a/test/resource.cpp
+++ b/test/resource.cpp
@@ -231,29 +231,57 @@ void test_map_key(Resource& h)
 
   // Verify using Resource as a key to find entries works
   // Generic
-  ASSERT_EQ(map.count(h), 1);
-  ASSERT_EQ(multimap.count(h), 2);
-  ASSERT_EQ(map.count(d1), 1);
-  ASSERT_EQ(multimap.count(d1), 1);
-  ASSERT_EQ(map.count(d2), 1);
-  ASSERT_EQ(multimap.count(d2), 2);
+  if constexpr (std::same_as<Res, Host>) {
+    ASSERT_EQ(map.count(h), 1);
+    ASSERT_EQ(multimap.count(h), 5);
+    ASSERT_EQ(map.count(d1), 1);
+    ASSERT_EQ(multimap.count(d1), 5);
+    ASSERT_EQ(map.count(d2), 1);
+    ASSERT_EQ(multimap.count(d2), 5);
+  } else {
+    ASSERT_EQ(map.count(h), 1);
+    ASSERT_EQ(multimap.count(h), 2);
+    ASSERT_EQ(map.count(d1), 1);
+    ASSERT_EQ(multimap.count(d1), 1);
+    ASSERT_EQ(map.count(d2), 1);
+    ASSERT_EQ(multimap.count(d2), 2);
+  }
 
   // Typed
-  ASSERT_EQ(rmap.count(r1), 1);
-  ASSERT_EQ(rmultimap.count(r1), 1);
-  ASSERT_EQ(rmap.count(r2), 1);
-  ASSERT_EQ(rmultimap.count(r2), 2);
+  if constexpr (std::same_as<Res, Host>) {
+    ASSERT_EQ(rmap.count(r1), 1);
+    ASSERT_EQ(rmultimap.count(r1), 3);
+    ASSERT_EQ(rmap.count(r2), 1);
+    ASSERT_EQ(rmultimap.count(r2), 3);
+  } else {
+    ASSERT_EQ(rmap.count(r1), 1);
+    ASSERT_EQ(rmultimap.count(r1), 1);
+    ASSERT_EQ(rmap.count(r2), 1);
+    ASSERT_EQ(rmultimap.count(r2), 2);
+  }
 
   // Verify equal_range works
   // Generic
   auto range = map.equal_range(h);
   auto range2 = multimap.equal_range(d2);
-  ASSERT_EQ(std::distance(range.first, range.second), 1);
-  ASSERT_EQ(std::distance(range2.first, range2.second), 2);
+  if constexpr (std::same_as<Res, Host>) {
+    ASSERT_EQ(std::distance(range.first, range.second), 1);
+    ASSERT_EQ(std::distance(range2.first, range2.second), 5);
+  } else {
+    ASSERT_EQ(std::distance(range.first, range.second), 1);
+    ASSERT_EQ(std::distance(range2.first, range2.second), 2);
+  }
 
   // Typed
+  auto rrange = rmap.equal_range(r1);
   auto rrange2 = rmultimap.equal_range(r2);
-  ASSERT_EQ(std::distance(rrange2.first, rrange2.second), 2);
+  if constexpr (std::same_as<Res, Host>) {
+    ASSERT_EQ(std::distance(rrange.first, rrange.second), 1);
+    ASSERT_EQ(std::distance(rrange2.first, rrange2.second), 3);
+  } else {
+    ASSERT_EQ(std::distance(rrange.first, rrange.second), 1);
+    ASSERT_EQ(std::distance(rrange2.first, rrange2.second), 2);
+  }
 }
 
 //
@@ -309,29 +337,57 @@ void test_map_key(Event& he)
 
   // Verify using Event as a key to find entries works
   // Generic
-  ASSERT_EQ(map.count(he), 1);
-  ASSERT_EQ(multimap.count(he), 2);
-  ASSERT_EQ(map.count(d1), 1);
-  ASSERT_EQ(multimap.count(d1), 1);
-  ASSERT_EQ(map.count(d2), 1);
-  ASSERT_EQ(multimap.count(d2), 2);
+  if constexpr (std::same_as<Res, Host>) {
+    ASSERT_EQ(map.count(he), 1);
+    ASSERT_EQ(multimap.count(he), 5);
+    ASSERT_EQ(map.count(d1), 1);
+    ASSERT_EQ(multimap.count(d1), 5);
+    ASSERT_EQ(map.count(d2), 1);
+    ASSERT_EQ(multimap.count(d2), 5);
+  } else {
+    ASSERT_EQ(map.count(he), 1);
+    ASSERT_EQ(multimap.count(he), 2);
+    ASSERT_EQ(map.count(d1), 1);
+    ASSERT_EQ(multimap.count(d1), 1);
+    ASSERT_EQ(map.count(d2), 1);
+    ASSERT_EQ(multimap.count(d2), 2);
+  }
 
   // Typed
-  ASSERT_EQ(rmap.count(e1), 1);
-  ASSERT_EQ(rmultimap.count(e1), 1);
-  ASSERT_EQ(rmap.count(e2), 1);
-  ASSERT_EQ(rmultimap.count(e2), 2);
+  if constexpr (std::same_as<Res, Host>) {
+    ASSERT_EQ(rmap.count(e1), 1);
+    ASSERT_EQ(rmultimap.count(e1), 3);
+    ASSERT_EQ(rmap.count(e2), 1);
+    ASSERT_EQ(rmultimap.count(e2), 3);
+  } else {
+    ASSERT_EQ(rmap.count(e1), 1);
+    ASSERT_EQ(rmultimap.count(e1), 1);
+    ASSERT_EQ(rmap.count(e2), 1);
+    ASSERT_EQ(rmultimap.count(e2), 2);
+  }
 
   // Verify equal_range works
   // Generic
   auto range = map.equal_range(he);
   auto range2 = multimap.equal_range(d2);
-  ASSERT_EQ(std::distance(range.first, range.second), 1);
-  ASSERT_EQ(std::distance(range2.first, range2.second), 2);
+  if constexpr (std::same_as<Res, Host>) {
+    ASSERT_EQ(std::distance(range.first, range.second), 1);
+    ASSERT_EQ(std::distance(range2.first, range2.second), 5);
+  } else {
+    ASSERT_EQ(std::distance(range.first, range.second), 1);
+    ASSERT_EQ(std::distance(range2.first, range2.second), 2);
+  }
 
   // Typed
+  auto rrange = rmap.equal_range(e1);
   auto rrange2 = rmultimap.equal_range(e2);
-  ASSERT_EQ(std::distance(rrange2.first, rrange2.second), 2);
+  if constexpr (std::same_as<Res, Host>) {
+    ASSERT_EQ(std::distance(rrange.first, rrange.second), 1);
+    ASSERT_EQ(std::distance(rrange2.first, rrange2.second), 3);
+  } else {
+    ASSERT_EQ(std::distance(rrange.first, rrange.second), 1);
+    ASSERT_EQ(std::distance(rrange2.first, rrange2.second), 2);
+  }
 }
 
 //

--- a/test/resource.cpp
+++ b/test/resource.cpp
@@ -174,19 +174,23 @@ TEST(CampResource, GetPlatform)
 
 TEST(CampEvent, GetPlatform)
 {
-  ASSERT_EQ(static_cast<const Event>(Host()).get_platform(), Platform::host);
+  ASSERT_EQ(static_cast<const Event>(Host().get_event_erased()).get_platform(),
+            Platform::host);
 #ifdef CAMP_HAVE_CUDA
-  ASSERT_EQ(static_cast<const Event>(Cuda()).get_platform(), Platform::cuda);
+  ASSERT_EQ(static_cast<const Event>(Cuda().get_event_erased()).get_platform(),
+            Platform::cuda);
 #endif
 #ifdef CAMP_HAVE_HIP
-  ASSERT_EQ(static_cast<const Event>(Hip()).get_platform(), Platform::hip);
+  ASSERT_EQ(static_cast<const Event>(Hip().get_event_erased()).get_platform(),
+            Platform::hip);
 #endif
 #ifdef CAMP_HAVE_OMP_OFFLOAD
-  ASSERT_EQ(static_cast<const Event>(Omp()).get_platform(),
+  ASSERT_EQ(static_cast<const Event>(Omp().get_event_erased()).get_platform(),
             Platform::omp_target);
 #endif
 #ifdef CAMP_HAVE_SYCL
-  ASSERT_EQ(static_cast<const Event>(Sycl()).get_platform(), Platform::sycl);
+  ASSERT_EQ(static_cast<const Event>(Sycl().get_event_erased()).get_platform(),
+            Platform::sycl);
 #endif
 }
 


### PR DESCRIPTION
Make events usable as keys in some containers like unordered_map.
Add hashability and comparability.

I also made Event and Resource safe to use when empty, but I might break that off into a separate PR as its orthogonal to these changes.