### PR TITLE
Move Only Events

### DIFF
--- a/include/camp/concepts.hpp
+++ b/include/camp/concepts.hpp
@@ -381,7 +381,7 @@ namespace resources
 
     template <typename T>
     struct is_concrete_resource
-        : is_concrete_resource_impl<typename std::decay_t<T>> {
+        : is_concrete_resource_impl<typename std::remove_cvref_t<T>> {
     };
 
     template <typename T>

--- a/include/camp/concepts.hpp
+++ b/include/camp/concepts.hpp
@@ -356,6 +356,51 @@ namespace type_traits
   };
 
 }  // end namespace type_traits
+
+namespace resources
+{
+  inline namespace v1
+  {
+
+    template <typename T>
+    struct is_concrete_event_impl : std::false_type {
+    };
+
+    template <typename T>
+    struct is_concrete_event
+        : is_concrete_event_impl<typename std::remove_cvref_t<T>> {
+    };
+
+    template <typename T>
+    inline constexpr bool is_concrete_event_v = is_concrete_event<T>::value;
+
+
+    template <typename T>
+    struct is_concrete_resource_impl : std::false_type {
+    };
+
+    template <typename T>
+    struct is_concrete_resource
+        : is_concrete_resource_impl<typename std::decay_t<T>> {
+    };
+
+    template <typename T>
+    inline constexpr bool is_concrete_resource_v = is_concrete_resource<T>::value;
+
+  }  // namespace v1
+}  // namespace resources
+
+namespace concepts
+{
+
+  template < typename T >
+  concept ConcreteEvent = ::camp::resources::is_concrete_event_v<T>;
+
+  template < typename T >
+  concept ConcreteResource = ::camp::resources::is_concrete_resource_v<T>;
+
+}  // namespace concepts
+
 }  // namespace camp
 
 #endif /* CAMP_CONCEPTS_HPP */

--- a/include/camp/resource.hpp
+++ b/include/camp/resource.hpp
@@ -36,6 +36,7 @@ namespace resources
     public:
       using event_type = Event;
 
+      Resource() = default;
       Resource(Resource &&) = default;
       Resource(Resource const &) = default;
       Resource &operator=(Resource &&) = default;

--- a/include/camp/resource.hpp
+++ b/include/camp/resource.hpp
@@ -209,6 +209,8 @@ namespace resources
         m_value->wait();
       }
 
+      explicit operator bool() const { return static_cast<bool>(m_value); }
+
       /*
        * \brief Compares two Resources to see if they are equal. Two Resources
        * are equal if they have the platform and same stream/queue

--- a/include/camp/resource.hpp
+++ b/include/camp/resource.hpp
@@ -41,11 +41,7 @@ namespace resources
       Resource &operator=(Resource &&) = default;
       Resource &operator=(Resource const &) = default;
 
-      template <typename T,
-                typename = typename std::enable_if_t<
-                    !std::is_same_v<typename std::decay_t<T>, Resource>
-                    && is_concrete_resource_v<T>>
-                >
+      template <camp::concepts::ConcreteResource T>
       Resource(T &&value)
       {
         m_value.reset(new ContextModel<type::ref::rem<T>>(forward<T>(value)));

--- a/include/camp/resource.hpp
+++ b/include/camp/resource.hpp
@@ -276,7 +276,7 @@ namespace resources
       class ContextModel final : public ContextInterface
       {
       public:
-        ContextModel(T const &modelVal) : m_modelVal(modelVal) {}
+        explicit ContextModel(T const &modelVal) : m_modelVal(modelVal) {}
 
         Platform get_platform() const override
         {

--- a/include/camp/resource.hpp
+++ b/include/camp/resource.hpp
@@ -181,7 +181,7 @@ namespace resources
         return m_value->get_event_erased();
       }
 
-      void wait_for(Event& e)
+      void wait_for(Event const& e)
       {
         if (!m_value) {
             e.wait();
@@ -280,7 +280,7 @@ namespace resources
 
         virtual Event get_event() = 0;
         virtual Event get_event_erased() = 0;
-        virtual void wait_for(Event& e) = 0;
+        virtual void wait_for(Event const& e) = 0;
         virtual void wait() = 0;
       };
 
@@ -337,7 +337,7 @@ namespace resources
           return m_modelVal.get_event_erased();
         }
 
-        void wait_for(Event& e) override { m_modelVal.wait_for(e); }
+        void wait_for(Event const& e) override { m_modelVal.wait_for(e); }
 
         void wait() override { m_modelVal.wait(); }
 

--- a/include/camp/resource.hpp
+++ b/include/camp/resource.hpp
@@ -20,40 +20,7 @@
 #include "camp/defines.hpp"
 #include "camp/helpers.hpp"
 
-namespace camp
-{
-namespace resources
-{
-  template <typename T>
-  struct is_concrete_resource_impl : std::false_type {
-  };
-
-  template <typename T>
-  struct is_concrete_resource
-      : is_concrete_resource_impl<typename std::decay_t<T>> {
-  };
-
-  template <typename T>
-  inline constexpr bool is_concrete_resource_v = is_concrete_resource<T>::value;
-}  // namespace resources
-}  // namespace camp
-
 #include "camp/resource/event.hpp"
-#include "camp/resource/host.hpp"
-
-#if defined(CAMP_HAVE_CUDA)
-#include "camp/resource/cuda.hpp"
-#endif
-#if defined(CAMP_HAVE_HIP)
-#include "camp/resource/hip.hpp"
-#endif
-#if defined(CAMP_HAVE_SYCL)
-#include "camp/resource/sycl.hpp"
-#endif
-
-#if defined(CAMP_HAVE_OMP_OFFLOAD)
-#include "camp/resource/omp_target.hpp"
-#endif
 
 // last to ensure we don't hide breakage in the others
 #include "camp/resource/platform.hpp"
@@ -373,38 +340,6 @@ namespace resources
       std::shared_ptr<ContextInterface> m_value;
     };
 
-    template <Platform p>
-    struct resource_from_platform;
-
-    template <>
-    struct resource_from_platform<Platform::host> {
-      using type = ::camp::resources::Host;
-    };
-#if defined(CAMP_HAVE_CUDA)
-    template <>
-    struct resource_from_platform<Platform::cuda> {
-      using type = ::camp::resources::Cuda;
-    };
-#endif
-#if defined(CAMP_HAVE_HIP)
-    template <>
-    struct resource_from_platform<Platform::hip> {
-      using type = ::camp::resources::Hip;
-    };
-#endif
-#if defined(CAMP_HAVE_SYCL)
-    template <>
-    struct resource_from_platform<Platform::sycl> {
-      using type = ::camp::resources::Sycl;
-    };
-#endif
-#if defined(CAMP_HAVE_OMP_OFFLOAD)
-    template <>
-    struct resource_from_platform<Platform::omp_target> {
-      using type = ::camp::resources::Omp;
-    };
-#endif
-
     namespace detail
     {
       template <typename Res>
@@ -481,5 +416,21 @@ struct hash<camp::resources::Resource> {
 };
 
 }  // namespace std
+
+#include "camp/resource/host.hpp"
+
+#if defined(CAMP_HAVE_CUDA)
+#include "camp/resource/cuda.hpp"
+#endif
+#if defined(CAMP_HAVE_HIP)
+#include "camp/resource/hip.hpp"
+#endif
+#if defined(CAMP_HAVE_SYCL)
+#include "camp/resource/sycl.hpp"
+#endif
+
+#if defined(CAMP_HAVE_OMP_OFFLOAD)
+#include "camp/resource/omp_target.hpp"
+#endif
 
 #endif /* __CAMP_RESOURCE_HPP */

--- a/include/camp/resource.hpp
+++ b/include/camp/resource.hpp
@@ -34,6 +34,8 @@ namespace resources
     class Resource
     {
     public:
+      using event_type = Event;
+
       Resource(Resource &&) = default;
       Resource(Resource const &) = default;
       Resource &operator=(Resource &&) = default;
@@ -340,20 +342,10 @@ namespace resources
       std::shared_ptr<ContextInterface> m_value;
     };
 
-    namespace detail
-    {
-      template <typename Res>
-      using get_event_type =
-          typename std::decay<decltype(std::declval<Res>().get_event())>::type;
-
-      template <typename T>
-      using is_erased_resource_or_proxy =
-          typename std::is_same<get_event_type<T>, Event>::type;
-    }  // namespace detail
-
     template <typename Res>
-    struct EventProxy : ::camp::resources::detail::EventProxyBase {
-      using native_event = ::camp::resources::detail::get_event_type<Res>;
+    struct EventProxy : ::camp::resources::detail::EventProxyBase
+    {
+      using native_event = typename Res::event_type;
 
       EventProxy(EventProxy &&) = default;
       EventProxy(EventProxy const &) = delete;
@@ -362,31 +354,28 @@ namespace resources
 
       EventProxy(Res r) : resource_{move(r)} {}
 
-      template <typename T = Res>
-      typename std::enable_if<!detail::is_erased_resource_or_proxy<T>::value,
-                              native_event>::type
-      get()
+      native_event get()
+      requires (!std::same_as<native_event, Event>)
       {
         return resource_.get_event();
       }
 
-      template <typename T = Res>
-      typename std::enable_if<detail::is_erased_resource_or_proxy<T>::value,
-                              Event>::type
-      get()
+      Event get()
+      requires (std::same_as<native_event, Event>)
       {
         return resource_.get_event_erased();
       }
 
-      template <typename T = Res>
-      operator typename std::enable_if<
-          !detail::is_erased_resource_or_proxy<T>::value,
-          native_event>::type()
+      operator native_event()
+      requires (!std::same_as<native_event, Event>)
       {
         return resource_.get_event();
       }
 
-      operator Event() { return resource_.get_event_erased(); }
+      operator Event()
+      {
+        return resource_.get_event_erased();
+      }
 
       Res resource_;
     };

--- a/include/camp/resource.hpp
+++ b/include/camp/resource.hpp
@@ -181,15 +181,22 @@ namespace resources
         return m_value->get_event_erased();
       }
 
-      void wait_for(Event *e)
+      void wait_for(Event& e)
       {
         if (!m_value) {
-          if (e) {
-            e->wait();
-          }
+            e.wait();
           return;
         }
         m_value->wait_for(e);
+      }
+
+      [[deprecated]]
+      void wait_for(Event *e)
+      {
+        if (!e) {
+          return;
+        }
+        wait_for(*e);
       }
 
       void wait()
@@ -273,7 +280,7 @@ namespace resources
 
         virtual Event get_event() = 0;
         virtual Event get_event_erased() = 0;
-        virtual void wait_for(Event *e) = 0;
+        virtual void wait_for(Event& e) = 0;
         virtual void wait() = 0;
       };
 
@@ -330,7 +337,7 @@ namespace resources
           return m_modelVal.get_event_erased();
         }
 
-        void wait_for(Event *e) override { m_modelVal.wait_for(e); }
+        void wait_for(Event& e) override { m_modelVal.wait_for(e); }
 
         void wait() override { m_modelVal.wait(); }
 

--- a/include/camp/resource.hpp
+++ b/include/camp/resource.hpp
@@ -240,7 +240,9 @@ namespace resources
           return false;
         }
         if (lhs.get_platform() == rhs.get_platform()) {
-          return lhs.get<Res>() == rhs;
+          if (auto lhs_res = lhs.try_get<Res>()) {
+            return *lhs_res == rhs;
+          }
         }
         return false;
       }

--- a/include/camp/resource.hpp
+++ b/include/camp/resource.hpp
@@ -190,15 +190,6 @@ namespace resources
         m_value->wait_for(e);
       }
 
-      [[deprecated]]
-      void wait_for(Event *e)
-      {
-        if (!e) {
-          return;
-        }
-        wait_for(*e);
-      }
-
       void wait()
       {
         if (!m_value) {

--- a/include/camp/resource.hpp
+++ b/include/camp/resource.hpp
@@ -48,7 +48,7 @@ namespace resources
       }
 
       template <typename T>
-      T *try_get()
+      T* try_get()
       {
         if (!m_value) {
           return nullptr;
@@ -61,7 +61,7 @@ namespace resources
       }
 
       template <typename T>
-      T const*try_get() const
+      T const* try_get() const
       {
         if (!m_value) {
           return nullptr;
@@ -97,16 +97,6 @@ namespace resources
       T get() &&
       {
         T* result = try_get<T>();
-        if (result == nullptr) {
-          ::camp::throw_re("Incompatible Resource type get cast.");
-        }
-        return std::move(*result);
-      }
-
-      template <typename T>
-      T get() const&&
-      {
-        T const* result = try_get<T>();
         if (result == nullptr) {
           ::camp::throw_re("Incompatible Resource type get cast.");
         }

--- a/include/camp/resource.hpp
+++ b/include/camp/resource.hpp
@@ -233,6 +233,18 @@ namespace resources
         return false;
       }
 
+      template < camp::concepts::ConcreteResource Res >
+      friend inline bool operator==(Resource const &lhs, Res const &rhs)
+      {
+        if (!lhs.m_value) {
+          return false;
+        }
+        if (lhs.get_platform() == rhs.get_platform()) {
+          return lhs.get<Res>() == rhs;
+        }
+        return false;
+      }
+
     private:
       friend struct std::hash<camp::resources::Resource>;
 

--- a/include/camp/resource/cuda.hpp
+++ b/include/camp/resource/cuda.hpp
@@ -18,6 +18,7 @@
 
 #include <array>
 #include <mutex>
+#include <utility>
 
 #include "camp/defines.hpp"
 #include "camp/helpers.hpp"

--- a/include/camp/resource/cuda.hpp
+++ b/include/camp/resource/cuda.hpp
@@ -242,7 +242,7 @@ namespace resources
       CudaEvent get_event()
       {
         auto d{device_guard(get_device())};
-        return CudaEvent(res.get_stream());
+        return CudaEvent(get_stream());
       }
 
       Event get_event_erased() { return Event{get_event()}; }

--- a/include/camp/resource/cuda.hpp
+++ b/include/camp/resource/cuda.hpp
@@ -239,9 +239,13 @@ namespace resources
         return c;
       }
 
-      CudaEvent get_event() { return CudaEvent(*this); }
+      CudaEvent get_event()
+      {
+        auto d{device_guard(get_device())};
+        return CudaEvent(res.get_stream());
+      }
 
-      Event get_event_erased() { return Event{CudaEvent(*this)}; }
+      Event get_event_erased() { return Event{get_event()}; }
 
       void wait()
       {
@@ -249,15 +253,25 @@ namespace resources
         CAMP_CUDA_API_INVOKE_AND_CHECK(cudaStreamSynchronize, stream);
       }
 
+      void wait_for(CudaEvent *e)
+      {
+        if (!e) {
+          return;
+        }
+        auto d{device_guard(device)};
+        CAMP_CUDA_API_INVOKE_AND_CHECK(cudaStreamWaitEvent,
+                                       get_stream(),
+                                       e->getCudaEvent_t(),
+                                       0);
+      }
+
       void wait_for(Event *e)
       {
-        auto *cuda_event = e->try_get<CudaEvent>();
-        if (cuda_event) {
-          auto d{device_guard(device)};
-          CAMP_CUDA_API_INVOKE_AND_CHECK(cudaStreamWaitEvent,
-                                         get_stream(),
-                                         cuda_event->getCudaEvent_t(),
-                                         0);
+        if (!e) {
+          return;
+        }
+        if (auto cuda_event = e->try_get<CudaEvent>()) {
+          wait_for(cuda_event);
         } else {
           e->wait();
         }

--- a/include/camp/resource/cuda.hpp
+++ b/include/camp/resource/cuda.hpp
@@ -138,7 +138,7 @@ namespace resources
         CAMP_CUDA_API_INVOKE_AND_CHECK(cudaEventCreateWithFlags,
                                        &event,
                                        cudaEventDisableTiming);
-        CAMP_CUDA_API_INVOKE_AND_CHECK(cudaEventRecord, m_event, stream);
+        CAMP_CUDA_API_INVOKE_AND_CHECK(cudaEventRecord, event, stream);
         return event;
       }
 

--- a/include/camp/resource/cuda.hpp
+++ b/include/camp/resource/cuda.hpp
@@ -16,6 +16,7 @@
 
 #include <cuda_runtime.h>
 
+#include <cstddef>
 #include <array>
 #include <mutex>
 #include <utility>
@@ -253,6 +254,8 @@ namespace resources
         auto d{device_guard(device)};
         CAMP_CUDA_API_INVOKE_AND_CHECK(cudaStreamSynchronize, stream);
       }
+
+      void wait_for(std::nullptr_t) {}
 
       void wait_for(CudaEvent *e)
       {

--- a/include/camp/resource/cuda.hpp
+++ b/include/camp/resource/cuda.hpp
@@ -292,19 +292,19 @@ namespace resources
             case MemoryAccess::Unknown:
             case MemoryAccess::Device:
               CAMP_CUDA_API_INVOKE_AND_CHECK(cudaMalloc,
-                                             &ret,
+                                             (void **)&ret,
                                              sizeof(T) * size);
               break;
             case MemoryAccess::Pinned:
               // TODO: do a test here for whether managed is *actually* shared
               // so we can use the better performing memory
               CAMP_CUDA_API_INVOKE_AND_CHECK(cudaMallocHost,
-                                             &ret,
+                                             (void **)&ret,
                                              sizeof(T) * size);
               break;
             case MemoryAccess::Managed:
               CAMP_CUDA_API_INVOKE_AND_CHECK(cudaMallocManaged,
-                                             &ret,
+                                             (void **)&ret,
                                              sizeof(T) * size);
               break;
           }
@@ -339,6 +339,7 @@ namespace resources
             break;
           case MemoryAccess::Unknown:
             ::camp::throw_re("Unknown memory access type, cannot free");
+            break;
         }
       }
 

--- a/include/camp/resource/cuda.hpp
+++ b/include/camp/resource/cuda.hpp
@@ -60,9 +60,31 @@ namespace resources
     class CudaEvent
     {
     public:
-      CudaEvent(cudaStream_t stream) { init(stream); }
+      CudaEvent(cudaStream_t stream)
+        : m_event(init(stream))
+      {}
 
       CudaEvent(Cuda &res);
+
+      CudaEvent(CudaEvent const&) = delete;
+
+      CudaEvent(CudaEvent&& rhs) noexcept
+        : m_event(std::exchange(rhs.m_event, nullptr))
+      {}
+
+      CudaEvent& operator=(CudaEvent const&) = delete;
+
+      CudaEvent& operator=(CudaEvent&& rhs) noexcept
+      {
+        finalize(m_event);
+        m_event = std::exchange(rhs.m_event, nullptr);
+        return *this;
+      }
+
+      ~CudaEvent()
+      {
+        finalize(m_event);
+      }
 
       Platform get_platform() const { return Platform::cuda; }
 
@@ -96,14 +118,24 @@ namespace resources
 
     private:
       // note that cudaEvent_t is an alias for a pointer and is nullable
-      cudaEvent_t m_event;
+      cudaEvent_t m_event = nullptr;
 
-      void init(cudaStream_t stream)
+      static cudaEvent_t init(cudaStream_t stream)
       {
+        cudaEvent_t event;
         CAMP_CUDA_API_INVOKE_AND_CHECK(cudaEventCreateWithFlags,
-                                       &m_event,
+                                       &event,
                                        cudaEventDisableTiming);
         CAMP_CUDA_API_INVOKE_AND_CHECK(cudaEventRecord, m_event, stream);
+        return event;
+      }
+
+      static void finalize(cudaEvent_t& event)
+      {
+        if (event != nullptr) {
+          campCudaErrchk(cudaEventDestroy(event));
+          event = nullptr;
+        }
       }
     };
 

--- a/include/camp/resource/cuda.hpp
+++ b/include/camp/resource/cuda.hpp
@@ -30,7 +30,21 @@ namespace resources
 {
   inline namespace v1
   {
+    class CudaEvent;
     class Cuda;
+
+    template <>
+    struct resource_from_platform<Platform::cuda> {
+      using type = ::camp::resources::Cuda;
+    };
+
+    template <>
+    struct is_concrete_event_impl<CudaEvent> : std::true_type {
+    };
+
+    template <>
+    struct is_concrete_resource_impl<Cuda> : std::true_type {
+    };
 
     namespace
     {
@@ -350,17 +364,7 @@ namespace resources
       int device;
     };
 
-    inline CudaEvent::CudaEvent(Cuda &res)
-    {
-      auto d{device_guard(res.get_device())};
-      init(res.get_stream());
-    }
-
   }  // namespace v1
-
-  template <>
-  struct is_concrete_resource_impl<Cuda> : std::true_type {
-  };
 
 }  // namespace resources
 }  // namespace camp

--- a/include/camp/resource/cuda.hpp
+++ b/include/camp/resource/cuda.hpp
@@ -255,7 +255,7 @@ namespace resources
         CAMP_CUDA_API_INVOKE_AND_CHECK(cudaStreamSynchronize, stream);
       }
 
-      void wait_for(CudaEvent& e)
+      void wait_for(CudaEvent const& e)
       {
         auto d{device_guard(device)};
         CAMP_CUDA_API_INVOKE_AND_CHECK(cudaStreamWaitEvent,
@@ -264,7 +264,7 @@ namespace resources
                                        0);
       }
 
-      void wait_for(Event& e)
+      void wait_for(Event const& e)
       {
         if (auto cuda_event = e.try_get<CudaEvent>()) {
           wait_for(*cuda_event);

--- a/include/camp/resource/cuda.hpp
+++ b/include/camp/resource/cuda.hpp
@@ -273,19 +273,6 @@ namespace resources
         }
       }
 
-      [[deprecated]]
-      void wait_for(Event *e)
-      {
-        if (!e) {
-          return;
-        }
-        if (auto cuda_event = e->try_get<CudaEvent>()) {
-          wait_for(*cuda_event);
-        } else {
-          e->wait();
-        }
-      }
-
       // Memory
       template <typename T>
       T *allocate(size_t size, MemoryAccess ma = MemoryAccess::Device)

--- a/include/camp/resource/cuda.hpp
+++ b/include/camp/resource/cuda.hpp
@@ -132,7 +132,7 @@ namespace resources
 
     private:
       // note that cudaEvent_t is an alias for a pointer and is nullable
-      cudaEvent_t m_event = nullptr;
+      cudaEvent_t m_event;
 
       static cudaEvent_t init(cudaStream_t stream)
       {

--- a/include/camp/resource/cuda.hpp
+++ b/include/camp/resource/cuda.hpp
@@ -206,6 +206,8 @@ namespace resources
       }
 
     public:
+      using event_type = CudaEvent;
+
       Cuda(int group = -1, int dev = 0)
           : stream(get_a_stream(group)), device(dev)
       {

--- a/include/camp/resource/cuda.hpp
+++ b/include/camp/resource/cuda.hpp
@@ -255,27 +255,32 @@ namespace resources
         CAMP_CUDA_API_INVOKE_AND_CHECK(cudaStreamSynchronize, stream);
       }
 
-      void wait_for(std::nullptr_t) {}
-
-      void wait_for(CudaEvent *e)
+      void wait_for(CudaEvent& e)
       {
-        if (!e) {
-          return;
-        }
         auto d{device_guard(device)};
         CAMP_CUDA_API_INVOKE_AND_CHECK(cudaStreamWaitEvent,
                                        get_stream(),
-                                       e->getCudaEvent_t(),
+                                       e.getCudaEvent_t(),
                                        0);
       }
 
+      void wait_for(Event& e)
+      {
+        if (auto cuda_event = e.try_get<CudaEvent>()) {
+          wait_for(*cuda_event);
+        } else {
+          e.wait();
+        }
+      }
+
+      [[deprecated]]
       void wait_for(Event *e)
       {
         if (!e) {
           return;
         }
         if (auto cuda_event = e->try_get<CudaEvent>()) {
-          wait_for(cuda_event);
+          wait_for(*cuda_event);
         } else {
           e->wait();
         }

--- a/include/camp/resource/cuda.hpp
+++ b/include/camp/resource/cuda.hpp
@@ -145,7 +145,7 @@ namespace resources
       static void finalize(cudaEvent_t& event)
       {
         if (event != nullptr) {
-          campCudaErrchk(cudaEventDestroy(event));
+          CAMP_CUDA_API_INVOKE_AND_CHECK(cudaEventDestroy, event);
           event = nullptr;
         }
       }

--- a/include/camp/resource/cuda.hpp
+++ b/include/camp/resource/cuda.hpp
@@ -74,11 +74,9 @@ namespace resources
     class CudaEvent
     {
     public:
-      CudaEvent(cudaStream_t stream)
+      explicit CudaEvent(cudaStream_t stream)
         : m_event(init(stream))
       {}
-
-      CudaEvent(Cuda &res);
 
       CudaEvent(CudaEvent const&) = delete;
 

--- a/include/camp/resource/event.hpp
+++ b/include/camp/resource/event.hpp
@@ -42,16 +42,10 @@ namespace resources
       Event &operator=(Event const &e) = default;
       Event &operator=(Event &&e) = default;
 
-      template <
-          typename T,
-          typename std::enable_if<
-              !std::is_same_v<typename std::decay_t<T>, Event> &&
-              !(std::is_convertible<typename std::decay<T>::type *,
-                                    ::camp::resources::detail::EventProxyBase
-                                        *>::value)>::type * = nullptr>
-      Event(T &&value)
+      template <camp::concepts::ConcreteEvent T>
+      explicit Event(T &&value)
       {
-        m_value.reset(new EventModel<type::ref::rem<T>>(value));
+        m_value.reset(new EventModel<type::ref::rem<T>>(std::forward<T>(value)));
       }
 
       template <typename T>

--- a/include/camp/resource/event.hpp
+++ b/include/camp/resource/event.hpp
@@ -43,7 +43,7 @@ namespace resources
       Event &operator=(Event &&e) = default;
 
       template <camp::concepts::ConcreteEvent T>
-      explicit Event(T &&value)
+      Event(T &&value)
       {
         m_value.reset(new EventModel<type::ref::rem<T>>(std::forward<T>(value)));
       }

--- a/include/camp/resource/event.hpp
+++ b/include/camp/resource/event.hpp
@@ -49,7 +49,7 @@ namespace resources
       }
 
       template <typename T>
-      T *try_get()
+      T* try_get()
       {
         if (!m_value) {
           return nullptr;
@@ -58,11 +58,11 @@ namespace resources
         if (!result) {
           return nullptr;
         }
-        return result->get();
+        return &result->get();
       }
 
       template <typename T>
-      T const*try_get() const
+      T const* try_get() const
       {
         if (!m_value) {
           return nullptr;
@@ -95,7 +95,7 @@ namespace resources
       }
 
       template <typename T>
-      T get() &&
+      T && get() &&
       {
         T* result = try_get<T>();
         if (result == nullptr) {
@@ -105,7 +105,7 @@ namespace resources
       }
 
       template <typename T>
-      T get() const&&
+      T const&& get() const&&
       {
         T const* result = try_get<T>();
         if (result == nullptr) {
@@ -218,9 +218,13 @@ namespace resources
           m_modelVal.wait();
         }
 
-        T const& get() const { return m_modelVal; }
+        T const& get() const& { return m_modelVal; }
 
-        T& get() { return m_modelVal; }
+        T& get() & { return m_modelVal; }
+
+        T const&& get() const&& { return m_modelVal; }
+
+        T&& get() && { return m_modelVal; }
 
       private:
         T m_modelVal;

--- a/include/camp/resource/event.hpp
+++ b/include/camp/resource/event.hpp
@@ -181,10 +181,12 @@ namespace resources
       };
 
       template <typename T>
-      class EventModel : public EventInterface
+      class EventModel final : public EventInterface
       {
       public:
-        EventModel(T const &modelVal) : m_modelVal(modelVal) {}
+        EventModel(T modelVal)
+          : m_modelVal(std::move(modelVal))
+        {}
 
         Platform get_platform() const override
         {
@@ -198,13 +200,19 @@ namespace resources
 
         size_t get_hash() const override { return m_modelVal.get_hash(); }
 
-        bool check() const override { return m_modelVal.check(); }
+        bool check() const override
+        {
+          return m_modelVal.check();
+        }
 
-        void wait() const override { m_modelVal.wait(); }
+        void wait() const override
+        {
+          m_modelVal.wait();
+        }
 
-        const T* get() const { return &m_modelVal; }
+        T const& get() const { return m_modelVal; }
 
-        T* get() { return &m_modelVal; }
+        T& get() { return m_modelVal; }
 
       private:
         T m_modelVal;

--- a/include/camp/resource/event.hpp
+++ b/include/camp/resource/event.hpp
@@ -123,6 +123,8 @@ namespace resources
 
       void wait() const { if (m_value) { m_value->wait(); } }
 
+      explicit operator bool() const { return static_cast<bool>(m_value); }
+
       /*
        * \brief Compares two Events to see if they represent the same underlying
        *        typed event. Two Events are equal if they have the platform and

--- a/include/camp/resource/event.hpp
+++ b/include/camp/resource/event.hpp
@@ -155,7 +155,9 @@ namespace resources
           return false;
         }
         if (lhs.get_platform() == rhs.get_platform()) {
-          return lhs.get<Evt>() == rhs;
+          if (auto lhs_event = lhs.try_get<Evt>()) {
+            return *lhs_event == rhs;
+          }
         }
         return false;
       }

--- a/include/camp/resource/event.hpp
+++ b/include/camp/resource/event.hpp
@@ -58,7 +58,7 @@ namespace resources
         if (!result) {
           return nullptr;
         }
-        return &result->get();
+        return result->get();
       }
 
       template <typename T>
@@ -71,7 +71,7 @@ namespace resources
         if (!result) {
           return nullptr;
         }
-        return &result->get();
+        return result->get();
       }
 
       template <typename T>
@@ -95,19 +95,9 @@ namespace resources
       }
 
       template <typename T>
-      T && get() &&
+      T get() &&
       {
         T* result = try_get<T>();
-        if (result == nullptr) {
-          ::camp::throw_re("Incompatible Event type get cast.");
-        }
-        return std::move(*result);
-      }
-
-      template <typename T>
-      T const&& get() const&&
-      {
-        T const* result = try_get<T>();
         if (result == nullptr) {
           ::camp::throw_re("Incompatible Event type get cast.");
         }
@@ -220,13 +210,9 @@ namespace resources
           m_modelVal.wait();
         }
 
-        T const& get() const& { return m_modelVal; }
+        T const* get() const { return &m_modelVal; }
 
-        T& get() & { return m_modelVal; }
-
-        T const&& get() const&& { return m_modelVal; }
-
-        T&& get() && { return m_modelVal; }
+        T* get() { return &m_modelVal; }
 
       private:
         T m_modelVal;

--- a/include/camp/resource/event.hpp
+++ b/include/camp/resource/event.hpp
@@ -148,6 +148,18 @@ namespace resources
         return false;
       }
 
+      template < camp::concepts::ConcreteEvent Evt >
+      friend inline bool operator==(Event const &lhs, Evt const &rhs)
+      {
+        if (!lhs.m_value) {
+          return false;
+        }
+        if (lhs.get_platform() == rhs.get_platform()) {
+          return lhs.get<Evt>() == rhs;
+        }
+        return false;
+      }
+
     private:
       friend struct std::hash<camp::resources::Event>;
 

--- a/include/camp/resource/event.hpp
+++ b/include/camp/resource/event.hpp
@@ -180,7 +180,7 @@ namespace resources
       class EventModel final : public EventInterface
       {
       public:
-        EventModel(T modelVal)
+        explicit EventModel(T modelVal)
           : m_modelVal(std::move(modelVal))
         {}
 

--- a/include/camp/resource/event.hpp
+++ b/include/camp/resource/event.hpp
@@ -77,7 +77,7 @@ namespace resources
         if (!result) {
           return nullptr;
         }
-        return result->get();
+        return &result->get();
       }
 
       template <typename T>

--- a/include/camp/resource/hip.hpp
+++ b/include/camp/resource/hip.hpp
@@ -238,9 +238,13 @@ namespace resources
         return h;
       }
 
-      HipEvent get_event() { return HipEvent(*this); }
+      HipEvent get_event()
+      {
+        auto d{device_guard(get_device())};
+        return HipEvent(get_stream());
+      }
 
-      Event get_event_erased() { return Event{HipEvent(*this)}; }
+      Event get_event_erased() { return Event{get_event()}; }
 
       void wait()
       {
@@ -248,15 +252,24 @@ namespace resources
         CAMP_HIP_API_INVOKE_AND_CHECK(hipStreamSynchronize, stream);
       }
 
+      void wait_for(HipEvent *e)
+      {
+        if (!e) {
+          return;
+        }
+        auto d{device_guard(device)};
+        CAMP_HIP_API_INVOKE_AND_CHECK(hipStreamWaitEvent,
+                                      get_stream(),
+                                      e->getHipEvent_t(),
+                                      0);
+      }
       void wait_for(Event *e)
       {
-        auto *hip_event = e->try_get<HipEvent>();
-        if (hip_event) {
-          auto d{device_guard(device)};
-          CAMP_HIP_API_INVOKE_AND_CHECK(hipStreamWaitEvent,
-                                        get_stream(),
-                                        hip_event->getHipEvent_t(),
-                                        0);
+        if (!e) {
+          return;
+        }
+        if (auto hip_event = e->try_get<HipEvent>()) {
+          wait_for(hip_event);
         } else {
           e->wait();
         }

--- a/include/camp/resource/hip.hpp
+++ b/include/camp/resource/hip.hpp
@@ -269,6 +269,7 @@ namespace resources
                                       e->getHipEvent_t(),
                                       0);
       }
+
       void wait_for(Event *e)
       {
         if (!e) {
@@ -390,6 +391,7 @@ namespace resources
 
 namespace std
 {
+
 /*
  * \brief Specialization of std::hash for camp::resources::HipEvent
  *

--- a/include/camp/resource/hip.hpp
+++ b/include/camp/resource/hip.hpp
@@ -18,6 +18,7 @@
 
 #include <array>
 #include <mutex>
+#include <utility>
 
 #include "camp/defines.hpp"
 #include "camp/helpers.hpp"

--- a/include/camp/resource/hip.hpp
+++ b/include/camp/resource/hip.hpp
@@ -114,9 +114,9 @@ namespace resources
 
       /*
        * \brief Compares two events to see if they represent the same underlying
-       *        cuda event.
+       *        hip event.
        *
-       * \return True if both refer to the same cuda event, false otherwise.
+       * \return True if both refer to the same hip event, false otherwise.
        */
       friend inline bool operator==(HipEvent const& lhs, HipEvent const& rhs) = default;
 
@@ -145,7 +145,7 @@ namespace resources
       static void finalize(hipEvent_t& event)
       {
         if (event != nullptr) {
-          CAMP_CUDA_API_INVOKE_AND_CHECK(hipEventDestroy, event);
+          CAMP_HIP_API_INVOKE_AND_CHECK(hipEventDestroy, event);
           event = nullptr;
         }
       }
@@ -365,10 +365,7 @@ namespace resources
        *
        * \return True or false depending on if this is the same stream
        */
-      bool operator==(Hip const &h) const
-      {
-        return (get_stream() == h.get_stream());
-      }
+      friend inline bool operator==(Hip const& lhs, Hip const& rhs) = default;
 
       /*
        * \brief Compares two (Hip) resources to see if they are NOT equal
@@ -394,6 +391,25 @@ namespace resources
 }  // namespace resources
 }  // namespace camp
 
+namespace std
+{
+/*
+ * \brief Specialization of std::hash for camp::resources::HipEvent
+ *
+ * Provides a hash function for hip typed event objects, enabling their use
+ * as keys in unordered associative containers (std::unordered_map,
+ * std::unordered_set, etc.)
+ *
+ * \return A size_t hash value
+ */
+template <>
+struct hash<camp::resources::HipEvent> {
+  std::size_t operator()(const camp::resources::HipEvent &e) const
+  {
+    return e.get_hash();
+  }
+};
+
 /*
  * \brief Specialization of std::hash for camp::resources::Hip
  *
@@ -403,8 +419,6 @@ namespace resources
  *
  * \return A size_t hash value
  */
-namespace std
-{
 template <>
 struct hash<camp::resources::Hip> {
   std::size_t operator()(const camp::resources::Hip &h) const
@@ -412,6 +426,7 @@ struct hash<camp::resources::Hip> {
     return h.get_hash();
   }
 };
+
 }  // namespace std
 
 #endif  // #ifdef CAMP_ENABLE_HIP

--- a/include/camp/resource/hip.hpp
+++ b/include/camp/resource/hip.hpp
@@ -367,13 +367,6 @@ namespace resources
        */
       friend inline bool operator==(Hip const& lhs, Hip const& rhs) = default;
 
-      /*
-       * \brief Compares two (Hip) resources to see if they are NOT equal
-       *
-       * \return Negation of == operator
-       */
-      bool operator!=(Hip const &h) const { return !(*this == h); }
-
       size_t get_hash() const
       {
         const size_t hip_type = size_t(get_platform()) << 32;

--- a/include/camp/resource/hip.hpp
+++ b/include/camp/resource/hip.hpp
@@ -74,12 +74,12 @@ namespace resources
     class HipEvent
     {
     public:
-      explicit HipEvent(hipStream_t stream) { init(stream); }
+      explicit HipEvent(hipStream_t stream) : m_event(init(stream)) {}
 
       HipEvent(HipEvent const&) = delete;
 
       HipEvent(HipEvent&& rhs) noexcept
-        : m_event(::camp::exchange(rhs.m_event, nullptr))
+        : m_event(std::exchange(rhs.m_event, nullptr))
       {}
 
       HipEvent& operator=(HipEvent const&) = delete;
@@ -88,7 +88,7 @@ namespace resources
       HipEvent& operator=(HipEvent&& rhs) noexcept
       {
         finalize(m_event);
-        m_event = ::camp::exchange(rhs.m_event, nullptr);
+        m_event = std::exchange(rhs.m_event, nullptr);
         return *this;
       }
 
@@ -132,12 +132,14 @@ namespace resources
       // note that hipEvent_t is an alias for a pointer and is nullable
       hipEvent_t m_event;
 
-      void init(hipStream_t stream)
+      static hipEvent_t init(hipStream_t stream)
       {
+        hipEvent_t event;
         CAMP_HIP_API_INVOKE_AND_CHECK(hipEventCreateWithFlags,
-                                      &m_event,
+                                      &event,
                                       hipEventDisableTiming);
-        CAMP_HIP_API_INVOKE_AND_CHECK(hipEventRecord, m_event, stream);
+        CAMP_HIP_API_INVOKE_AND_CHECK(hipEventRecord, event, stream);
+        return event;
       }
 
       static void finalize(hipEvent_t& event)

--- a/include/camp/resource/hip.hpp
+++ b/include/camp/resource/hip.hpp
@@ -16,6 +16,7 @@
 
 #include <hip/hip_runtime.h>
 
+#include <cstddef>
 #include <array>
 #include <mutex>
 #include <utility>
@@ -254,6 +255,8 @@ namespace resources
         auto d{device_guard(device)};
         CAMP_HIP_API_INVOKE_AND_CHECK(hipStreamSynchronize, stream);
       }
+
+      void wait_for(std::nullptr_t) {}
 
       void wait_for(HipEvent *e)
       {

--- a/include/camp/resource/hip.hpp
+++ b/include/camp/resource/hip.hpp
@@ -274,19 +274,6 @@ namespace resources
         }
       }
 
-      [[deprecated]]
-      void wait_for(Event *e)
-      {
-        if (!e) {
-          return;
-        }
-        if (auto hip_event = e->try_get<HipEvent>()) {
-          wait_for(*hip_event);
-        } else {
-          e->wait();
-        }
-      }
-
       // Memory
       template <typename T>
       T *allocate(size_t size, MemoryAccess ma = MemoryAccess::Device)

--- a/include/camp/resource/hip.hpp
+++ b/include/camp/resource/hip.hpp
@@ -64,6 +64,27 @@ namespace resources
 
       HipEvent(Hip &res);
 
+      HipEvent(HipEvent const&) = delete;
+
+      HipEvent(HipEvent&& rhs) noexcept
+        : m_event(::camp::exchange(rhs.m_event, nullptr))
+      {}
+
+      HipEvent& operator=(HipEvent const&) = delete;
+
+
+      HipEvent& operator=(HipEvent&& rhs) noexcept
+      {
+        finalize(m_event);
+        m_event = ::camp::exchange(rhs.m_event, nullptr);
+        return *this;
+      }
+
+      ~HipEvent()
+      {
+        finalize(m_event);
+      }
+
       Platform get_platform() const { return Platform::hip; }
 
       bool check() const
@@ -79,23 +100,7 @@ namespace resources
 
       hipEvent_t getHipEvent_t() const { return m_event; }
 
-      /*
-       * \brief Compares two events to see if they represent the same underlying
-       *        hip event.
-       *
-       * \return True if both refer to the same hip event, false otherwise.
-       */
-      friend inline bool operator==(HipEvent const& lhs, HipEvent const& rhs) = default;
-
-      size_t get_hash() const
-      {
-        const size_t platform_type = size_t(get_platform()) << 32;
-        size_t hash = std::hash<hipEvent_t>{}(m_event);
-        return platform_type | (hash & 0xFFFFFFFF);
-      }
-
     private:
-      // note that cudaEvent_t is an alias for a pointer and is nullable
       hipEvent_t m_event;
 
       void init(hipStream_t stream)
@@ -306,7 +311,17 @@ namespace resources
        *
        * \return True or false depending on if this is the same stream
        */
-      friend inline bool operator==(Hip const& lhs, Hip const& rhs) = default;
+      bool operator==(Hip const &h) const
+      {
+        return (get_stream() == h.get_stream());
+      }
+
+      /*
+       * \brief Compares two (Hip) resources to see if they are NOT equal
+       *
+       * \return Negation of == operator
+       */
+      bool operator!=(Hip const &h) const { return !(*this == h); }
 
       size_t get_hash() const
       {
@@ -334,26 +349,6 @@ namespace resources
 }  // namespace resources
 }  // namespace camp
 
-namespace std
-{
-
-/*
- * \brief Specialization of std::hash for camp::resources::HipEvent
- *
- * Provides a hash function for hip typed event objects, enabling their use
- * as keys in unordered associative containers (std::unordered_map,
- * std::unordered_set, etc.)
- *
- * \return A size_t hash value
- */
-template <>
-struct hash<camp::resources::HipEvent> {
-  std::size_t operator()(const camp::resources::HipEvent &e) const
-  {
-    return e.get_hash();
-  }
-};
-
 /*
  * \brief Specialization of std::hash for camp::resources::Hip
  *
@@ -363,6 +358,8 @@ struct hash<camp::resources::HipEvent> {
  *
  * \return A size_t hash value
  */
+namespace std
+{
 template <>
 struct hash<camp::resources::Hip> {
   std::size_t operator()(const camp::resources::Hip &h) const
@@ -370,7 +367,6 @@ struct hash<camp::resources::Hip> {
     return h.get_hash();
   }
 };
-
 }  // namespace std
 
 #endif  // #ifdef CAMP_ENABLE_HIP

--- a/include/camp/resource/hip.hpp
+++ b/include/camp/resource/hip.hpp
@@ -256,27 +256,32 @@ namespace resources
         CAMP_HIP_API_INVOKE_AND_CHECK(hipStreamSynchronize, stream);
       }
 
-      void wait_for(std::nullptr_t) {}
-
-      void wait_for(HipEvent *e)
+      void wait_for(HipEvent& e)
       {
-        if (!e) {
-          return;
-        }
         auto d{device_guard(device)};
         CAMP_HIP_API_INVOKE_AND_CHECK(hipStreamWaitEvent,
                                       get_stream(),
-                                      e->getHipEvent_t(),
+                                      e.getHipEvent_t(),
                                       0);
       }
 
+      void wait_for(Event& e)
+      {
+        if (auto hip_event = e.try_get<HipEvent>()) {
+          wait_for(*hip_event);
+        } else {
+          e.wait();
+        }
+      }
+
+      [[deprecated]]
       void wait_for(Event *e)
       {
         if (!e) {
           return;
         }
         if (auto hip_event = e->try_get<HipEvent>()) {
-          wait_for(hip_event);
+          wait_for(*hip_event);
         } else {
           e->wait();
         }

--- a/include/camp/resource/hip.hpp
+++ b/include/camp/resource/hip.hpp
@@ -256,7 +256,7 @@ namespace resources
         CAMP_HIP_API_INVOKE_AND_CHECK(hipStreamSynchronize, stream);
       }
 
-      void wait_for(HipEvent& e)
+      void wait_for(HipEvent const& e)
       {
         auto d{device_guard(device)};
         CAMP_HIP_API_INVOKE_AND_CHECK(hipStreamWaitEvent,
@@ -265,7 +265,7 @@ namespace resources
                                       0);
       }
 
-      void wait_for(Event& e)
+      void wait_for(Event const& e)
       {
         if (auto hip_event = e.try_get<HipEvent>()) {
           wait_for(*hip_event);

--- a/include/camp/resource/hip.hpp
+++ b/include/camp/resource/hip.hpp
@@ -112,7 +112,24 @@ namespace resources
 
       hipEvent_t getHipEvent_t() const { return m_event; }
 
+      /*
+       * \brief Compares two events to see if they represent the same underlying
+       *        cuda event.
+       *
+       * \return True if both refer to the same cuda event, false otherwise.
+       */
+      friend inline bool operator==(HipEvent const& lhs, HipEvent const& rhs) = default;
+
+      size_t get_hash() const
+      {
+        const size_t platform_type = size_t(get_platform()) << 32;
+        size_t hash = std::hash<hipEvent_t>{}(m_event);
+        return platform_type | (hash & 0xFFFFFFFF);
+      }
+
+
     private:
+      // note that hipEvent_t is an alias for a pointer and is nullable
       hipEvent_t m_event;
 
       void init(hipStream_t stream)
@@ -121,6 +138,14 @@ namespace resources
                                       &m_event,
                                       hipEventDisableTiming);
         CAMP_HIP_API_INVOKE_AND_CHECK(hipEventRecord, m_event, stream);
+      }
+
+      static void finalize(hipEvent_t& event)
+      {
+        if (event != nullptr) {
+          CAMP_CUDA_API_INVOKE_AND_CHECK(hipEventDestroy, event);
+          event = nullptr;
+        }
       }
     };
 

--- a/include/camp/resource/hip.hpp
+++ b/include/camp/resource/hip.hpp
@@ -30,7 +30,21 @@ namespace resources
 {
   inline namespace v1
   {
+    class HipEvent;
     class Hip;
+
+    template <>
+    struct resource_from_platform<Platform::hip> {
+      using type = ::camp::resources::Hip;
+    };
+
+    template <>
+    struct is_concrete_event_impl<HipEvent> : std::true_type {
+    };
+
+    template <>
+    struct is_concrete_resource_impl<Hip> : std::true_type {
+    };
 
     namespace
     {
@@ -335,17 +349,8 @@ namespace resources
       int device;
     };
 
-    inline HipEvent::HipEvent(Hip &res)
-    {
-      auto d{device_guard(res.get_device())};
-      init(res.get_stream());
-    }
-
   }  // namespace v1
 
-  template <>
-  struct is_concrete_resource_impl<Hip> : std::true_type {
-  };
 }  // namespace resources
 }  // namespace camp
 

--- a/include/camp/resource/hip.hpp
+++ b/include/camp/resource/hip.hpp
@@ -180,6 +180,8 @@ namespace resources
       }
 
     public:
+      using event_type = HipEvent;
+
       Hip(int group = -1, int dev = 0)
           : stream(get_a_stream(group)), device(dev)
       {

--- a/include/camp/resource/hip.hpp
+++ b/include/camp/resource/hip.hpp
@@ -74,9 +74,7 @@ namespace resources
     class HipEvent
     {
     public:
-      HipEvent(hipStream_t stream) { init(stream); }
-
-      HipEvent(Hip &res);
+      explicit HipEvent(hipStream_t stream) { init(stream); }
 
       HipEvent(HipEvent const&) = delete;
 

--- a/include/camp/resource/host.hpp
+++ b/include/camp/resource/host.hpp
@@ -113,7 +113,11 @@ namespace resources
         if (!e) {
           return;
         }
-        e->wait();
+        if (auto host_event = e->try_get<HostEvent>()) {
+          wait_for(host_event);
+        } else {
+          e->wait();
+        }
       }
 
       // Memory

--- a/include/camp/resource/host.hpp
+++ b/include/camp/resource/host.hpp
@@ -10,6 +10,7 @@
 #ifndef __CAMP_HOST_HPP
 #define __CAMP_HOST_HPP
 
+#include <cstddef>
 #include <cstdlib>
 #include <cstring>
 
@@ -96,6 +97,8 @@ namespace resources
       Event get_event_erased() { return Event{get_event()}; }
 
       void wait() {}
+
+      void wait_for(std::nullptr_t) {}
 
       void wait_for(HostEvent *e)
       {

--- a/include/camp/resource/host.hpp
+++ b/include/camp/resource/host.hpp
@@ -93,15 +93,25 @@ namespace resources
 
       HostEvent get_event() { return HostEvent(); }
 
-      Event get_event_erased()
-      {
-        Event e{HostEvent()};
-        return e;
-      }
+      Event get_event_erased() { return Event{get_event()}; }
 
       void wait() {}
 
-      void wait_for(Event *e) { e->wait(); }
+      void wait_for(HostEvent *e)
+      {
+        if (!e) {
+          return;
+        }
+        e->wait();
+      }
+
+      void wait_for(Event *e)
+      {
+        if (!e) {
+          return;
+        }
+        e->wait();
+      }
 
       // Memory
       template <typename T>

--- a/include/camp/resource/host.hpp
+++ b/include/camp/resource/host.hpp
@@ -78,6 +78,8 @@ namespace resources
     class Host
     {
     public:
+      using event_type = HostEvent;
+
       Host(int /* group */ = -1) {}
 
       // Methods

--- a/include/camp/resource/host.hpp
+++ b/include/camp/resource/host.hpp
@@ -98,23 +98,28 @@ namespace resources
 
       void wait() {}
 
-      void wait_for(std::nullptr_t) {}
-
-      void wait_for(HostEvent *e)
+      void wait_for(HostEvent& e)
       {
-        if (!e) {
-          return;
-        }
-        e->wait();
+        e.wait();
       }
 
+      void wait_for(Event& e)
+      {
+        if (auto host_event = e.try_get<HostEvent>()) {
+          wait_for(*host_event);
+        } else {
+          e.wait();
+        }
+      }
+
+      [[deprecated]]
       void wait_for(Event *e)
       {
         if (!e) {
           return;
         }
         if (auto host_event = e->try_get<HostEvent>()) {
-          wait_for(host_event);
+          wait_for(*host_event);
         } else {
           e->wait();
         }

--- a/include/camp/resource/host.hpp
+++ b/include/camp/resource/host.hpp
@@ -98,12 +98,12 @@ namespace resources
 
       void wait() {}
 
-      void wait_for(HostEvent& e)
+      void wait_for(HostEvent const& e)
       {
         e.wait();
       }
 
-      void wait_for(Event& e)
+      void wait_for(Event const& e)
       {
         if (auto host_event = e.try_get<HostEvent>()) {
           wait_for(*host_event);

--- a/include/camp/resource/host.hpp
+++ b/include/camp/resource/host.hpp
@@ -23,6 +23,22 @@ namespace resources
   inline namespace v1
   {
 
+    class HostEvent;
+    class Host;
+
+    template <>
+    struct resource_from_platform<Platform::host> {
+      using type = ::camp::resources::Host;
+    };
+
+    template <>
+    struct is_concrete_event_impl<HostEvent> : std::true_type {
+    };
+
+    template <>
+    struct is_concrete_resource_impl<Host> : std::true_type {
+    };
+
     class HostEvent
     {
     public:
@@ -128,10 +144,6 @@ namespace resources
     };
 
   }  // namespace v1
-
-  template <>
-  struct is_concrete_resource_impl<Host> : std::true_type {
-  };
 
 }  // namespace resources
 }  // namespace camp

--- a/include/camp/resource/host.hpp
+++ b/include/camp/resource/host.hpp
@@ -26,7 +26,17 @@ namespace resources
     class HostEvent
     {
     public:
-      HostEvent() {}
+      HostEvent() = default;
+
+      HostEvent(HostEvent const&) = delete;
+
+      HostEvent(HostEvent&&) = default;
+
+      HostEvent& operator=(HostEvent const&) = delete;
+
+      HostEvent& operator=(HostEvent&&) = default;
+
+      ~HostEvent() = default;
 
       Platform get_platform() const { return Platform::host; }
 

--- a/include/camp/resource/host.hpp
+++ b/include/camp/resource/host.hpp
@@ -112,19 +112,6 @@ namespace resources
         }
       }
 
-      [[deprecated]]
-      void wait_for(Event *e)
-      {
-        if (!e) {
-          return;
-        }
-        if (auto host_event = e->try_get<HostEvent>()) {
-          wait_for(*host_event);
-        } else {
-          e->wait();
-        }
-      }
-
       // Memory
       template <typename T>
       T *allocate(size_t n, MemoryAccess = MemoryAccess::Device)

--- a/include/camp/resource/omp_target.hpp
+++ b/include/camp/resource/omp_target.hpp
@@ -16,6 +16,7 @@
 
 #include <omp.h>
 
+#include <cstddef>
 #include <map>
 #include <memory>
 #include <mutex>
@@ -190,6 +191,8 @@ namespace resources
         {
         }
       }
+
+      void wait_for(std::nullptr_t) {}
 
       void wait_for(OmpEvent *e)
       {

--- a/include/camp/resource/omp_target.hpp
+++ b/include/camp/resource/omp_target.hpp
@@ -19,6 +19,7 @@
 #include <map>
 #include <memory>
 #include <mutex>
+#include <utility>
 
 #include "camp/resource/event.hpp"
 #include "camp/resource/platform.hpp"

--- a/include/camp/resource/omp_target.hpp
+++ b/include/camp/resource/omp_target.hpp
@@ -190,18 +190,28 @@ namespace resources
         }
       }
 
+      void wait_for(OmpEvent *e)
+      {
+        if (!e) {
+          return;
+        }
+        char *local_addr = addr;
+        char *other_addr = (char *)e->getEventAddr();
+        CAMP_ALLOW_UNUSED_LOCAL(local_addr);
+        CAMP_ALLOW_UNUSED_LOCAL(other_addr);
+#pragma omp target depend(inout : local_addr[0]) depend(in : other_addr[0]) \
+  nowait
+        {
+        }
+      }
+
       void wait_for(Event *e)
       {
-        OmpEvent *oe = e->try_get<OmpEvent>();
-        if (oe) {
-          char *local_addr = addr;
-          char *other_addr = (char *)oe->getEventAddr();
-          CAMP_ALLOW_UNUSED_LOCAL(local_addr);
-          CAMP_ALLOW_UNUSED_LOCAL(other_addr);
-#pragma omp target depend(inout : local_addr[0]) depend(in : other_addr[0]) \
-    nowait
-          {
-          }
+        if (!e) {
+          return;
+        }
+        if (auto omp_event = e->try_get<OmpEvent>()) {
+          wait_for(omp_event);
         } else {
           e->wait();
         }

--- a/include/camp/resource/omp_target.hpp
+++ b/include/camp/resource/omp_target.hpp
@@ -242,10 +242,7 @@ namespace resources
       void deallocate(void *p, MemoryAccess ma = MemoryAccess::Device)
       {
         check_ma(ma);
-#pragma omp critical(camp_register_ptr)
-        {
-          get_dev_register().erase(p);
-        }
+        deregister_ptr_dev(p);
         omp_target_free(p, dev);
       }
 
@@ -275,6 +272,14 @@ namespace resources
 #pragma omp critical(camp_register_ptr)
         {
           get_dev_register()[p] = device;
+        }
+      }
+
+      void deregister_ptr_dev(void const *p)
+      {
+#pragma omp critical(camp_register_ptr)
+        {
+          get_dev_register().erase(p);
         }
       }
 

--- a/include/camp/resource/omp_target.hpp
+++ b/include/camp/resource/omp_target.hpp
@@ -48,7 +48,7 @@ namespace resources
     class OmpEvent
     {
     public:
-      OmpEvent(char *addr_in, int device = omp_get_default_device())
+      explicit OmpEvent(char *addr_in, int device = omp_get_default_device())
           : addr(addr_in), dev(device)
       {
 #pragma omp target device(dev) depend(inout : addr_in[0]) nowait

--- a/include/camp/resource/omp_target.hpp
+++ b/include/camp/resource/omp_target.hpp
@@ -41,6 +41,24 @@ namespace resources
         }
       }
 
+      OmpEvent(OmpEvent const&) = delete;
+
+      OmpEvent(OmpEvent&& rhs) noexcept
+        : addr(std::exchange(rhs.addr, nullptr))
+        , dev(std::exchange(rhs.dev, -1))
+      {}
+
+      OmpEvent& operator=(OmpEvent const&) = delete;
+
+      OmpEvent& operator=(OmpEvent&& rhs) noexcept
+      {
+        addr = std::exchange(rhs.addr, nullptr);
+        dev = std::exchange(rhs.dev, -1);
+        return *this;
+      }
+
+      ~OmpEvent() = default;
+
       Platform get_platform() const { return Platform::omp_target; }
 
       bool check() const
@@ -79,8 +97,8 @@ namespace resources
       }
 
     private:
-      char *addr;
-      int dev;
+      char *addr = nullptr;
+      int dev = -1;
     };
 
     class Omp

--- a/include/camp/resource/omp_target.hpp
+++ b/include/camp/resource/omp_target.hpp
@@ -213,19 +213,6 @@ namespace resources
         }
       }
 
-      [[deprecated]]
-      void wait_for(Event *e)
-      {
-        if (!e) {
-          return;
-        }
-        if (auto omp_event = e->try_get<OmpEvent>()) {
-          wait_for(*omp_event);
-        } else {
-          e->wait();
-        }
-      }
-
       // Memory
       template <typename T>
       T *allocate(size_t size, MemoryAccess ma = MemoryAccess::Device)

--- a/include/camp/resource/omp_target.hpp
+++ b/include/camp/resource/omp_target.hpp
@@ -192,15 +192,10 @@ namespace resources
         }
       }
 
-      void wait_for(std::nullptr_t) {}
-
-      void wait_for(OmpEvent *e)
+      void wait_for(OmpEvent& e)
       {
-        if (!e) {
-          return;
-        }
         char *local_addr = addr;
-        char *other_addr = (char *)e->getEventAddr();
+        char *other_addr = (char *)e.getEventAddr();
         CAMP_ALLOW_UNUSED_LOCAL(local_addr);
         CAMP_ALLOW_UNUSED_LOCAL(other_addr);
 #pragma omp target depend(inout : local_addr[0]) depend(in : other_addr[0]) \
@@ -209,13 +204,23 @@ namespace resources
         }
       }
 
+      void wait_for(Event& e)
+      {
+        if (auto omp_event = e.try_get<OmpEvent>()) {
+          wait_for(*omp_event);
+        } else {
+          e.wait();
+        }
+      }
+
+      [[deprecated]]
       void wait_for(Event *e)
       {
         if (!e) {
           return;
         }
         if (auto omp_event = e->try_get<OmpEvent>()) {
-          wait_for(omp_event);
+          wait_for(*omp_event);
         } else {
           e->wait();
         }

--- a/include/camp/resource/omp_target.hpp
+++ b/include/camp/resource/omp_target.hpp
@@ -150,6 +150,8 @@ namespace resources
       }
 
     public:
+      using event_type = OmpEvent;
+
       Omp(int group = -1, int device = omp_get_default_device())
           : addr(get_addr(group)), dev(device)
       {

--- a/include/camp/resource/omp_target.hpp
+++ b/include/camp/resource/omp_target.hpp
@@ -192,7 +192,7 @@ namespace resources
         }
       }
 
-      void wait_for(OmpEvent& e)
+      void wait_for(OmpEvent const& e)
       {
         char *local_addr = addr;
         char *other_addr = (char *)e.getEventAddr();
@@ -204,7 +204,7 @@ namespace resources
         }
       }
 
-      void wait_for(Event& e)
+      void wait_for(Event const& e)
       {
         if (auto omp_event = e.try_get<OmpEvent>()) {
           wait_for(*omp_event);

--- a/include/camp/resource/omp_target.hpp
+++ b/include/camp/resource/omp_target.hpp
@@ -112,8 +112,8 @@ namespace resources
       }
 
     private:
-      char *addr = nullptr;
-      int dev = -1;
+      char *addr;
+      int dev;
     };
 
     class Omp

--- a/include/camp/resource/omp_target.hpp
+++ b/include/camp/resource/omp_target.hpp
@@ -29,6 +29,21 @@ namespace resources
 {
   inline namespace v1
   {
+    class OmpEvent;
+    class Omp;
+
+    template <>
+    struct resource_from_platform<Platform::omp_target> {
+      using type = ::camp::resources::Omp;
+    };
+
+    template <>
+    struct is_concrete_event_impl<OmpEvent> : std::true_type {
+    };
+
+    template <>
+    struct is_concrete_resource_impl<Omp> : std::true_type {
+    };
 
     class OmpEvent
     {
@@ -313,9 +328,7 @@ namespace resources
 
   }  // namespace v1
 
-  template <>
-  struct is_concrete_resource_impl<Omp> : std::true_type {
-  };
+
 }  // namespace resources
 }  // namespace camp
 

--- a/include/camp/resource/platform.hpp
+++ b/include/camp/resource/platform.hpp
@@ -27,6 +27,10 @@ namespace resources
     };
 
     enum class MemoryAccess { Unknown, Device, Pinned, Managed };
+
+    template <Platform p>
+    struct resource_from_platform;
+
   }  // namespace v1
 }  // namespace resources
 }  // namespace camp

--- a/include/camp/resource/sycl.hpp
+++ b/include/camp/resource/sycl.hpp
@@ -14,6 +14,7 @@
 
 #ifdef CAMP_ENABLE_SYCL
 
+#include <cstddef>
 #include <array>
 #include <map>
 #include <mutex>
@@ -317,6 +318,8 @@ namespace resources
       Event get_event_erased() { return Event{get_event()}; }
 
       void wait() { qu.wait(); }
+
+      void wait_for(std::nullptr_t) {}
 
       void wait_for(SyclEvent* e)
       {

--- a/include/camp/resource/sycl.hpp
+++ b/include/camp/resource/sycl.hpp
@@ -312,19 +312,29 @@ namespace resources
       Platform get_platform() const { return Platform::sycl; }
 
       // Event
-      SyclEvent get_event() { return SyclEvent(*this); }
+      SyclEvent get_event() { return SyclEvent(get_queue()); }
 
-      Event get_event_erased() { return Event{SyclEvent(*this)}; }
+      Event get_event_erased() { return Event{get_event()}; }
 
       void wait() { qu.wait(); }
 
+      void wait_for(SyclEvent* e)
+      {
+        if (!e) {
+          return;
+        }
+        qu.submit([&](::sycl::handler& h) {
+          h.depends_on(e->getSyclEvent_t());
+        });
+      }
+
       void wait_for(Event* e)
       {
-        auto* sycl_event = e->try_get<SyclEvent>();
-        if (sycl_event) {
-          qu.submit([&](::sycl::handler& h) {
-            h.depends_on(sycl_event->getSyclEvent_t());
-          });
+        if (!e) {
+          return;
+        }
+        if (auto sycl_event = e->try_get<SyclEvent>()) {
+          wait_for(sycl_event);
         } else {
           e->wait();
         }

--- a/include/camp/resource/sycl.hpp
+++ b/include/camp/resource/sycl.hpp
@@ -53,15 +53,13 @@ namespace resources
       {}
 
       // TODO: see what overhead an empty submit has
-      SyclEvent(sycl::queue& qu)
+      explicit SyclEvent(sycl::queue& qu)
       {
         if (!qu.is_in_order()) {
           ::camp::throw_re("Queue is not in_order.");
         }
         m_event = qu.submit([&](::sycl::handler& CAMP_UNUSED_ARG(h)) {});
       }
-
-      SyclEvent(Sycl& res);
 
       SyclEvent(SyclEvent const&) = delete;
 

--- a/include/camp/resource/sycl.hpp
+++ b/include/camp/resource/sycl.hpp
@@ -152,6 +152,8 @@ namespace resources
       }
 
     public:
+      using event_type = SyclEvent;
+
       /*
        * \brief Get the camp managed sycl context.
        *

--- a/include/camp/resource/sycl.hpp
+++ b/include/camp/resource/sycl.hpp
@@ -49,6 +49,16 @@ namespace resources
 
       SyclEvent(Sycl& res);
 
+      SyclEvent(SyclEvent const&) = delete;
+
+      SyclEvent(SyclEvent&& rhs) = default;
+
+      SyclEvent& operator=(SyclEvent const&) = delete;
+
+      SyclEvent& operator=(SyclEvent&& rhs) = default;
+
+      ~SyclEvent() = default;
+
       Platform get_platform() const { return Platform::sycl; }
 
       bool check() const

--- a/include/camp/resource/sycl.hpp
+++ b/include/camp/resource/sycl.hpp
@@ -319,25 +319,30 @@ namespace resources
 
       void wait() { qu.wait(); }
 
-      void wait_for(std::nullptr_t) {}
-
-      void wait_for(SyclEvent* e)
+      void wait_for(SyclEvent& e)
       {
-        if (!e) {
-          return;
-        }
         qu.submit([&](::sycl::handler& h) {
-          h.depends_on(e->getSyclEvent_t());
+          h.depends_on(e.getSyclEvent_t());
         });
       }
 
+      void wait_for(Event &e)
+      {
+        if (auto sycl_event = e.try_get<SyclEvent>()) {
+          wait_for(*sycl_event);
+        } else {
+          e.wait();
+        }
+      }
+
+      [[deprecated]]
       void wait_for(Event* e)
       {
         if (!e) {
           return;
         }
         if (auto sycl_event = e->try_get<SyclEvent>()) {
-          wait_for(sycl_event);
+          wait_for(*sycl_event);
         } else {
           e->wait();
         }

--- a/include/camp/resource/sycl.hpp
+++ b/include/camp/resource/sycl.hpp
@@ -29,7 +29,21 @@ namespace resources
 {
   inline namespace v1
   {
+    class SyclEvent;
     class Sycl;
+
+    template <>
+    struct resource_from_platform<Platform::sycl> {
+      using type = ::camp::resources::Sycl;
+    };
+
+    template <>
+    struct is_concrete_event_impl<SyclEvent> : std::true_type {
+    };
+
+    template <>
+    struct is_concrete_resource_impl<Sycl> : std::true_type {
+    };
 
     class SyclEvent
     {
@@ -389,15 +403,8 @@ namespace resources
       sycl::queue qu;
     };
 
-    inline SyclEvent::SyclEvent(Sycl &res)
-      : SyclEvent(res.get_queue())
-    {}
-
   }  // namespace v1
 
-  template <>
-  struct is_concrete_resource_impl<Sycl> : std::true_type {
-  };
 }  // namespace resources
 }  // namespace camp
 

--- a/include/camp/resource/sycl.hpp
+++ b/include/camp/resource/sycl.hpp
@@ -319,14 +319,14 @@ namespace resources
 
       void wait() { qu.wait(); }
 
-      void wait_for(SyclEvent& e)
+      void wait_for(SyclEvent const& e)
       {
         qu.submit([&](::sycl::handler& h) {
           h.depends_on(e.getSyclEvent_t());
         });
       }
 
-      void wait_for(Event &e)
+      void wait_for(Event const& e)
       {
         if (auto sycl_event = e.try_get<SyclEvent>()) {
           wait_for(*sycl_event);

--- a/include/camp/resource/sycl.hpp
+++ b/include/camp/resource/sycl.hpp
@@ -335,19 +335,6 @@ namespace resources
         }
       }
 
-      [[deprecated]]
-      void wait_for(Event* e)
-      {
-        if (!e) {
-          return;
-        }
-        if (auto sycl_event = e->try_get<SyclEvent>()) {
-          wait_for(*sycl_event);
-        } else {
-          e->wait();
-        }
-      }
-
       // Memory
       template <typename T>
       T* allocate(size_t size, MemoryAccess ma = MemoryAccess::Device)

--- a/test/resource.cpp
+++ b/test/resource.cpp
@@ -1859,8 +1859,8 @@ TEST(CampResourceSycl, Helpers)
   ASSERT_EQ(Sycl::get_thread_default_context(), new_context);
 
   auto gpuSelector = sycl::gpu_selector_v;
-  sycl::property_list ordered_properties(
-      sycl::property::queue::in_order());
+  sycl::property_list ordered_properties =
+      sycl::property_list(sycl::property::queue::in_order());
   sycl::queue ordered_queue(new_context, gpuSelector, ordered_properties);
   Sycl resource = Sycl::SyclFromQueue(ordered_queue);
   const Sycl& const_resource = resource;

--- a/test/resource.cpp
+++ b/test/resource.cpp
@@ -225,7 +225,7 @@ void test_vector(Resource& h)
   rvec.emplace_back(d2.get<Res>());
   rvec.emplace_back(r2);
 
-  // Verify using Resource in a vector to works
+  // Verify using Resource in a vector works
   // Generic
   ASSERT_EQ(vec.size(), 4);
   ASSERT_EQ(vec[0], h);

--- a/test/resource.cpp
+++ b/test/resource.cpp
@@ -1491,3 +1491,104 @@ TEST(CampResourceMemory, Sycl)
   test_memory_ops<Sycl>(MemoryAccess::Managed);
 }
 #endif
+
+#ifdef CAMP_HAVE_CUDA
+TEST(CampCuda, Helpers)
+{
+  int current_device = -1;
+  cudaStream_t stream;
+  CAMP_CUDA_API_INVOKE_AND_CHECK(cudaGetDevice, &current_device);
+  CAMP_CUDA_API_INVOKE_AND_CHECK(cudaStreamCreate, &stream);
+
+  Cuda resource = Cuda::CudaFromStream(stream, current_device);
+  ASSERT_EQ(resource.get_device(), current_device);
+  ASSERT_EQ(resource.get_stream(), stream);
+
+  {
+    auto event = resource.get_event();
+    ASSERT_NE(event.getCudaEvent_t(), nullptr);
+  }
+
+  CAMP_CUDA_API_INVOKE_AND_CHECK(cudaStreamDestroy, stream);
+}
+#endif
+
+#ifdef CAMP_HAVE_HIP
+TEST(CampHip, Helpers)
+{
+  int current_device = -1;
+  hipStream_t stream;
+  CAMP_HIP_API_INVOKE_AND_CHECK(hipGetDevice, &current_device);
+  CAMP_HIP_API_INVOKE_AND_CHECK(hipStreamCreate, &stream);
+
+  Hip resource = Hip::HipFromStream(stream, current_device);
+  ASSERT_EQ(resource.get_device(), current_device);
+  ASSERT_EQ(resource.get_stream(), stream);
+
+  {
+    auto event = resource.get_event();
+    ASSERT_NE(event.getHipEvent_t(), nullptr);
+  }
+
+  CAMP_HIP_API_INVOKE_AND_CHECK(hipStreamDestroy, stream);
+}
+#endif
+
+#ifdef CAMP_HAVE_OMP_OFFLOAD
+TEST(CampOmp, Helpers)
+{
+  char a[1];
+  Omp resource = Omp::OmpFromAddr(&a[0]);
+
+  ASSERT_EQ(resource.get_platform(), Platform::omp_target);
+  ASSERT_EQ(resource.get_depend_location(), &a[0]);
+  ASSERT_EQ(resource.get_device(), omp_get_default_device());
+
+  {
+    auto event = resource.get_event();
+    ASSERT_EQ(event.getEventAddr(), &a[0]);
+  }
+
+  auto* ptr = resource.allocate<unsigned char>(16);
+  ASSERT_EQ(resource.get_ptr_dev(ptr), resource.get_device());
+  resource.deallocate(ptr);
+  ASSERT_EQ(resource.get_ptr_dev(&ptr), omp_get_initial_device());
+
+  ASSERT_THROW((void)resource.allocate<unsigned char>(1, MemoryAccess::Pinned),
+               std::runtime_error);
+  ASSERT_THROW((void)resource.calloc(1, MemoryAccess::Managed),
+               std::runtime_error);
+  ASSERT_THROW((void)resource.deallocate(&ptr, MemoryAccess::Pinned),
+               std::runtime_error);
+}
+#endif
+
+#ifdef CAMP_HAVE_SYCL
+TEST(CampSycl, Helpers)
+{
+  sycl::context original_default = Sycl::get_default_context();
+  sycl::context original_thread = Sycl::get_thread_default_context();
+  sycl::context new_context;
+
+  Sycl::set_default_context(new_context);
+  ASSERT_EQ(Sycl::get_default_context(), new_context);
+  Sycl::set_thread_default_context(new_context);
+  ASSERT_EQ(Sycl::get_thread_default_context(), new_context);
+
+  auto gpuSelector = sycl::gpu_selector_v;
+  sycl::property_list ordered_properties(
+      sycl::property::queue::in_order());
+  sycl::queue ordered_queue(new_context, gpuSelector, ordered_properties);
+  Sycl resource = Sycl::SyclFromQueue(ordered_queue);
+  ASSERT_EQ(resource.get_queue(), ordered_queue);
+
+  auto event = resource.get_event();
+  ASSERT_EQ(event.getSyclEvent_t(), event.getSyclEvent_t());
+
+  sycl::queue unordered_queue(new_context, gpuSelector);
+  ASSERT_THROW((void)SyclEvent(unordered_queue), std::runtime_error);
+
+  Sycl::set_default_context(original_default);
+  Sycl::set_thread_default_context(original_thread);
+}
+#endif

--- a/test/resource.cpp
+++ b/test/resource.cpp
@@ -195,6 +195,145 @@ TEST(CampEvent, GetPlatform)
 }
 
 template <typename Res>
+void test_vector(Resource& h)
+{
+  // Generic
+  std::vector<Resource> vec;
+  Resource d1{Res()};
+  Resource d2{Res()};
+
+  // Typed
+  std::vector<Res> rvec;
+  Res r1;
+  Res r2;
+
+  // Generic
+  vec.emplace_back(Host());
+  vec.emplace_back(h);
+  vec.emplace_back(d1);
+  vec.emplace_back(r1);
+
+  // Typed
+  rvec.emplace_back(Res());
+  rvec.emplace_back(d2.get<Res>());
+  rvec.emplace_back(r2);
+
+  // Verify using Resource in a vector to works
+  // Generic
+  ASSERT_EQ(vec.size(), 4);
+  ASSERT_EQ(vec[0], h);
+  ASSERT_EQ(vec[1], h);
+  ASSERT_EQ(vec[2], d1);
+  ASSERT_EQ(vec[3], r1);
+
+  // Typed
+  ASSERT_EQ(rvec.size(), 3);
+  if constexpr (std::same_as<Res, Host>) {
+    ASSERT_EQ(rvec[0], Res());
+  } else {
+    ASSERT_NE(rvec[0], Res());
+  }
+  ASSERT_EQ(rvec[1], d2);
+  ASSERT_EQ(rvec[2], r2);
+}
+
+//
+TEST(CampResource, Vector)
+{
+  Resource h{Host()};
+  test_vector<Host>(h);
+#if defined(CAMP_HAVE_CUDA)
+  test_vector<Cuda>(h);
+#elif defined(CAMP_HAVE_HIP)
+  test_vector<Hip>(h);
+#elif defined(CAMP_HAVE_OMP_OFFLOAD)
+  test_vector<Omp>(h);
+#elif defined(CAMP_HAVE_SYCL)
+  test_vector<Sycl>(h);
+#endif
+}
+
+template <typename Res>
+void test_vector(Event& he)
+{
+  using typed_event = typename Res::event_type;
+
+  // Generic
+  Event d1 = Res().get_event_erased();
+  Event d2 = Res().get_event_erased();
+  std::vector<Event> vec;
+
+  // Typed
+  typed_event e1 = Res().get_event();
+  typed_event e2 = Res().get_event();
+  std::vector<typed_event> rvec;
+
+  // Generic
+  vec.emplace_back(Host().get_event());
+  vec.emplace_back(Host().get_event_erased());
+  vec.emplace_back(std::move(d1));
+  vec.emplace_back(std::move(e1));
+  vec.emplace_back(Res().get_event());
+  vec.emplace_back(Res().get_event_erased());
+
+  // Typed
+  rvec.emplace_back(std::move(std::move(d2).get<typed_event>()));
+  rvec.emplace_back(std::move(e2));
+  rvec.emplace_back(Res().get_event());
+
+  // Verify using Event in a vector works
+  // Generic
+  ASSERT_EQ(vec.size(), 6);
+  ASSERT_EQ(vec[0], he);
+  ASSERT_EQ(vec[0], vec[1]);
+  if constexpr (std::same_as<Res, Host>) {
+    ASSERT_EQ(vec[1], vec[2]);
+    ASSERT_EQ(vec[2], vec[3]);
+    ASSERT_EQ(vec[3], vec[4]);
+    ASSERT_EQ(vec[4], vec[5]);
+  } else {
+    ASSERT_NE(vec[1], vec[2]);
+    ASSERT_NE(vec[2], vec[3]);
+    ASSERT_NE(vec[3], vec[4]);
+    ASSERT_NE(vec[4], vec[5]);
+  }
+
+  for (Event& e : vec) {
+    (void)e;
+  }
+
+  // Typed
+  ASSERT_EQ(rvec.size(), 3);
+  if constexpr (std::same_as<Res, Host>) {
+    ASSERT_EQ(rvec[0], rvec[1]);
+    ASSERT_EQ(rvec[1], rvec[2]);
+  } else {
+    ASSERT_NE(rvec[0], rvec[1]);
+    ASSERT_NE(rvec[1], rvec[2]);
+  }
+
+  for (typed_event& e : rvec) {
+    (void)e;
+  }
+}
+
+//
+TEST(CampEvent, Vector)
+{
+  Event he = Host().get_event_erased();
+  test_vector<Host>(he);
+#if defined(CAMP_HAVE_CUDA)
+  test_vector<Cuda>(he);
+#elif defined(CAMP_HAVE_HIP)
+  test_vector<Hip>(he);
+#elif defined(CAMP_HAVE_OMP_OFFLOAD)
+  test_vector<Omp>(he);
+#elif defined(CAMP_HAVE_SYCL)
+  test_vector<Sycl>(he);
+#endif
+}
+
+template <typename Res>
 void test_map_key(Resource& h)
 {
   // Generic

--- a/test/resource.cpp
+++ b/test/resource.cpp
@@ -204,16 +204,13 @@ TEST(CampEvent, GetPlatform)
 
 TEST(CampResource, EmptyBehavior)
 {
+  Resource empty;
+  Resource empty2;
   Resource full{Host()};
   Resource sink{std::move(full)};
-  Resource full2{Host()};
-  Resource sink2{std::move(full2)};
-  Resource& empty = full;
-  Resource& empty2 = full2;
   int value = 7;
 
   CAMP_ALLOW_UNUSED_LOCAL(sink);
-  CAMP_ALLOW_UNUSED_LOCAL(sink2);
 
   ASSERT_FALSE(empty);
   ASSERT_EQ(empty.get_platform(), Platform::undefined);
@@ -352,6 +349,10 @@ void test_vector(Resource& h)
   ASSERT_EQ(vec[1], h);
   ASSERT_EQ(vec[2], d1);
   ASSERT_EQ(vec[3], r1);
+
+  vec.resize(6);
+  ASSERT_FALSE(vec[4]);
+  ASSERT_FALSE(vec[5]);
 
   // Typed
   ASSERT_EQ(rvec.size(), 3);

--- a/test/resource.cpp
+++ b/test/resource.cpp
@@ -112,7 +112,7 @@ TEST(CampResource, Copy)
 template <typename Res, typename Res2>
 void test_convert_fails()
 {
-  Resource r{Res()};
+  const Resource r{Res()};
   r.get<Res>();
   ASSERT_THROW(r.get<Res2>(), std::runtime_error);
   ASSERT_FALSE(r.try_get<Res2>());
@@ -139,7 +139,7 @@ TEST(CampResource, ConvertFails)
 template <typename Res>
 void test_convert_works(Platform platform)
 {
-  Resource r{Res()};
+  const Resource r{Res()};
   ASSERT_TRUE(r.try_get<Res>());
   ASSERT_EQ(r.get<Res>().get_platform(), platform);
 }
@@ -249,8 +249,8 @@ TEST(CampResource, EmptyBehavior)
 
 TEST(CampEvent, EmptyBehavior)
 {
-  Event empty;
-  Event empty2;
+  const Event empty;
+  const Event empty2;
 
   ASSERT_FALSE(empty);
   ASSERT_EQ(empty.get_platform(), Platform::undefined);
@@ -262,7 +262,7 @@ TEST(CampEvent, EmptyBehavior)
   ASSERT_FALSE(empty.try_get<HostEvent>());
   ASSERT_THROW((void)empty.get<HostEvent>(), std::runtime_error);
 
-  Event host_event{Host().get_event()};
+  const Event host_event{Host().get_event()};
   ASSERT_TRUE(host_event);
   ASSERT_TRUE(host_event.try_get<HostEvent>());
   ASSERT_FALSE(host_event.try_get<HostEvent2>());
@@ -715,6 +715,9 @@ void test_id_compare(Resource& h1)
   Res r;
   Resource r2{r};
   Resource r3{Res(0)};  // should be same as r1
+  const Resource cr{Res()};
+  const Resource& ch1 = h1;
+  const Res& ctr = cr.get<Res>();
 
   EXPECT_EQ(r1, r3);
 
@@ -735,6 +738,12 @@ void test_id_compare(Resource& h1)
 
   ASSERT_FALSE(r1 == h1);
   ASSERT_FALSE(h1 == r1);
+
+  ASSERT_TRUE(cr == ctr);
+  ASSERT_FALSE(cr != ctr);
+
+  ASSERT_FALSE(ch1 == ctr);
+  ASSERT_TRUE(ch1 != ctr);
 }
 
 //
@@ -743,6 +752,8 @@ TEST(CampResource, Compare)
   Resource h1{Host()};
   Host h;
   Resource h2{h};
+  const Resource ch{Host()};
+  const Host& cth = ch.get<Host>();
 
   ASSERT_TRUE(h1 == h1);
   ASSERT_TRUE(h2 == h2);
@@ -755,6 +766,8 @@ TEST(CampResource, Compare)
   ASSERT_FALSE(h1 != h2);
   ASSERT_FALSE(h2 != h1);
   ASSERT_FALSE(h != h);
+  ASSERT_TRUE(ch == cth);
+  ASSERT_FALSE(ch != cth);
 
 #ifdef CAMP_HAVE_CUDA
   test_id_compare<Cuda>(h1);
@@ -840,6 +853,9 @@ void test_id_compare(Event& he)
   Event e1 = Res().get_event();
   Event e2 = Res().get_event_erased();
   typename Res::event_type te = Res().get_event();
+  const Event ce = Res().get_event_erased();
+  const Event& che = he;
+  const typename Res::event_type& cte = ce.get<typename Res::event_type>();
 
   ASSERT_TRUE(e1 == e1);
   ASSERT_TRUE(e2 == e2);
@@ -858,6 +874,12 @@ void test_id_compare(Event& he)
 
   ASSERT_FALSE(e1 == he);
   ASSERT_FALSE(he == e1);
+
+  ASSERT_TRUE(ce == cte);
+  ASSERT_FALSE(ce != cte);
+
+  ASSERT_FALSE(che == cte);
+  ASSERT_TRUE(che != cte);
 }
 
 //
@@ -898,16 +920,20 @@ TEST(CampEvent, HostEventCompare)
   HostEvent te = Host().get_default().get_event();
   Event e1 = Host().get_event();
   Event e2 = Host().get_event_erased();
+  const Event ce = Host().get_event_erased();
+  const HostEvent& cte = ce.get<HostEvent>();
 
   ASSERT_TRUE(e1 == te);
   ASSERT_TRUE(e1 == e2);
   ASSERT_TRUE(e2 == te);
   ASSERT_TRUE(e2 == e1);
+  ASSERT_TRUE(ce == cte);
 
   ASSERT_FALSE(e1 != te);
   ASSERT_FALSE(e1 != e2);
   ASSERT_FALSE(e2 != te);
   ASSERT_FALSE(e2 != e1);
+  ASSERT_FALSE(ce != cte);
 
   Event e3{std::move(te)};
 
@@ -1009,8 +1035,10 @@ TEST(CampResource, StreamSelect)
 template <typename Res>
 void test_get()
 {
-  Resource dev_res{Res()};
-  auto erased_res = dev_res.get<Res>();
+  const Resource dev_res{Res()};
+  static_assert(std::is_same_v<decltype(dev_res.template get<Res>()),
+                               const Res&>);
+  const auto& erased_res = dev_res.get<Res>();
   Res pure_res;
   ASSERT_EQ(typeid(erased_res), typeid(pure_res));
 }
@@ -1550,11 +1578,12 @@ TEST(CampCuda, Helpers)
   CAMP_CUDA_API_INVOKE_AND_CHECK(cudaStreamCreate, &stream);
 
   Cuda resource = Cuda::CudaFromStream(stream, current_device);
-  ASSERT_EQ(resource.get_device(), current_device);
-  ASSERT_EQ(resource.get_stream(), stream);
+  const Cuda& const_resource = resource;
+  ASSERT_EQ(const_resource.get_device(), current_device);
+  ASSERT_EQ(const_resource.get_stream(), stream);
 
   {
-    auto event = resource.get_event();
+    const auto event = resource.get_event();
     ASSERT_NE(event.getCudaEvent_t(), nullptr);
   }
 
@@ -1571,11 +1600,12 @@ TEST(CampHip, Helpers)
   CAMP_HIP_API_INVOKE_AND_CHECK(hipStreamCreate, &stream);
 
   Hip resource = Hip::HipFromStream(stream, current_device);
-  ASSERT_EQ(resource.get_device(), current_device);
-  ASSERT_EQ(resource.get_stream(), stream);
+  const Hip& const_resource = resource;
+  ASSERT_EQ(const_resource.get_device(), current_device);
+  ASSERT_EQ(const_resource.get_stream(), stream);
 
   {
-    auto event = resource.get_event();
+    const auto event = resource.get_event();
     ASSERT_NE(event.getHipEvent_t(), nullptr);
   }
 
@@ -1588,13 +1618,14 @@ TEST(CampOmp, Helpers)
 {
   char a[1];
   Omp resource = Omp::OmpFromAddr(&a[0]);
+  const Omp& const_resource = resource;
 
-  ASSERT_EQ(resource.get_platform(), Platform::omp_target);
-  ASSERT_EQ(resource.get_depend_location(), &a[0]);
-  ASSERT_EQ(resource.get_device(), omp_get_default_device());
+  ASSERT_EQ(const_resource.get_platform(), Platform::omp_target);
+  ASSERT_EQ(const_resource.get_depend_location(), &a[0]);
+  ASSERT_EQ(const_resource.get_device(), omp_get_default_device());
 
   {
-    auto event = resource.get_event();
+    const auto event = resource.get_event();
     ASSERT_EQ(event.getEventAddr(), &a[0]);
   }
 
@@ -1629,9 +1660,10 @@ TEST(CampSycl, Helpers)
       sycl::property::queue::in_order());
   sycl::queue ordered_queue(new_context, gpuSelector, ordered_properties);
   Sycl resource = Sycl::SyclFromQueue(ordered_queue);
-  ASSERT_EQ(resource.get_queue(), ordered_queue);
+  const Sycl& const_resource = resource;
+  ASSERT_EQ(const_resource.get_queue(), ordered_queue);
 
-  auto event = resource.get_event();
+  const auto event = resource.get_event();
   ASSERT_EQ(event.getSyclEvent_t(), event.getSyclEvent_t());
 
   sycl::queue unordered_queue(new_context, gpuSelector);

--- a/test/resource.cpp
+++ b/test/resource.cpp
@@ -1142,6 +1142,8 @@ TEST(CampResourceTypeTraits, ConcreteResource)
   test_concrete_resource_trait<Omp>();
 #endif
 
+  // Resource is not a concrete resource
+  ASSERT_FALSE(is_concrete_resource<Resource>::value);
   // Test is_concrete_resource with non-resource types
   ASSERT_FALSE(is_concrete_resource<int>::value);
   ASSERT_FALSE(is_concrete_resource<float>::value);

--- a/test/resource.cpp
+++ b/test/resource.cpp
@@ -1181,6 +1181,72 @@ TEST(CampEvent, Get)
 #endif
 }
 
+template <typename Res, typename... EventArgs>
+void test_get_const_typed_event(EventArgs&&... eventArgs)
+{
+  using ResEvent = typename Res::event_type;
+
+  Resource r{Res()};
+  const Event erased_event = r.get_event();
+
+  static_assert(
+      std::is_same_v<decltype(erased_event.template try_get<ResEvent>()),
+                     const ResEvent*>);
+  static_assert(
+      std::is_same_v<decltype(erased_event.template get<ResEvent>()),
+                     const ResEvent&>);
+
+  const ResEvent* typed_event_ptr = erased_event.template try_get<ResEvent>();
+  ASSERT_NE(typed_event_ptr, nullptr);
+  ASSERT_FALSE(erased_event.template try_get<HostEvent2>());
+
+  const auto& typed_event = erased_event.template get<ResEvent>();
+  ASSERT_EQ(typed_event_ptr, &typed_event);
+  ASSERT_THROW((void)erased_event.template get<HostEvent2>(),
+               std::runtime_error);
+
+  ResEvent event(std::forward<EventArgs>(eventArgs)...);
+  ASSERT_EQ(typeid(event), typeid(typed_event));
+}
+
+//
+TEST(CampEvent, GetConst)
+{
+  test_get_const_typed_event<Host>();
+#if defined(CAMP_HAVE_CUDA)
+  {
+    cudaStream_t s;
+    CAMP_CUDA_API_INVOKE_AND_CHECK(cudaStreamCreate, &s);
+    test_get_const_typed_event<Cuda>(s);
+    CAMP_CUDA_API_INVOKE_AND_CHECK(cudaStreamDestroy, s);
+  }
+#endif
+#if defined(CAMP_HAVE_HIP)
+  {
+    hipStream_t s;
+    CAMP_HIP_API_INVOKE_AND_CHECK(hipStreamCreate, &s);
+    test_get_const_typed_event<Hip>(s);
+    CAMP_HIP_API_INVOKE_AND_CHECK(hipStreamDestroy, s);
+  }
+#endif
+#ifdef CAMP_HAVE_OMP_OFFLOAD
+  {
+    char a[1];
+    test_get_const_typed_event<Omp>(&a[0]);
+  }
+#endif
+#ifdef CAMP_HAVE_SYCL
+  {
+    auto gpuSelector = sycl::gpu_selector_v;
+    sycl::property_list propertyList =
+        sycl::property_list(sycl::property::queue::in_order());
+    sycl::context context;
+    sycl::queue q(context, gpuSelector, propertyList);
+    test_get_const_typed_event<Sycl>(q);
+  }
+#endif
+}
+
 template <typename Res>
 static EventProxy<Res> do_stuff(Res r)
 {

--- a/test/resource.cpp
+++ b/test/resource.cpp
@@ -1075,10 +1075,13 @@ void test_wait()
 {
   auto r = Res();
   r.wait();
+  r.wait_for(nullptr);
   Event erased_event = r.get_event_erased();
   r.wait_for(&erased_event);
   auto typed_event = r.get_event();
   r.wait_for(&typed_event);
+  Event host_event = Host().get_event_erased();
+  r.wait_for(&host_event);
   Resource er(r);
   er.wait();
 }

--- a/test/resource.cpp
+++ b/test/resource.cpp
@@ -649,9 +649,9 @@ TEST(CampResource, HostCompare)
 template <typename Res>
 void test_id_compare(Event& he)
 {
-  Event e1{Res().get_event()};
-  auto te = Res().get_event();
-  Event e2{te};
+  Event e1 = Res().get_event();
+  Event e2 = Res().get_event_erased();
+  typename Res::event_type te = Res().get_event();
 
   ASSERT_TRUE(e1 == e1);
   ASSERT_TRUE(e2 == e2);
@@ -663,7 +663,7 @@ void test_id_compare(Event& he)
   ASSERT_FALSE(e2 != e2);
   ASSERT_FALSE(e1 == e2);
   ASSERT_FALSE(e2 == e1);
-  ASSERT_FALSE(te!= te);
+  ASSERT_FALSE(te != te);
 
   ASSERT_TRUE(e1 != he);
   ASSERT_TRUE(he != e1);
@@ -675,9 +675,9 @@ void test_id_compare(Event& he)
 //
 TEST(CampEvent, Compare)
 {
-  Event e1{Host().get_event_erased()};
-  auto te = Host().get_event();
-  Event e2{te};
+  Event e1 = Host().get_event();
+  Event e2 = Host().get_event_erased();
+  HostEvent te = Host().get_event();
 
   ASSERT_TRUE(e1 == e1);
   ASSERT_TRUE(e2 == e2);
@@ -708,15 +708,26 @@ TEST(CampEvent, Compare)
 TEST(CampEvent, HostEventCompare)
 {
   HostEvent te = Host().get_default().get_event();
-  Event e2{Host().get_event()};
-  Event e3{Host().get_event_erased()};
+  Event e1 = Host().get_event();
+  Event e2 = Host().get_event_erased();
 
-  ASSERT_TRUE(Event{te} == e2);
-  ASSERT_TRUE(Event{te} == e3);
+  ASSERT_TRUE(e1 == te);
+  ASSERT_TRUE(e1 == e2);
   ASSERT_TRUE(e2 == te);
-  ASSERT_TRUE(e2 == e3);
-  ASSERT_TRUE(e3 == te);
+  ASSERT_TRUE(e2 == e1);
+
+  ASSERT_FALSE(e1 != te);
+  ASSERT_FALSE(e1 != e2);
+  ASSERT_FALSE(e2 != te);
+  ASSERT_FALSE(e2 != e1);
+
+  Event e3{std::move(te)};
+
+  ASSERT_TRUE(e3 == e1);
   ASSERT_TRUE(e3 == e2);
+
+  ASSERT_FALSE(e3 != e1);
+  ASSERT_FALSE(e3 != e2);
 }
 
 template <typename Res>

--- a/test/resource.cpp
+++ b/test/resource.cpp
@@ -897,7 +897,7 @@ void test_get_typed_event(EventArgs&&... eventArgs)
 {
   Resource r{Res()};
   Event erased_event = r.get_event();
-  auto typed_event = erased_event.get<ResEvent>();
+  auto&& typed_event = erased_event.get<ResEvent>();
   ResEvent event(std::forward<EventArgs>(eventArgs)...);
   ASSERT_EQ(typeid(event), typeid(typed_event));
 }
@@ -1031,8 +1031,10 @@ void test_wait()
 {
   auto r = Res();
   r.wait();
-  Event event = r.get_event_erased();
-  r.wait_for(&event);
+  Event erased_event = r.get_event_erased();
+  r.wait_for(&erased_event);
+  auto typed_event = r.get_event();
+  r.wait_for(&typed_event);
   Resource er(r);
   er.wait();
 }

--- a/test/resource.cpp
+++ b/test/resource.cpp
@@ -249,13 +249,16 @@ TEST(CampResource, Vector)
 {
   Resource h{Host()};
   test_vector<Host>(h);
-#if defined(CAMP_HAVE_CUDA)
+#ifdef CAMP_HAVE_CUDA
   test_vector<Cuda>(h);
-#elif defined(CAMP_HAVE_HIP)
+#endif
+#ifdef CAMP_HAVE_HIP
   test_vector<Hip>(h);
-#elif defined(CAMP_HAVE_OMP_OFFLOAD)
+#endif
+#ifdef CAMP_HAVE_OMP_OFFLOAD
   test_vector<Omp>(h);
-#elif defined(CAMP_HAVE_SYCL)
+#endif
+#ifdef CAMP_HAVE_SYCL
   test_vector<Sycl>(h);
 #endif
 }
@@ -329,13 +332,16 @@ TEST(CampEvent, Vector)
 {
   Event he = Host().get_event_erased();
   test_vector<Host>(he);
-#if defined(CAMP_HAVE_CUDA)
+#ifdef CAMP_HAVE_CUDA
   test_vector<Cuda>(he);
-#elif defined(CAMP_HAVE_HIP)
+#endif
+#ifdef CAMP_HAVE_HIP
   test_vector<Hip>(he);
-#elif defined(CAMP_HAVE_OMP_OFFLOAD)
+#endif
+#ifdef CAMP_HAVE_OMP_OFFLOAD
   test_vector<Omp>(he);
-#elif defined(CAMP_HAVE_SYCL)
+#endif
+#ifdef CAMP_HAVE_SYCL
   test_vector<Sycl>(he);
 #endif
 }
@@ -435,13 +441,16 @@ TEST(CampResource, UnorderedMapKey)
 {
   Resource h{Host()};
   test_map_key<Host>(h);
-#if defined(CAMP_HAVE_CUDA)
+#ifdef CAMP_HAVE_CUDA
   test_map_key<Cuda>(h);
-#elif defined(CAMP_HAVE_HIP)
+#endif
+#ifdef CAMP_HAVE_HIP
   test_map_key<Hip>(h);
-#elif defined(CAMP_HAVE_OMP_OFFLOAD)
+#endif
+#ifdef CAMP_HAVE_OMP_OFFLOAD
   test_map_key<Omp>(h);
-#elif defined(CAMP_HAVE_SYCL)
+#endif
+#ifdef CAMP_HAVE_SYCL
   test_map_key<Sycl>(h);
 #endif
 }
@@ -565,13 +574,16 @@ TEST(CampEvent, UnorderedMapKey)
 {
   Event he = Host().get_event_erased();
   test_map_key<Host>(he);
-#if defined(CAMP_HAVE_CUDA)
+#ifdef CAMP_HAVE_CUDA
   test_map_key<Cuda>(he);
-#elif defined(CAMP_HAVE_HIP)
+#endif
+#ifdef CAMP_HAVE_HIP
   test_map_key<Hip>(he);
-#elif defined(CAMP_HAVE_OMP_OFFLOAD)
+#endif
+#ifdef CAMP_HAVE_OMP_OFFLOAD
   test_map_key<Omp>(he);
-#elif defined(CAMP_HAVE_SYCL)
+#endif
+#ifdef CAMP_HAVE_SYCL
   test_map_key<Sycl>(he);
 #endif
 }

--- a/test/resource.cpp
+++ b/test/resource.cpp
@@ -1563,7 +1563,7 @@ void test_concrete_resource_trait()
   ASSERT_TRUE(is_concrete_resource<Res&&>::value);
 }
 //
-TEST(CampResourceTypeTraits, ConcreteResource)
+TEST(CampResource, ConcreteResourceTypeTrait)
 {
   test_concrete_resource_trait<Host>();
 
@@ -1606,7 +1606,7 @@ void test_concrete_event_trait()
   ASSERT_TRUE(is_concrete_event<Evt&&>::value);
 }
 //
-TEST(CampResourceTypeTraits, ConcreteEvent)
+TEST(CampEvent, ConcreteEventTypeTrait)
 {
   test_concrete_event_trait<HostEvent>();
 
@@ -1714,13 +1714,13 @@ void test_inferred_deallocate(MemoryAccess access)
   r.deallocate(ptr);
 }
 
-TEST(CampResourceMemory, Host)
+TEST(CampResource, MemoryHost)
 {
   test_memory_ops<Host>(MemoryAccess::Device);
 }
 
 #ifdef CAMP_HAVE_CUDA
-TEST(CampResourceMemory, Cuda)
+TEST(CampResource, MemoryCuda)
 {
   test_memory_ops<Cuda>(MemoryAccess::Unknown);
   test_memory_ops<Cuda>(MemoryAccess::Device);
@@ -1734,7 +1734,7 @@ TEST(CampResourceMemory, Cuda)
 #endif
 
 #ifdef CAMP_HAVE_HIP
-TEST(CampResourceMemory, Hip)
+TEST(CampResource, MemoryHip)
 {
   test_memory_ops<Hip>(MemoryAccess::Unknown);
   test_memory_ops<Hip>(MemoryAccess::Device);
@@ -1748,14 +1748,14 @@ TEST(CampResourceMemory, Hip)
 #endif
 
 #ifdef CAMP_HAVE_OMP_OFFLOAD
-TEST(CampResourceMemory, Omp)
+TEST(CampResource, MemoryOmp)
 {
   test_memory_ops<Omp>(MemoryAccess::Device);
 }
 #endif
 
 #ifdef CAMP_HAVE_SYCL
-TEST(CampResourceMemory, Sycl)
+TEST(CampResource, MemorySycl)
 {
   test_memory_ops<Sycl>(MemoryAccess::Unknown);
   test_memory_ops<Sycl>(MemoryAccess::Device);
@@ -1765,7 +1765,7 @@ TEST(CampResourceMemory, Sycl)
 #endif
 
 #ifdef CAMP_HAVE_CUDA
-TEST(CampCuda, Helpers)
+TEST(CampResourceCuda, Helpers)
 {
   int current_device = -1;
   cudaStream_t stream;
@@ -1787,7 +1787,7 @@ TEST(CampCuda, Helpers)
 #endif
 
 #ifdef CAMP_HAVE_HIP
-TEST(CampHip, Helpers)
+TEST(CampResourceHip, Helpers)
 {
   int current_device = -1;
   hipStream_t stream;
@@ -1809,7 +1809,7 @@ TEST(CampHip, Helpers)
 #endif
 
 #ifdef CAMP_HAVE_OMP_OFFLOAD
-TEST(CampOmp, Helpers)
+TEST(CampResourceOmp, Helpers)
 {
   char a[1];
   Omp resource = Omp::OmpFromAddr(&a[0]);
@@ -1847,7 +1847,7 @@ TEST(CampOmp, Helpers)
 #endif
 
 #ifdef CAMP_HAVE_SYCL
-TEST(CampSycl, Helpers)
+TEST(CampResourceSycl, Helpers)
 {
   sycl::context original_default = Sycl::get_default_context();
   sycl::context original_thread = Sycl::get_thread_default_context();

--- a/test/resource.cpp
+++ b/test/resource.cpp
@@ -201,6 +201,73 @@ TEST(CampEvent, GetPlatform)
 #endif
 }
 
+TEST(CampResource, EmptyBehavior)
+{
+  Resource full{Host()};
+  Resource sink{std::move(full)};
+  Resource full2{Host()};
+  Resource sink2{std::move(full2)};
+  Resource& empty = full;
+  Resource& empty2 = full2;
+  int value = 7;
+
+  CAMP_ALLOW_UNUSED_LOCAL(sink);
+  CAMP_ALLOW_UNUSED_LOCAL(sink2);
+
+  ASSERT_FALSE(empty);
+  ASSERT_EQ(empty.get_platform(), Platform::undefined);
+  ASSERT_EQ(empty, empty2);
+  ASSERT_NE(empty, Resource{Host()});
+  ASSERT_EQ(std::hash<Resource>{}(empty), 0u);
+
+  ASSERT_EQ(empty.allocate<int>(0), nullptr);
+  ASSERT_EQ(empty.calloc(0), nullptr);
+  empty.deallocate(nullptr);
+  empty.memcpy(&value, &value, 0);
+  empty.memset(&value, 0, 0);
+  empty.wait();
+  empty.wait_for(nullptr);
+
+  ASSERT_THROW((void)empty.get<Host>(), std::runtime_error);
+  ASSERT_FALSE(empty.try_get<Host>());
+  ASSERT_THROW((void)empty.allocate<int>(1), std::runtime_error);
+  ASSERT_THROW((void)empty.calloc(1), std::runtime_error);
+  ASSERT_THROW(empty.deallocate(&value), std::runtime_error);
+  ASSERT_THROW(empty.memcpy(&value, &value, 1), std::runtime_error);
+  ASSERT_THROW(empty.memset(&value, 0, 1), std::runtime_error);
+
+  Event empty_event = empty.get_event();
+  Event empty_erased_event = empty.get_event_erased();
+  ASSERT_FALSE(empty_event);
+  ASSERT_FALSE(empty_erased_event);
+  ASSERT_EQ(empty_event, empty_erased_event);
+
+  Event host_event = Host().get_event_erased();
+  empty.wait_for(&host_event);
+}
+
+TEST(CampEvent, EmptyBehavior)
+{
+  Event empty;
+  Event empty2;
+
+  ASSERT_FALSE(empty);
+  ASSERT_EQ(empty.get_platform(), Platform::undefined);
+  ASSERT_TRUE(empty.check());
+  empty.wait();
+  ASSERT_EQ(empty, empty2);
+  ASSERT_NE(empty, Host().get_event_erased());
+  ASSERT_EQ(std::hash<Event>{}(empty), 0u);
+  ASSERT_FALSE(empty.try_get<HostEvent>());
+  ASSERT_THROW((void)empty.get<HostEvent>(), std::runtime_error);
+
+  Event host_event{Host().get_event()};
+  ASSERT_TRUE(host_event);
+  ASSERT_TRUE(host_event.try_get<HostEvent>());
+  ASSERT_FALSE(host_event.try_get<HostEvent2>());
+  ASSERT_THROW((void)host_event.get<HostEvent2>(), std::runtime_error);
+}
+
 TEST(CampPlatform, ResourceFromPlatform)
 {
   ASSERT_TRUE((std::is_same_v<resource_from_platform<Platform::host>::type,

--- a/test/resource.cpp
+++ b/test/resource.cpp
@@ -1700,6 +1700,14 @@ TEST(CampOmp, Helpers)
   resource.deallocate(ptr);
   ASSERT_EQ(resource.get_ptr_dev(&ptr), omp_get_initial_device());
 
+  unsigned char manual_registration_token = 0;
+  resource.register_ptr_dev(&manual_registration_token, resource.get_device());
+  ASSERT_EQ(resource.get_ptr_dev(&manual_registration_token),
+            resource.get_device());
+  resource.deregister_ptr_dev(&manual_registration_token);
+  ASSERT_EQ(resource.get_ptr_dev(&manual_registration_token),
+            omp_get_initial_device());
+
   ASSERT_THROW((void)resource.allocate<unsigned char>(1, MemoryAccess::Pinned),
                std::runtime_error);
   ASSERT_THROW((void)resource.calloc(1, MemoryAccess::Managed),

--- a/test/resource.cpp
+++ b/test/resource.cpp
@@ -439,40 +439,64 @@ TEST(CampResource, UnorderedMapKey)
 #endif
 }
 
+struct ref_hash {
+  template <typename T>
+  std::size_t operator()(std::reference_wrapper<T> const& ref) const {
+    return std::hash<T>()(ref.get());
+  }
+};
+
+struct ref_equal {
+  template <typename T>
+  bool operator()(std::reference_wrapper<T> const& lhs,
+                  std::reference_wrapper<T> const& rhs) const {
+    return lhs.get() == rhs.get();
+  }
+};
+
 template <typename Res>
 void test_map_key(Event& he)
 {
-  // Generic
-  std::unordered_map<Event, size_t> map;
-  std::unordered_multimap<Event, size_t> multimap;
-  Event d1{Res().get_event_erased()};
-  Event d2{Res().get_event_erased()};
+  using typed_event = typename Res::event_type;
 
-  // Typed
-  auto e1{Res().get_event()};
-  auto e2{Res().get_event()};
-  std::unordered_map<decltype(e1), size_t> rmap;
-  std::unordered_multimap<decltype(e2), size_t> rmultimap;
+  using erased_event_ref = std::reference_wrapper<Event>;
+  using typed_event_ref = std::reference_wrapper<typed_event>;
 
   // Generic
-  map.insert({he, 10});
-  multimap.insert({he, 10});
-  map.insert({he, 20});
-  multimap.insert({he, 20});
-  map.insert({d1, 30});
-  multimap.insert({d1, 30});
-  map.insert({d2, 40});
-  multimap.insert({d2, 40});
-  map.insert({d2, 50});
-  multimap.insert({d2, 50});
+  Event d1_ = Res().get_event_erased();
+  Event d2_ = Res().get_event_erased();
+  erased_event_ref d1(d1_);
+  erased_event_ref d2(d2_);
+  std::unordered_map<erased_event_ref, size_t, ref_hash, ref_equal> map;
+  std::unordered_multimap<erased_event_ref, size_t, ref_hash, ref_equal> multimap;
 
   // Typed
-  rmap.insert({e1, 30});
-  rmultimap.insert({e1, 30});
-  rmap.insert({e2, 40});
-  rmultimap.insert({e2, 40});
-  rmap.insert({e2, 50});
-  rmultimap.insert({e2, 50});
+  typed_event e1_ = Res().get_event();
+  typed_event e2_ = Res().get_event();
+  typed_event_ref e1(e1_);
+  typed_event_ref e2(e2_);
+  std::unordered_map<typed_event_ref, size_t, ref_hash, ref_equal> rmap;
+  std::unordered_multimap<typed_event_ref, size_t, ref_hash, ref_equal> rmultimap;
+
+  // Generic
+  map.emplace(he, 10);
+  multimap.emplace(he, 10);
+  map.emplace(he, 20);
+  multimap.emplace(he, 20);
+  map.emplace(d1, 30);
+  multimap.emplace(d1, 30);
+  map.emplace(d2, 40);
+  multimap.emplace(d2, 40);
+  map.emplace(d2, 50);
+  multimap.emplace(d2, 50);
+
+  // Typed
+  rmap.emplace(e1, 30);
+  rmultimap.emplace(e1, 30);
+  rmap.emplace(e2, 40);
+  rmultimap.emplace(e2, 40);
+  rmap.emplace(e2, 50);
+  rmultimap.emplace(e2, 50);
 
   // Verify using Event as a key to find entries works
   // Generic
@@ -532,7 +556,7 @@ void test_map_key(Event& he)
 //
 TEST(CampEvent, UnorderedMapKey)
 {
-  Event he{Host().get_event_erased()};
+  Event he = Host().get_event_erased();
   test_map_key<Host>(he);
 #if defined(CAMP_HAVE_CUDA)
   test_map_key<Cuda>(he);

--- a/test/resource.cpp
+++ b/test/resource.cpp
@@ -1432,10 +1432,21 @@ void test_memory_ops(MemoryAccess access)
   r.deallocate(zeroed, access);
 }
 
+template <typename Res>
+void test_inferred_deallocate(MemoryAccess access)
+{
+  Res r;
+  auto* ptr = r.template allocate<unsigned char>(32, access);
+  ASSERT_NE(ptr, nullptr);
+  verify_memset_value(r, ptr, 0x3C);
+  r.deallocate(ptr);
+}
+
 TEST(CampResourceMemory, Host)
 {
   test_memory_ops<Host>(MemoryAccess::Device);
 }
+
 #ifdef CAMP_HAVE_CUDA
 TEST(CampResourceMemory, Cuda)
 {
@@ -1443,6 +1454,10 @@ TEST(CampResourceMemory, Cuda)
   test_memory_ops<Cuda>(MemoryAccess::Device);
   test_memory_ops<Cuda>(MemoryAccess::Pinned);
   test_memory_ops<Cuda>(MemoryAccess::Managed);
+
+  test_inferred_deallocate<Cuda>(MemoryAccess::Device);
+  test_inferred_deallocate<Cuda>(MemoryAccess::Pinned);
+  test_inferred_deallocate<Cuda>(MemoryAccess::Managed);
 }
 #endif
 
@@ -1453,6 +1468,10 @@ TEST(CampResourceMemory, Hip)
   test_memory_ops<Hip>(MemoryAccess::Device);
   test_memory_ops<Hip>(MemoryAccess::Pinned);
   test_memory_ops<Hip>(MemoryAccess::Managed);
+
+  test_inferred_deallocate<Hip>(MemoryAccess::Device);
+  test_inferred_deallocate<Hip>(MemoryAccess::Pinned);
+  test_inferred_deallocate<Hip>(MemoryAccess::Managed);
 }
 #endif
 

--- a/test/resource.cpp
+++ b/test/resource.cpp
@@ -864,6 +864,31 @@ TEST(CampResource, Get)
 #endif
 }
 
+template <typename Res>
+void test_get_rvalue()
+{
+  Resource dev_res{Res()};
+  auto moved_res = std::move(dev_res).get<Res>();
+  ASSERT_EQ(typeid(moved_res), typeid(Res{}));
+}
+
+TEST(CampResource, GetRValue)
+{
+  test_get_rvalue<Host>();
+#ifdef CAMP_HAVE_CUDA
+  test_get_rvalue<Cuda>();
+#endif
+#ifdef CAMP_HAVE_HIP
+  test_get_rvalue<Hip>();
+#endif
+#ifdef CAMP_HAVE_OMP_OFFLOAD
+  test_get_rvalue<Omp>();
+#endif
+#ifdef CAMP_HAVE_SYCL
+  test_get_rvalue<Sycl>();
+#endif
+}
+
 template <typename Res, typename ResEvent, typename... EventArgs>
 void test_get_event(EventArgs&&... eventArgs)
 {

--- a/test/resource.cpp
+++ b/test/resource.cpp
@@ -202,6 +202,36 @@ TEST(CampEvent, GetPlatform)
 }
 
 template <typename Res>
+void test_zero_size_memory_ops()
+{
+  Resource r{Res()};
+  int value = 13;
+
+  ASSERT_EQ(r.allocate<int>(0), nullptr);
+  ASSERT_EQ(r.calloc(0), nullptr);
+  r.deallocate(nullptr);
+  r.memcpy(&value, &value, 0);
+  r.memset(&value, 0, 0);
+}
+
+TEST(CampResource, ZeroSizeMemory)
+{
+  test_zero_size_memory_ops<Host>();
+#ifdef CAMP_HAVE_CUDA
+  test_zero_size_memory_ops<Cuda>();
+#endif
+#ifdef CAMP_HAVE_HIP
+  test_zero_size_memory_ops<Hip>();
+#endif
+#ifdef CAMP_HAVE_OMP_OFFLOAD
+  test_zero_size_memory_ops<Omp>();
+#endif
+#ifdef CAMP_HAVE_SYCL
+  test_zero_size_memory_ops<Sycl>();
+#endif
+}
+
+template <typename Res>
 void test_vector(Resource& h)
 {
   // Generic

--- a/test/resource.cpp
+++ b/test/resource.cpp
@@ -9,6 +9,7 @@
 
 #include "camp/resource.hpp"
 
+#include <array>
 #include <type_traits>
 
 #include "camp/camp.hpp"
@@ -1365,3 +1366,109 @@ TEST(CampResourceTypeTraits, ConcreteEvent)
   // Host2 has an overload of is_concrete_event_impl
   ASSERT_TRUE(is_concrete_event<HostEvent2>::value);
 }
+
+template <typename Res>
+void verify_bytes_roundtrip(Res& r, unsigned char* ptr)
+{
+  constexpr size_t N = 32;
+  std::array<unsigned char, N> expected{};
+  std::array<unsigned char, N> actual{};
+
+  for (size_t i = 0; i < N; ++i) {
+    expected[i] = static_cast<unsigned char>(i * 7 + 3);
+  }
+
+  r.memcpy(ptr, expected.data(), N);
+  r.wait();
+  actual.fill(0);
+  r.memcpy(actual.data(), ptr, N);
+  r.wait();
+  ASSERT_EQ(actual, expected);
+}
+
+template <typename Res>
+void verify_zero_initialized(Res& r, void* ptr)
+{
+  constexpr size_t N = 32;
+  std::array<unsigned char, N> actual{};
+  actual.fill(0xFF);
+  r.memcpy(actual.data(), ptr, N);
+  r.wait();
+  for (auto value : actual) {
+    ASSERT_EQ(value, 0u);
+  }
+}
+
+template <typename Res>
+void verify_memset_value(Res& r, void* ptr, unsigned char value)
+{
+  constexpr size_t N = 32;
+  std::array<unsigned char, N> actual{};
+  r.memset(ptr, value, N);
+  r.wait();
+  actual.fill(0);
+  r.memcpy(actual.data(), ptr, N);
+  r.wait();
+  for (auto byte : actual) {
+    ASSERT_EQ(byte, value);
+  }
+}
+
+template <typename Res>
+void test_memory_ops(MemoryAccess access)
+{
+  constexpr size_t N = 32;
+  Res r;
+  auto* ptr = r.template allocate<unsigned char>(N, access);
+  ASSERT_NE(ptr, nullptr);
+  verify_memset_value(r, ptr, 0x5A);
+  verify_bytes_roundtrip(r, ptr);
+
+  void* zeroed = r.calloc(N, access);
+  ASSERT_NE(zeroed, nullptr);
+  verify_zero_initialized(r, zeroed);
+
+  r.deallocate(ptr, access);
+  r.deallocate(zeroed, access);
+}
+
+TEST(CampResourceMemory, Host)
+{
+  test_memory_ops<Host>(MemoryAccess::Device);
+}
+#ifdef CAMP_HAVE_CUDA
+TEST(CampResourceMemory, Cuda)
+{
+  test_memory_ops<Cuda>(MemoryAccess::Unknown);
+  test_memory_ops<Cuda>(MemoryAccess::Device);
+  test_memory_ops<Cuda>(MemoryAccess::Pinned);
+  test_memory_ops<Cuda>(MemoryAccess::Managed);
+}
+#endif
+
+#ifdef CAMP_HAVE_HIP
+TEST(CampResourceMemory, Hip)
+{
+  test_memory_ops<Hip>(MemoryAccess::Unknown);
+  test_memory_ops<Hip>(MemoryAccess::Device);
+  test_memory_ops<Hip>(MemoryAccess::Pinned);
+  test_memory_ops<Hip>(MemoryAccess::Managed);
+}
+#endif
+
+#ifdef CAMP_HAVE_OMP_OFFLOAD
+TEST(CampResourceMemory, Omp)
+{
+  test_memory_ops<Omp>(MemoryAccess::Device);
+}
+#endif
+
+#ifdef CAMP_HAVE_SYCL
+TEST(CampResourceMemory, Sycl)
+{
+  test_memory_ops<Sycl>(MemoryAccess::Unknown);
+  test_memory_ops<Sycl>(MemoryAccess::Device);
+  test_memory_ops<Sycl>(MemoryAccess::Pinned);
+  test_memory_ops<Sycl>(MemoryAccess::Managed);
+}
+#endif

--- a/test/resource.cpp
+++ b/test/resource.cpp
@@ -19,6 +19,8 @@ using namespace camp::resources;
 // compatible but different resource for conversion test
 struct Host2 : Host {
 };
+struct HostEvent2 : HostEvent {
+};
 #ifdef CAMP_HAVE_CUDA
 struct Cuda2 : Cuda {
 };
@@ -43,10 +45,15 @@ namespace resources
   template <>
   struct is_concrete_resource_impl<Host2> : std::true_type {
   };
+  template <>
+  struct is_concrete_event_impl<HostEvent2> : std::true_type {
+  };
 }  // namespace resources
 }  // namespace camp
 
 struct NotAResource { };
+
+struct NotAnEvent { };
 
 template <typename Res>
 void test_construct()
@@ -1155,4 +1162,47 @@ TEST(CampResourceTypeTraits, ConcreteResource)
   ASSERT_FALSE(is_concrete_resource<NotAResource>::value);
   // Host2 has an overload of is_concrete_resource_impl
   ASSERT_TRUE(is_concrete_resource<Host2>::value);
+}
+
+template <typename Evt>
+void test_concrete_event_trait()
+{
+  ASSERT_TRUE(is_concrete_event<Evt>::value);
+  ASSERT_TRUE(is_concrete_event<Evt&>::value);
+  ASSERT_TRUE(is_concrete_event<const Evt>::value);
+  ASSERT_TRUE(is_concrete_event<const Evt&>::value);
+  ASSERT_TRUE(is_concrete_event<Evt&&>::value);
+}
+//
+TEST(CampResourceTypeTraits, ConcreteEvent)
+{
+  test_concrete_event_trait<HostEvent>();
+
+#ifdef CAMP_HAVE_CUDA
+  test_concrete_event_trait<CudaEvent>();
+#endif
+
+#ifdef CAMP_HAVE_HIP
+  test_concrete_event_trait<HipEvent>();
+#endif
+
+#ifdef CAMP_HAVE_SYCL
+  test_concrete_event_trait<SyclEvent>();
+#endif
+
+#ifdef CAMP_HAVE_OMP_OFFLOAD
+  test_concrete_event_trait<OmpEvent>();
+#endif
+
+  // Event is not a concrete event
+  ASSERT_FALSE(is_concrete_event<Event>::value);
+  // Test is_concrete_event with non-event types
+  ASSERT_FALSE(is_concrete_event<int>::value);
+  ASSERT_FALSE(is_concrete_event<float>::value);
+  ASSERT_FALSE(is_concrete_event<double>::value);
+  ASSERT_FALSE(is_concrete_event<void*>::value);
+  ASSERT_FALSE(is_concrete_event<char*>::value);
+  ASSERT_FALSE(is_concrete_event<NotAnEvent>::value);
+  // Host2 has an overload of is_concrete_event_impl
+  ASSERT_TRUE(is_concrete_event<HostEvent2>::value);
 }

--- a/test/resource.cpp
+++ b/test/resource.cpp
@@ -784,6 +784,55 @@ TEST(CampResource, HostCompare)
   ASSERT_TRUE(h3 == h2);
 }
 
+template <typename Res>
+void test_get_default(Platform platform)
+{
+  auto d1 = Res::get_default();
+  auto d2 = Res::get_default();
+
+  ASSERT_EQ(d1.get_platform(), platform);
+  ASSERT_EQ(d2.get_platform(), platform);
+  ASSERT_EQ(d1, d2);
+  ASSERT_EQ(std::hash<Res>{}(d1), std::hash<Res>{}(d2));
+
+  Resource r1{d1};
+  Resource r2{d2};
+  ASSERT_EQ(r1.get_platform(), platform);
+  ASSERT_EQ(r2.get_platform(), platform);
+  ASSERT_EQ(r1, r2);
+  ASSERT_EQ(std::hash<Resource>{}(r1), std::hash<Resource>{}(r2));
+
+  typename Res::event_type typed_event = d1.get_event();
+  Event erased_event = d1.get_event_erased();
+  ASSERT_EQ(typed_event.get_platform(), platform);
+  ASSERT_EQ(erased_event.get_platform(), platform);
+  ASSERT_TRUE(erased_event);
+
+  d1.wait_for(nullptr);
+  d1.wait_for(&typed_event);
+  d1.wait_for(&erased_event);
+  d1.wait();
+  typed_event.wait();
+  erased_event.wait();
+}
+
+TEST(CampResource, GetDefault)
+{
+  test_get_default<Host>(Platform::host);
+#ifdef CAMP_HAVE_CUDA
+  test_get_default<Cuda>(Platform::cuda);
+#endif
+#ifdef CAMP_HAVE_HIP
+  test_get_default<Hip>(Platform::hip);
+#endif
+#ifdef CAMP_HAVE_OMP_OFFLOAD
+  test_get_default<Omp>(Platform::omp_target);
+#endif
+#ifdef CAMP_HAVE_SYCL
+  test_get_default<Sycl>(Platform::sycl);
+#endif
+}
+
 
 template <typename Res>
 void test_id_compare(Event& he)

--- a/test/resource.cpp
+++ b/test/resource.cpp
@@ -285,7 +285,6 @@ TEST(CampResource, EmptyBehavior)
   empty.memcpy(&value, &value, 0);
   empty.memset(&value, 0, 0);
   empty.wait();
-  empty.wait_for(nullptr);
 
   ASSERT_THROW((void)empty.get<Host>(), std::runtime_error);
   ASSERT_FALSE(empty.try_get<Host>());
@@ -302,7 +301,8 @@ TEST(CampResource, EmptyBehavior)
   ASSERT_EQ(empty_event, empty_erased_event);
 
   Event host_event = Host().get_event_erased();
-  empty.wait_for(&host_event);
+  empty.wait_for(empty_event);
+  empty.wait_for(host_event);
 }
 
 TEST(CampEvent, EmptyBehavior)
@@ -948,9 +948,10 @@ void test_get_default(Platform platform)
   ASSERT_EQ(erased_event.get_platform(), platform);
   ASSERT_TRUE(erased_event);
 
-  d1.wait_for(nullptr);
-  d1.wait_for(&typed_event);
-  d1.wait_for(&erased_event);
+  Event empty_event;
+  d1.wait_for(empty_event);
+  d1.wait_for(typed_event);
+  d1.wait_for(erased_event);
   d1.wait();
   typed_event.wait();
   erased_event.wait();
@@ -1465,13 +1466,14 @@ void test_wait()
 {
   auto r = Res();
   r.wait();
-  r.wait_for(nullptr);
+  Event empty_event;
+  r.wait_for(empty_event);
   Event erased_event = r.get_event_erased();
-  r.wait_for(&erased_event);
+  r.wait_for(erased_event);
   auto typed_event = r.get_event();
-  r.wait_for(&typed_event);
+  r.wait_for(typed_event);
   Event host_event = Host().get_event_erased();
-  r.wait_for(&host_event);
+  r.wait_for(host_event);
   Resource er(r);
   er.wait();
 }

--- a/test/resource.cpp
+++ b/test/resource.cpp
@@ -201,6 +201,28 @@ TEST(CampEvent, GetPlatform)
 #endif
 }
 
+TEST(CampPlatform, ResourceFromPlatform)
+{
+  ASSERT_TRUE((std::is_same_v<resource_from_platform<Platform::host>::type,
+                              Host>));
+#ifdef CAMP_HAVE_CUDA
+  ASSERT_TRUE((std::is_same_v<resource_from_platform<Platform::cuda>::type,
+                              Cuda>));
+#endif
+#ifdef CAMP_HAVE_HIP
+  ASSERT_TRUE((std::is_same_v<resource_from_platform<Platform::hip>::type,
+                              Hip>));
+#endif
+#ifdef CAMP_HAVE_OMP_OFFLOAD
+  ASSERT_TRUE(
+      (std::is_same_v<resource_from_platform<Platform::omp_target>::type, Omp>));
+#endif
+#ifdef CAMP_HAVE_SYCL
+  ASSERT_TRUE((std::is_same_v<resource_from_platform<Platform::sycl>::type,
+                              Sycl>));
+#endif
+}
+
 template <typename Res>
 void test_zero_size_memory_ops()
 {

--- a/test/resource.cpp
+++ b/test/resource.cpp
@@ -109,6 +109,67 @@ TEST(CampResource, Copy)
 #endif
 }
 
+template <typename Res>
+void test_copy_assignment()
+{
+  Resource src{Res()};
+  Resource dst;
+
+  dst = src;
+
+  ASSERT_TRUE(src);
+  ASSERT_TRUE(dst);
+  ASSERT_TRUE(dst.try_get<Res>());
+  ASSERT_EQ(src, dst);
+}
+
+TEST(CampResource, CopyAssignment)
+{
+  test_copy_assignment<Host>();
+#ifdef CAMP_HAVE_CUDA
+  test_copy_assignment<Cuda>();
+#endif
+#ifdef CAMP_HAVE_HIP
+  test_copy_assignment<Hip>();
+#endif
+#ifdef CAMP_HAVE_OMP_OFFLOAD
+  test_copy_assignment<Omp>();
+#endif
+#ifdef CAMP_HAVE_SYCL
+  test_copy_assignment<Sycl>();
+#endif
+}
+
+template <typename Res>
+void test_move_assignment()
+{
+  Resource src{Res()};
+  Resource dst;
+
+  dst = std::move(src);
+
+  ASSERT_FALSE(src);
+  ASSERT_TRUE(dst);
+  ASSERT_TRUE(dst.try_get<Res>());
+}
+
+TEST(CampResource, MoveAssignment)
+{
+  test_move_assignment<Host>();
+#ifdef CAMP_HAVE_CUDA
+  test_move_assignment<Cuda>();
+#endif
+#ifdef CAMP_HAVE_HIP
+  test_move_assignment<Hip>();
+#endif
+#ifdef CAMP_HAVE_OMP_OFFLOAD
+  test_move_assignment<Omp>();
+#endif
+#ifdef CAMP_HAVE_SYCL
+  test_move_assignment<Sycl>();
+#endif
+}
+
 template <typename Res, typename Res2>
 void test_convert_fails()
 {
@@ -264,6 +325,71 @@ TEST(CampEvent, EmptyBehavior)
   ASSERT_TRUE(host_event.try_get<HostEvent>());
   ASSERT_FALSE(host_event.try_get<HostEvent2>());
   ASSERT_THROW((void)host_event.get<HostEvent2>(), std::runtime_error);
+}
+
+template <typename Res>
+void test_event_copy_assignment()
+{
+  using ResEvent = typename Res::event_type;
+
+  Event src = Res().get_event_erased();
+  Event dst;
+
+  dst = src;
+
+  ASSERT_TRUE(src);
+  ASSERT_TRUE(dst);
+  ASSERT_TRUE(dst.try_get<ResEvent>());
+  ASSERT_EQ(src, dst);
+}
+
+TEST(CampEvent, CopyAssignment)
+{
+  test_event_copy_assignment<Host>();
+#ifdef CAMP_HAVE_CUDA
+  test_event_copy_assignment<Cuda>();
+#endif
+#ifdef CAMP_HAVE_HIP
+  test_event_copy_assignment<Hip>();
+#endif
+#ifdef CAMP_HAVE_OMP_OFFLOAD
+  test_event_copy_assignment<Omp>();
+#endif
+#ifdef CAMP_HAVE_SYCL
+  test_event_copy_assignment<Sycl>();
+#endif
+}
+
+template <typename Res>
+void test_event_move_assignment()
+{
+  using ResEvent = typename Res::event_type;
+
+  Event src = Res().get_event_erased();
+  Event dst;
+
+  dst = std::move(src);
+
+  ASSERT_FALSE(src);
+  ASSERT_TRUE(dst);
+  ASSERT_TRUE(dst.try_get<ResEvent>());
+}
+
+TEST(CampEvent, MoveAssignment)
+{
+  test_event_move_assignment<Host>();
+#ifdef CAMP_HAVE_CUDA
+  test_event_move_assignment<Cuda>();
+#endif
+#ifdef CAMP_HAVE_HIP
+  test_event_move_assignment<Hip>();
+#endif
+#ifdef CAMP_HAVE_OMP_OFFLOAD
+  test_event_move_assignment<Omp>();
+#endif
+#ifdef CAMP_HAVE_SYCL
+  test_event_move_assignment<Sycl>();
+#endif
 }
 
 TEST(CampPlatform, ResourceFromPlatform)


### PR DESCRIPTION
Make typed events move only so they can own the native events that they contain and destroy those native events properly. Erased events (Event) are not move only and still have reference semantics as they are implemented with a shared_ptr.

This also other things I found along the way. For example some functions only took the erased version of a resource or event so I added an overload for the typed version for performance. I also updated the organization of some of the type traits and concepts used by the resources/events. I also updated the tests to test more things.