### PR TITLE
Resource allocator

### DIFF
--- a/include/camp/resource.hpp
+++ b/include/camp/resource.hpp
@@ -24,7 +24,6 @@
 
 // last to ensure we don't hide breakage in the others
 #include "camp/resource/platform.hpp"
-#include "camp/resource/resource_allocator.hpp"
 
 namespace camp
 {
@@ -423,5 +422,7 @@ struct hash<camp::resources::Resource> {
 #if defined(CAMP_HAVE_OMP_OFFLOAD)
 #include "camp/resource/omp_target.hpp"
 #endif
+
+#include "camp/resource/resource_allocator.hpp"
 
 #endif /* __CAMP_RESOURCE_HPP */

--- a/include/camp/resource.hpp
+++ b/include/camp/resource.hpp
@@ -19,10 +19,12 @@
 #include "camp/config.hpp"
 #include "camp/defines.hpp"
 #include "camp/helpers.hpp"
+
 #include "camp/resource/event.hpp"
 
 // last to ensure we don't hide breakage in the others
 #include "camp/resource/platform.hpp"
+#include "camp/resource/resource_allocator.hpp"
 
 namespace camp
 {
@@ -48,7 +50,7 @@ namespace resources
       }
 
       template <typename T>
-      T *try_get()
+      T* try_get()
       {
         if (!m_value) {
           return nullptr;
@@ -61,7 +63,7 @@ namespace resources
       }
 
       template <typename T>
-      T const *try_get() const
+      T const* try_get() const
       {
         if (!m_value) {
           return nullptr;
@@ -74,9 +76,9 @@ namespace resources
       }
 
       template <typename T>
-      T &get() &
+      T& get() &
       {
-        T *result = try_get<T>();
+        T* result = try_get<T>();
         if (result == nullptr) {
           ::camp::throw_re("Incompatible Resource type get cast.");
         }
@@ -84,9 +86,9 @@ namespace resources
       }
 
       template <typename T>
-      T const &get() const &
+      T const& get() const&
       {
-        T const *result = try_get<T>();
+        T const* result = try_get<T>();
         if (result == nullptr) {
           ::camp::throw_re("Incompatible Resource type get cast.");
         }
@@ -96,7 +98,7 @@ namespace resources
       template <typename T>
       T get() &&
       {
-        T *result = try_get<T>();
+        T* result = try_get<T>();
         if (result == nullptr) {
           ::camp::throw_re("Incompatible Resource type get cast.");
         }
@@ -180,10 +182,10 @@ namespace resources
         return m_value->get_event_erased();
       }
 
-      void wait_for(Event const &e)
+      void wait_for(Event const& e)
       {
         if (!m_value) {
-          e.wait();
+            e.wait();
           return;
         }
         m_value->wait_for(e);
@@ -211,7 +213,8 @@ namespace resources
         if (!lhs.m_value && !rhs.m_value) {
           return true;
         }
-        if ((!lhs.m_value && rhs.m_value) || (lhs.m_value && !rhs.m_value)) {
+        if ((!lhs.m_value && rhs.m_value) ||
+            (lhs.m_value && !rhs.m_value)) {
           return false;
         }
         if (lhs.get_platform() == rhs.get_platform()) {
@@ -220,7 +223,7 @@ namespace resources
         return false;
       }
 
-      template <camp::concepts::ConcreteResource Res>
+      template < camp::concepts::ConcreteResource Res >
       friend inline bool operator==(Resource const &lhs, Res const &rhs)
       {
         if (!lhs.m_value) {
@@ -269,7 +272,7 @@ namespace resources
 
         virtual Event get_event() = 0;
         virtual Event get_event_erased() = 0;
-        virtual void wait_for(Event const &e) = 0;
+        virtual void wait_for(Event const& e) = 0;
         virtual void wait() = 0;
       };
 
@@ -326,13 +329,13 @@ namespace resources
           return m_modelVal.get_event_erased();
         }
 
-        void wait_for(Event const &e) override { m_modelVal.wait_for(e); }
+        void wait_for(Event const& e) override { m_modelVal.wait_for(e); }
 
         void wait() override { m_modelVal.wait(); }
 
-        const T *get() const { return &m_modelVal; }
+        const T* get() const { return &m_modelVal; }
 
-        T *get() { return &m_modelVal; }
+        T* get() { return &m_modelVal; }
 
       private:
         T m_modelVal;
@@ -342,7 +345,8 @@ namespace resources
     };
 
     template <typename Res>
-    struct EventProxy : ::camp::resources::detail::EventProxyBase {
+    struct EventProxy : ::camp::resources::detail::EventProxyBase
+    {
       using native_event = typename Res::event_type;
 
       EventProxy(EventProxy &&) = default;
@@ -353,24 +357,27 @@ namespace resources
       EventProxy(Res r) : resource_{move(r)} {}
 
       native_event get()
-        requires(!std::same_as<native_event, Event>)
+      requires (!std::same_as<native_event, Event>)
       {
         return resource_.get_event();
       }
 
       Event get()
-        requires(std::same_as<native_event, Event>)
+      requires (std::same_as<native_event, Event>)
       {
         return resource_.get_event_erased();
       }
 
       operator native_event()
-        requires(!std::same_as<native_event, Event>)
+      requires (!std::same_as<native_event, Event>)
       {
         return resource_.get_event();
       }
 
-      operator Event() { return resource_.get_event_erased(); }
+      operator Event()
+      {
+        return resource_.get_event_erased();
+      }
 
       Res resource_;
     };
@@ -416,7 +423,5 @@ struct hash<camp::resources::Resource> {
 #if defined(CAMP_HAVE_OMP_OFFLOAD)
 #include "camp/resource/omp_target.hpp"
 #endif
-
-#include "camp/resource/resource_allocator.hpp"
 
 #endif /* __CAMP_RESOURCE_HPP */

--- a/include/camp/resource.hpp
+++ b/include/camp/resource.hpp
@@ -19,12 +19,10 @@
 #include "camp/config.hpp"
 #include "camp/defines.hpp"
 #include "camp/helpers.hpp"
-
 #include "camp/resource/event.hpp"
 
 // last to ensure we don't hide breakage in the others
 #include "camp/resource/platform.hpp"
-#include "camp/resource/resource_allocator.hpp"
 
 namespace camp
 {
@@ -46,11 +44,11 @@ namespace resources
       template <camp::concepts::ConcreteResource T>
       Resource(T &&value)
       {
-        m_value.reset(new ContextModel<type::ref::rem<T>>(forward<T>(value)));
+        m_value.reset(new ContextModel<camp::decay<T>>(forward<T>(value)));
       }
 
       template <typename T>
-      T* try_get()
+      T *try_get()
       {
         if (!m_value) {
           return nullptr;
@@ -63,7 +61,7 @@ namespace resources
       }
 
       template <typename T>
-      T const* try_get() const
+      T const *try_get() const
       {
         if (!m_value) {
           return nullptr;
@@ -76,9 +74,9 @@ namespace resources
       }
 
       template <typename T>
-      T& get() &
+      T &get() &
       {
-        T* result = try_get<T>();
+        T *result = try_get<T>();
         if (result == nullptr) {
           ::camp::throw_re("Incompatible Resource type get cast.");
         }
@@ -86,9 +84,9 @@ namespace resources
       }
 
       template <typename T>
-      T const& get() const&
+      T const &get() const &
       {
-        T const* result = try_get<T>();
+        T const *result = try_get<T>();
         if (result == nullptr) {
           ::camp::throw_re("Incompatible Resource type get cast.");
         }
@@ -98,7 +96,7 @@ namespace resources
       template <typename T>
       T get() &&
       {
-        T* result = try_get<T>();
+        T *result = try_get<T>();
         if (result == nullptr) {
           ::camp::throw_re("Incompatible Resource type get cast.");
         }
@@ -182,10 +180,10 @@ namespace resources
         return m_value->get_event_erased();
       }
 
-      void wait_for(Event const& e)
+      void wait_for(Event const &e)
       {
         if (!m_value) {
-            e.wait();
+          e.wait();
           return;
         }
         m_value->wait_for(e);
@@ -213,8 +211,7 @@ namespace resources
         if (!lhs.m_value && !rhs.m_value) {
           return true;
         }
-        if ((!lhs.m_value && rhs.m_value) ||
-            (lhs.m_value && !rhs.m_value)) {
+        if ((!lhs.m_value && rhs.m_value) || (lhs.m_value && !rhs.m_value)) {
           return false;
         }
         if (lhs.get_platform() == rhs.get_platform()) {
@@ -223,7 +220,7 @@ namespace resources
         return false;
       }
 
-      template < camp::concepts::ConcreteResource Res >
+      template <camp::concepts::ConcreteResource Res>
       friend inline bool operator==(Resource const &lhs, Res const &rhs)
       {
         if (!lhs.m_value) {
@@ -272,7 +269,7 @@ namespace resources
 
         virtual Event get_event() = 0;
         virtual Event get_event_erased() = 0;
-        virtual void wait_for(Event const& e) = 0;
+        virtual void wait_for(Event const &e) = 0;
         virtual void wait() = 0;
       };
 
@@ -329,13 +326,13 @@ namespace resources
           return m_modelVal.get_event_erased();
         }
 
-        void wait_for(Event const& e) override { m_modelVal.wait_for(e); }
+        void wait_for(Event const &e) override { m_modelVal.wait_for(e); }
 
         void wait() override { m_modelVal.wait(); }
 
-        const T* get() const { return &m_modelVal; }
+        const T *get() const { return &m_modelVal; }
 
-        T* get() { return &m_modelVal; }
+        T *get() { return &m_modelVal; }
 
       private:
         T m_modelVal;
@@ -345,8 +342,7 @@ namespace resources
     };
 
     template <typename Res>
-    struct EventProxy : ::camp::resources::detail::EventProxyBase
-    {
+    struct EventProxy : ::camp::resources::detail::EventProxyBase {
       using native_event = typename Res::event_type;
 
       EventProxy(EventProxy &&) = default;
@@ -357,27 +353,24 @@ namespace resources
       EventProxy(Res r) : resource_{move(r)} {}
 
       native_event get()
-      requires (!std::same_as<native_event, Event>)
+        requires(!std::same_as<native_event, Event>)
       {
         return resource_.get_event();
       }
 
       Event get()
-      requires (std::same_as<native_event, Event>)
+        requires(std::same_as<native_event, Event>)
       {
         return resource_.get_event_erased();
       }
 
       operator native_event()
-      requires (!std::same_as<native_event, Event>)
+        requires(!std::same_as<native_event, Event>)
       {
         return resource_.get_event();
       }
 
-      operator Event()
-      {
-        return resource_.get_event_erased();
-      }
+      operator Event() { return resource_.get_event_erased(); }
 
       Res resource_;
     };
@@ -423,5 +416,7 @@ struct hash<camp::resources::Resource> {
 #if defined(CAMP_HAVE_OMP_OFFLOAD)
 #include "camp/resource/omp_target.hpp"
 #endif
+
+#include "camp/resource/resource_allocator.hpp"
 
 #endif /* __CAMP_RESOURCE_HPP */

--- a/include/camp/resource.hpp
+++ b/include/camp/resource.hpp
@@ -24,6 +24,7 @@
 
 // last to ensure we don't hide breakage in the others
 #include "camp/resource/platform.hpp"
+#include "camp/resource/resource_allocator.hpp"
 
 namespace camp
 {

--- a/include/camp/resource/resource_allocator.hpp
+++ b/include/camp/resource/resource_allocator.hpp
@@ -27,14 +27,9 @@ struct ResourceAllocator
   {
     using value_type = T;
 
-    allocator()
-        : allocator(Resource::get_default(),
-                    camp::resources::MemoryAccess::Pinned)
-    {}
-
-    allocator(Resource res,
+    allocator(Resource res = Resource {},
               camp::resources::MemoryAccess mem_type =
-                  camp::resources::MemoryAccess::Pinned)
+                  camp::resources::MemoryAccess::Device)
         : m_res {res},
           m_mem_type {mem_type}
     {}
@@ -47,7 +42,7 @@ struct ResourceAllocator
 
     template<typename U>
     allocator(allocator<U> const& other) noexcept
-        : m_res(other.get_resource()),
+        : m_res {other.get_resource()},
           m_mem_type {other.get_mem_access()}
     {}
 

--- a/include/camp/resource/resource_allocator.hpp
+++ b/include/camp/resource/resource_allocator.hpp
@@ -10,8 +10,10 @@
 #ifndef __CAMP_RESOURCE_ALLOCATOR_HPP
 #define __CAMP_RESOURCE_ALLOCATOR_HPP
 
+#include <concepts>
 #include <cstddef>
 
+#include "camp/concepts.hpp"
 #include "camp/config.hpp"
 #include "camp/resource/platform.hpp"
 
@@ -19,86 +21,93 @@ namespace camp
 {
 namespace resources
 {
-template<typename Resource>
-struct ResourceAllocator
-{
-  template<typename T>
-  struct allocator
-  {
-    using value_type = T;
+  template <typename Resource>
+  struct ResourceAllocator {
+    template <typename T>
+    struct allocator {
+      using value_type = T;
+      using resource_type = Resource;
 
-    allocator(Resource res = Resource {},
-              camp::resources::MemoryAccess mem_type =
-                  camp::resources::MemoryAccess::Device)
-        : m_res {res},
-          m_mem_type {mem_type}
-    {}
-
-    allocator(allocator const&) = default;
-    allocator(allocator&&)      = default;
-
-    allocator& operator=(allocator const&) = default;
-    allocator& operator=(allocator&&)      = default;
-
-    template<typename U>
-    allocator(allocator<U> const& other) noexcept
-        : m_res {other.get_resource()},
-          m_mem_type {other.get_mem_access()}
-    {}
-
-    [[nodiscard]]
-    value_type* allocate(std::size_t num)
-    {
-      if (num > std::numeric_limits<std::size_t>::max() / sizeof(value_type))
+      allocator(Resource res = Resource{},
+                camp::resources::MemoryAccess mem_type =
+                    camp::resources::MemoryAccess::Device)
+          : m_res{res}, m_mem_type{mem_type}
       {
-        throw std::bad_alloc();
       }
 
-      value_type* ptr = m_res.template allocate<value_type>(num, m_mem_type);
+      allocator(allocator const&) = default;
+      allocator(allocator&&) = default;
 
-      if (!ptr)
+      allocator& operator=(allocator const&) = default;
+      allocator& operator=(allocator&&) = default;
+
+      template <typename OtherAllocator>
+        requires std::convertible_to<typename OtherAllocator::resource_type,
+                                     camp::resources::Resource>
+      allocator(OtherAllocator const& other) noexcept
+          : m_res{other.get_resource()}, m_mem_type{other.get_mem_access()}
       {
-        throw std::bad_alloc();
       }
 
-      return ptr;
-    }
+      [[nodiscard]]
+      value_type* allocate(std::size_t num)
+      {
+        if (num
+            > std::numeric_limits<std::size_t>::max() / sizeof(value_type)) {
+          throw std::bad_alloc();
+        }
 
-    void deallocate(value_type* ptr, std::size_t) noexcept
-    {
-      m_res.deallocate(ptr, m_mem_type);
-    }
+        value_type* ptr = m_res.template allocate<value_type>(num, m_mem_type);
 
-    [[nodiscard]]
-    Resource const& get_resource() const noexcept { return m_res; }
+        if (!ptr) {
+          throw std::bad_alloc();
+        }
 
-    [[nodiscard]]
-    Resource get_resource() noexcept { return m_res; }
+        return ptr;
+      }
 
-    [[nodiscard]]
-    camp::resources::MemoryAccess get_mem_access() const noexcept
-    {
-      return m_mem_type;
-    }
+      void deallocate(value_type* ptr, std::size_t) noexcept
+      {
+        m_res.deallocate(ptr, m_mem_type);
+      }
 
-    template<typename U>
-    friend inline bool operator==(allocator const& lhs, allocator<U> const& rhs)
-    {
-      return lhs.get_resource() == rhs.get_resource() &&
-             lhs.get_mem_access() == rhs.get_mem_access();
-    }
+      [[nodiscard]]
+      Resource const& get_resource() const noexcept
+      {
+        return m_res;
+      }
 
-  private:
-    Resource m_res;
-    camp::resources::MemoryAccess m_mem_type;
+      [[nodiscard]]
+      Resource get_resource() noexcept
+      {
+        return m_res;
+      }
+
+      [[nodiscard]]
+      camp::resources::MemoryAccess get_mem_access() const noexcept
+      {
+        return m_mem_type;
+      }
+
+      template <typename U>
+      friend inline bool operator==(allocator const& lhs,
+                                    allocator<U> const& rhs)
+      {
+        return lhs.get_resource() == rhs.get_resource()
+               && lhs.get_mem_access() == rhs.get_mem_access();
+      }
+
+    private:
+      Resource m_res;
+      camp::resources::MemoryAccess m_mem_type;
+    };
   };
-};
-}  // namespace detail
+}  // namespace resources
 
-template<typename T, typename Resource>
+template <typename T, typename Resource>
 using ResourceAllocator =
     typename resources::ResourceAllocator<Resource>::template allocator<T>;
 
-}  // namespace camp 
+}  // namespace camp
 
 #endif  // __CAMP_RESOURCE_ALLOCATOR_HPP

--- a/include/camp/resource/resource_allocator.hpp
+++ b/include/camp/resource/resource_allocator.hpp
@@ -75,18 +75,22 @@ struct ResourceAllocator
     }
 
     [[nodiscard]]
-    Resource const& get_resource() const { return m_res; }
+    Resource const& get_resource() const noexcept { return m_res; }
 
     [[nodiscard]]
-    Resource get_resource() { return m_res; }
+    Resource get_resource() noexcept { return m_res; }
 
     [[nodiscard]]
-    camp::resources::MemoryAccess get_mem_access() const { return m_mem_type; }
+    camp::resources::MemoryAccess get_mem_access() const noexcept
+    {
+      return m_mem_type;
+    }
 
     template<typename U>
     friend inline bool operator==(allocator const& lhs, allocator<U> const& rhs)
     {
-      return lhs.get_resource() == rhs.get_resource() && lhs.get_mem_access() == rhs.get_mem_access();
+      return lhs.get_resource() == rhs.get_resource() &&
+             lhs.get_mem_access() == rhs.get_mem_access();
     }
 
   private:

--- a/include/camp/resource/resource_allocator.hpp
+++ b/include/camp/resource/resource_allocator.hpp
@@ -13,7 +13,7 @@
 #include <cstddef>
 
 #include "camp/config.hpp"
-#include "camp/resources/platform.hpp"
+#include "camp/resource/platform.hpp"
 
 namespace camp
 {

--- a/include/camp/resource/resource_allocator.hpp
+++ b/include/camp/resource/resource_allocator.hpp
@@ -83,9 +83,6 @@ struct ResourceAllocator
     [[nodiscard]]
     camp::resources::MemoryAccess get_mem_access() const { return m_mem_type; }
 
-    [[nodiscard]]
-    camp::resources::MemoryAccess get_mem_access() { return m_mem_type; }
-
     template<typename U>
     friend inline bool operator==(allocator const& lhs, allocator<U> const& rhs)
     {

--- a/include/camp/resource/resource_allocator.hpp
+++ b/include/camp/resource/resource_allocator.hpp
@@ -1,0 +1,108 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) Lawrence Livermore National Security, LLC and other
+// Camp Project Developers. See top-level LICENSE and COPYRIGHT
+// files for dates and other details. No copyright assignment is required
+// to contribute to Camp.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#ifndef __CAMP_RESOURCE_ALLOCATOR_HPP
+#define __CAMP_RESOURCE_ALLOCATOR_HPP
+
+#include <cstddef>
+
+#include "camp/config.hpp"
+#include "camp/resources/platform.hpp"
+
+namespace camp
+{
+namespace resources
+{
+template<typename Resource>
+struct ResourceAllocator
+{
+  template<typename T>
+  struct allocator
+  {
+    using value_type = T;
+
+    allocator()
+        : allocator(Resource::get_default(),
+                    camp::resources::MemoryAccess::Pinned)
+    {}
+
+    allocator(Resource res,
+              camp::resources::MemoryAccess mem_type =
+                  camp::resources::MemoryAccess::Pinned)
+        : m_res {res},
+          m_mem_type {mem_type}
+    {}
+
+    allocator(allocator const&) = default;
+    allocator(allocator&&)      = default;
+
+    allocator& operator=(allocator const&) = default;
+    allocator& operator=(allocator&&)      = default;
+
+    template<typename U>
+    allocator(allocator<U> const& other) noexcept
+        : m_res(other.get_resource()),
+          m_mem_type {other.get_mem_access()}
+    {}
+
+    [[nodiscard]]
+    value_type* allocate(std::size_t num)
+    {
+      if (num > std::numeric_limits<std::size_t>::max() / sizeof(value_type))
+      {
+        throw std::bad_alloc();
+      }
+
+      value_type* ptr = m_res.template allocate<value_type>(num, m_mem_type);
+
+      if (!ptr)
+      {
+        throw std::bad_alloc();
+      }
+
+      return ptr;
+    }
+
+    void deallocate(value_type* ptr, std::size_t) noexcept
+    {
+      m_res.deallocate(ptr, m_mem_type);
+    }
+
+    [[nodiscard]]
+    Resource const& get_resource() const { return m_res; }
+
+    [[nodiscard]]
+    Resource get_resource() { return m_res; }
+
+    [[nodiscard]]
+    camp::resources::MemoryAccess get_mem_access() const { return m_mem_type; }
+
+    [[nodiscard]]
+    camp::resources::MemoryAccess get_mem_access() { return m_mem_type; }
+
+    template<typename U>
+    friend inline bool operator==(allocator const& lhs, allocator<U> const& rhs)
+    {
+      return lhs.get_resource() == rhs.get_resource() && lhs.get_mem_access() == rhs.get_mem_access();
+    }
+
+  private:
+    Resource m_res;
+    camp::resources::MemoryAccess m_mem_type;
+  };
+};
+}  // namespace detail
+
+template<typename T, typename Resource>
+using ResourceAllocator =
+    typename resources::ResourceAllocator<Resource>::template allocator<T>;
+
+}  // namespace camp 
+
+#endif  // __CAMP_RESOURCE_ALLOCATOR_HPP

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -60,6 +60,7 @@ endfunction()
 camp_add_test(array GTEST)
 camp_add_test(errors GTEST)
 camp_add_test(resource GTEST OFFLOAD)
+camp_add_test(resource_allocator GTEST OFFLOAD)
 camp_add_test(tuple GTEST)
 
 camp_add_test(accumulate)

--- a/test/resource_allocator.cpp
+++ b/test/resource_allocator.cpp
@@ -17,26 +17,6 @@
 
 using namespace camp::resources;
 
-// compatible but different resource for conversion test
-struct Host2 : Host {
-};
-#ifdef CAMP_HAVE_CUDA
-struct Cuda2 : Cuda {
-};
-#endif
-#ifdef CAMP_HAVE_HIP
-struct Hip2 : Hip {
-};
-#endif
-#ifdef CAMP_HAVE_OMP_OFFLOAD
-struct Omp2 : Omp {
-};
-#endif
-#ifdef CAMP_HAVE_SYCL
-struct Sycl2 : Sycl {
-};
-#endif
-
 template <typename Res>
 void test_construct()
 {

--- a/test/resource_allocator.cpp
+++ b/test/resource_allocator.cpp
@@ -1,0 +1,306 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) Lawrence Livermore National Security, LLC and other
+// Camp Project Developers. See top-level LICENSE and COPYRIGHT
+// files for dates and other details. No copyright assignment is required
+// to contribute to Camp.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#include "camp/resource.hpp"
+
+#include <array>
+#include <type_traits>
+
+#include "camp/camp.hpp"
+#include "gtest/gtest.h"
+
+using namespace camp::resources;
+
+// compatible but different resource for conversion test
+struct Host2 : Host {
+};
+#ifdef CAMP_HAVE_CUDA
+struct Cuda2 : Cuda {
+};
+#endif
+#ifdef CAMP_HAVE_HIP
+struct Hip2 : Hip {
+};
+#endif
+#ifdef CAMP_HAVE_OMP_OFFLOAD
+struct Omp2 : Omp {
+};
+#endif
+#ifdef CAMP_HAVE_SYCL
+struct Sycl2 : Sycl {
+};
+#endif
+
+template <typename Res>
+void test_construct()
+{
+  camp::ResourceAllocator<int, Res> alloc1{Res()};
+  camp::ResourceAllocator<int, Res> alloc2{Res(), MemoryAccess::Pinned};
+  camp::ResourceAllocator<int, Res> alloc3{Res(), MemoryAccess::Device};
+  camp::ResourceAllocator<int, Res> alloc4{Res(), MemoryAccess::Managed};
+  CAMP_ALLOW_UNUSED_LOCAL(alloc1);
+  CAMP_ALLOW_UNUSED_LOCAL(alloc2);
+  CAMP_ALLOW_UNUSED_LOCAL(alloc3);
+  CAMP_ALLOW_UNUSED_LOCAL(alloc4);
+}
+
+//
+TEST(CampResourceAllocator, Construct)
+{
+  test_construct<Host>();
+#ifdef CAMP_HAVE_CUDA
+  test_construct<Cuda>();
+#endif
+#ifdef CAMP_HAVE_HIP
+  test_construct<Hip>();
+#endif
+#ifdef CAMP_HAVE_OMP_OFFLOAD
+  test_construct<Omp>();
+#endif
+#ifdef CAMP_HAVE_SYCL
+  test_construct<Sycl>();
+#endif
+}
+
+template <typename Res>
+void test_copy()
+{
+  camp::ResourceAllocator<int, Res> alloc1{Res()};
+  auto alloc2 = alloc1;
+  camp::ResourceAllocator<int, Res> alloc3 = alloc1;
+  CAMP_ALLOW_UNUSED_LOCAL(alloc2);
+  CAMP_ALLOW_UNUSED_LOCAL(alloc3);
+}
+
+//
+TEST(CampResourceAllocator, Copy)
+{
+  test_copy<Host>();
+#ifdef CAMP_HAVE_CUDA
+  test_copy<Cuda>();
+#endif
+#ifdef CAMP_HAVE_HIP
+  test_copy<Hip>();
+#endif
+#ifdef CAMP_HAVE_OMP_OFFLOAD
+  test_copy<Omp>();
+#endif
+#ifdef CAMP_HAVE_SYCL
+  test_copy<Sycl>();
+#endif
+}
+
+template <typename Res>
+void test_copy_assignment()
+{
+  camp::ResourceAllocator<int, Res> src{Res()};
+  camp::ResourceAllocator<int, Res> dst;
+
+  dst = src;
+
+  ASSERT_TRUE(src);
+  ASSERT_TRUE(dst);
+  ASSERT_EQ(src, dst);
+  ASSERT_EQ(src.get_resource(), dst.get_resource());
+  ASSERT_EQ(src.get_mem_access(), dst.get_mem_access());
+}
+
+TEST(CampResourceAllocator, CopyAssignment)
+{
+  test_copy_assignment<Host>();
+#ifdef CAMP_HAVE_CUDA
+  test_copy_assignment<Cuda>();
+#endif
+#ifdef CAMP_HAVE_HIP
+  test_copy_assignment<Hip>();
+#endif
+#ifdef CAMP_HAVE_OMP_OFFLOAD
+  test_copy_assignment<Omp>();
+#endif
+#ifdef CAMP_HAVE_SYCL
+  test_copy_assignment<Sycl>();
+#endif
+}
+
+template <typename Res>
+void test_move_assignment()
+{
+  camp::ResourceAllocator<int, Res> src{Res()};
+  camp::ResourceAllocator<int, Res> dst;
+
+  dst = std::move(src);
+
+  ASSERT_FALSE(src);
+  ASSERT_TRUE(dst);
+}
+
+TEST(CampResourceAllocator, MoveAssignment)
+{
+  test_move_assignment<Host>();
+#ifdef CAMP_HAVE_CUDA
+  test_move_assignment<Cuda>();
+#endif
+#ifdef CAMP_HAVE_HIP
+  test_move_assignment<Hip>();
+#endif
+#ifdef CAMP_HAVE_OMP_OFFLOAD
+  test_move_assignment<Omp>();
+#endif
+#ifdef CAMP_HAVE_SYCL
+  test_move_assignment<Sycl>();
+#endif
+}
+
+template <typename Res>
+void test_get_resource(Res res)
+{
+  camp::ResourceAllocator<int, Res> alloc1{res};
+
+  ASSERT_EQ(alloc1.get_resource(), res);
+}
+
+TEST(CampResourceAllocator, GetResource)
+{
+  test_get_resource(Host{});
+#ifdef CAMP_HAVE_CUDA
+  test_get_resource(Cuda{});
+#endif
+#ifdef CAMP_HAVE_HIP
+  test_get_resource(Hip{});
+#endif
+#ifdef CAMP_HAVE_OMP_OFFLOAD
+  test_get_resource(Omp{});
+#endif
+#ifdef CAMP_HAVE_SYCL
+  test_get_resource(Sycl{});
+#endif
+}
+
+template <typename Res>
+void test_get_mem_access()
+{
+  camp::ResourceAllocator<int, Res> alloc1{Res(), MemoryAccess::Pinned};
+  camp::ResourceAllocator<int, Res> alloc2{Res(), MemoryAccess::Device};
+  camp::ResourceAllocator<int, Res> alloc3{Res(), MemoryAccess::Managed};
+
+  ASSERT_EQ(alloc1.get_mem_access(), alloc1.get_mem_access());
+  ASSERT_NE(alloc1.get_mem_access(), alloc2.get_mem_access());
+  ASSERT_NE(alloc1.get_mem_access(), alloc3.get_mem_access());
+
+  ASSERT_EQ(alloc2.get_mem_access(), alloc2.get_mem_access());
+  ASSERT_NE(alloc2.get_mem_access(), alloc3.get_mem_access());
+
+  ASSERT_EQ(alloc3.get_mem_access(), alloc3.get_mem_access());
+}
+
+TEST(CampResourceAllocator, GetMemAccess)
+{
+  test_get_mem_access<Host>();
+#ifdef CAMP_HAVE_CUDA
+  test_get_mem_access<Cuda>();
+#endif
+#ifdef CAMP_HAVE_HIP
+  test_get_mem_access<Hip>();
+#endif
+#ifdef CAMP_HAVE_OMP_OFFLOAD
+  test_get_mem_access<Omp>();
+#endif
+#ifdef CAMP_HAVE_SYCL
+  test_get_mem_access<Sycl>();
+#endif
+}
+
+template <typename Res>
+void test_compare()
+{
+  camp::ResourceAllocator<int, Res> alloc1{Res(), MemoryAccess::Pinned};
+  camp::ResourceAllocator<int, Res> alloc2{Res(), MemoryAccess::Device};
+  camp::ResourceAllocator<int, Res> alloc3{Res(), MemoryAccess::Managed};
+
+  ASSERT_EQ(alloc1, alloc1);
+  ASSERT_NE(alloc1, alloc2);
+  ASSERT_NE(alloc1, alloc3);
+}
+
+//
+TEST(CampResourceAllocator, Compare) 
+{
+  test_compare<Host>();
+#ifdef CAMP_HAVE_CUDA
+  test_compare<Cuda>();
+#endif
+#ifdef CAMP_HAVE_HIP
+  test_compare<Hip>();
+#endif
+#ifdef CAMP_HAVE_OMP_OFFLOAD
+  test_compare<Omp>();
+#endif
+#ifdef CAMP_HAVE_SYCL
+  test_compare<Sycl>();
+#endif
+}
+
+template <typename Res>
+void test_rebind()
+{
+  camp::ResourceAllocator<int, Res> alloc1{Res()};
+  camp::ResourceAllocator<double, Res> alloc2{alloc1};
+
+  ASSERT_EQ(alloc1, alloc2);
+  ASSERT_EQ(alloc1.get_resource(), alloc2.get_resource());
+  ASSERT_EQ(alloc1.get_mem_access(), alloc2.get_mem_access());
+}
+
+//
+TEST(CampResourceAllocator, Rebind)
+{
+  test_rebind<Host>();
+#ifdef CAMP_HAVE_CUDA
+  test_rebind<Cuda>();
+#endif
+#ifdef CAMP_HAVE_HIP
+  test_rebind<Hip>();
+#endif
+#ifdef CAMP_HAVE_OMP_OFFLOAD
+  test_rebind<Omp>();
+#endif
+#ifdef CAMP_HAVE_SYCL
+  test_rebind<Sycl>();
+#endif
+}
+
+template <typename Res>
+void test_allocate()
+{
+  camp::ResourceAllocator<int, Res> alloc1{Res()};
+
+  int* ptr = alloc1.allocate(5);
+
+  EXPECT_TRUE(ptr != nullptr);
+
+  alloc1.deallocate(ptr);
+}
+
+//
+TEST(CampResourceAllocator, Allocate)
+{
+  test_allocate<Host>();
+#ifdef CAMP_HAVE_CUDA
+  test_allocate<Cuda>();
+#endif
+#ifdef CAMP_HAVE_HIP
+  test_allocate<Hip>();
+#endif
+#ifdef CAMP_HAVE_OMP_OFFLOAD
+  test_allocate<Omp>();
+#endif
+#ifdef CAMP_HAVE_SYCL
+  test_allocate<Sycl>();
+#endif
+}

--- a/test/resource_allocator.cpp
+++ b/test/resource_allocator.cpp
@@ -9,8 +9,8 @@
 
 #include "camp/resource.hpp"
 
-#include <array>
-#include <type_traits>
+#include <numeric>
+#include <vector>
 
 #include "camp/camp.hpp"
 #include "gtest/gtest.h"
@@ -268,6 +268,41 @@ void test_allocate()
 
 //
 TEST(CampResourceAllocator, Allocate)
+{
+  test_allocate<Host>();
+#ifdef CAMP_HAVE_CUDA
+  test_allocate<Cuda>();
+#endif
+#ifdef CAMP_HAVE_HIP
+  test_allocate<Hip>();
+#endif
+#ifdef CAMP_HAVE_OMP_OFFLOAD
+  test_allocate<Omp>();
+#endif
+#ifdef CAMP_HAVE_SYCL
+  test_allocate<Sycl>();
+#endif
+}
+
+template <typename Res>
+void test_vector()
+{
+  static constexpr std::size_t num = 5;
+  camp::ResourceAllocator<int, Res> alloc{Res(), MemoryAccess::Pinned};
+
+  std::vector vec(num, alloc);
+  std::iota(vec.begin(), vec.end(), num);
+
+  EXPECT_TRUE(vec.data() != nullptr);
+  EXPECT_TRUE(vec.size() == num);
+
+  for (std::size_t i = 0; i < vec.size(); ++i) {
+    EXPECT_TRUE(vec[i] == static_cast<int>(i));
+  }
+}
+
+//
+TEST(CampResourceAllocator, Vector)
 {
   test_allocate<Host>();
 #ifdef CAMP_HAVE_CUDA

--- a/test/resource_allocator.cpp
+++ b/test/resource_allocator.cpp
@@ -7,12 +7,11 @@
 // SPDX-License-Identifier: (BSD-3-Clause)
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 
-#include "camp/resource.hpp"
-
 #include <numeric>
 #include <vector>
 
 #include "camp/camp.hpp"
+#include "camp/resource.hpp"
 #include "gtest/gtest.h"
 
 using namespace camp::resources;
@@ -293,7 +292,7 @@ void test_compare()
 }
 
 //
-TEST(CampResourceAllocator, Compare) 
+TEST(CampResourceAllocator, Compare)
 {
   test_compare<Host>();
 #ifdef CAMP_HAVE_CUDA
@@ -328,6 +327,13 @@ void test_rebind()
   ASSERT_EQ(alloc3, alloc4);
   ASSERT_EQ(alloc3.get_resource(), alloc4.get_resource());
   ASSERT_EQ(alloc3.get_mem_access(), alloc4.get_mem_access());
+
+  camp::ResourceAllocator<int, Resource> alloc5{alloc1};
+  camp::ResourceAllocator<double, Resource> alloc6{alloc2};
+
+  ASSERT_EQ(alloc5, alloc6);
+  ASSERT_EQ(alloc5.get_resource(), alloc6.get_resource());
+  ASSERT_EQ(alloc5.get_mem_access(), alloc6.get_mem_access());
 }
 
 //
@@ -414,7 +420,7 @@ void test_vector()
   // Move ctor
   auto vec3 = std::move(vec2);
   check_vec(vec3);
-  
+
   // Move assignment
   vec2 = std::move(vec3);
   check_vec(vec2);
@@ -434,7 +440,7 @@ void test_vector()
   // Move ctor
   auto vec6 = std::move(vec5);
   check_vec(vec6);
-  
+
   // Move assignment
   vec5 = std::move(vec6);
   check_vec(vec5);

--- a/test/resource_allocator.cpp
+++ b/test/resource_allocator.cpp
@@ -218,13 +218,16 @@ void test_get_mem_access()
   camp::ResourceAllocator<int, Res> alloc2{Res(), MemoryAccess::Device};
   camp::ResourceAllocator<int, Res> alloc3{Res(), MemoryAccess::Managed};
 
+  ASSERT_EQ(alloc1.get_mem_access(), MemoryAccess::Pinned);
   ASSERT_EQ(alloc1.get_mem_access(), alloc1.get_mem_access());
   ASSERT_NE(alloc1.get_mem_access(), alloc2.get_mem_access());
   ASSERT_NE(alloc1.get_mem_access(), alloc3.get_mem_access());
 
+  ASSERT_EQ(alloc2.get_mem_access(), MemoryAccess::Device);
   ASSERT_EQ(alloc2.get_mem_access(), alloc2.get_mem_access());
   ASSERT_NE(alloc2.get_mem_access(), alloc3.get_mem_access());
 
+  ASSERT_EQ(alloc3.get_mem_access(), MemoryAccess::Managed);
   ASSERT_EQ(alloc3.get_mem_access(), alloc3.get_mem_access());
 
   // Generic resource
@@ -232,13 +235,16 @@ void test_get_mem_access()
   camp::ResourceAllocator<int, Resource> alloc5{Res(), MemoryAccess::Device};
   camp::ResourceAllocator<int, Resource> alloc6{Res(), MemoryAccess::Managed};
 
+  ASSERT_EQ(alloc4.get_mem_access(), MemoryAccess::Pinned);
   ASSERT_EQ(alloc4.get_mem_access(), alloc4.get_mem_access());
   ASSERT_NE(alloc4.get_mem_access(), alloc5.get_mem_access());
   ASSERT_NE(alloc4.get_mem_access(), alloc6.get_mem_access());
 
+  ASSERT_EQ(alloc5.get_mem_access(), MemoryAccess::Device);
   ASSERT_EQ(alloc5.get_mem_access(), alloc5.get_mem_access());
   ASSERT_NE(alloc5.get_mem_access(), alloc6.get_mem_access());
 
+  ASSERT_EQ(alloc6.get_mem_access(), MemoryAccess::Managed);
   ASSERT_EQ(alloc6.get_mem_access(), alloc6.get_mem_access());
 }
 

--- a/test/resource_allocator.cpp
+++ b/test/resource_allocator.cpp
@@ -402,7 +402,7 @@ void test_vector()
 
   camp::ResourceAllocator<int, Res> alloc1{Res(), MemoryAccess::Pinned};
 
-  std::vector vec1(num, alloc1);
+  std::vector<int, camp::ResourceAllocator<int, Res>> vec1(num, alloc1);
   std::iota(vec1.begin(), vec1.end(), num);
   check_vec(vec1);
 
@@ -422,7 +422,7 @@ void test_vector()
   // Generic resource
   camp::ResourceAllocator<int, Resource> alloc2{Res(), MemoryAccess::Pinned};
 
-  std::vector vec4(num, alloc2);
+  std::vector<int, camp::ResourceAllocator<int, Resource>> vec4(num, alloc2);
   std::iota(vec4.begin(), vec4.end(), num);
   check_vec(vec4);
 

--- a/test/resource_allocator.cpp
+++ b/test/resource_allocator.cpp
@@ -136,8 +136,11 @@ template <typename Res>
 void test_get_resource(Res res)
 {
   camp::ResourceAllocator<int, Res> alloc1{res};
+  const camp::ResourceAllocator<int, Res> const_alloc1{res};
 
   ASSERT_EQ(alloc1.get_resource(), res);
+  ASSERT_EQ(const_alloc1.get_resource(), res);
+  ASSERT_EQ(alloc1.get_resource(), const_alloc1.get_resource());
 }
 
 TEST(CampResourceAllocator, GetResource)

--- a/test/resource_allocator.cpp
+++ b/test/resource_allocator.cpp
@@ -20,14 +20,27 @@ using namespace camp::resources;
 template <typename Res>
 void test_construct()
 {
+  // Specific resource
   camp::ResourceAllocator<int, Res> alloc1{Res()};
   camp::ResourceAllocator<int, Res> alloc2{Res(), MemoryAccess::Pinned};
   camp::ResourceAllocator<int, Res> alloc3{Res(), MemoryAccess::Device};
   camp::ResourceAllocator<int, Res> alloc4{Res(), MemoryAccess::Managed};
+
   CAMP_ALLOW_UNUSED_LOCAL(alloc1);
   CAMP_ALLOW_UNUSED_LOCAL(alloc2);
   CAMP_ALLOW_UNUSED_LOCAL(alloc3);
   CAMP_ALLOW_UNUSED_LOCAL(alloc4);
+
+  // Generic resource
+  camp::ResourceAllocator<int, Resource> alloc5{Res()};
+  camp::ResourceAllocator<int, Resource> alloc6{Res(), MemoryAccess::Pinned};
+  camp::ResourceAllocator<int, Resource> alloc7{Res(), MemoryAccess::Device};
+  camp::ResourceAllocator<int, Resource> alloc8{Res(), MemoryAccess::Managed};
+
+  CAMP_ALLOW_UNUSED_LOCAL(alloc5);
+  CAMP_ALLOW_UNUSED_LOCAL(alloc6);
+  CAMP_ALLOW_UNUSED_LOCAL(alloc7);
+  CAMP_ALLOW_UNUSED_LOCAL(alloc8);
 }
 
 //
@@ -51,11 +64,19 @@ TEST(CampResourceAllocator, Construct)
 template <typename Res>
 void test_copy()
 {
+  // Specific resource
   camp::ResourceAllocator<int, Res> alloc1{Res()};
   auto alloc2 = alloc1;
   camp::ResourceAllocator<int, Res> alloc3 = alloc1;
   CAMP_ALLOW_UNUSED_LOCAL(alloc2);
   CAMP_ALLOW_UNUSED_LOCAL(alloc3);
+
+  // Generic resource
+  camp::ResourceAllocator<int, Resource> alloc4{Res()};
+  auto alloc5 = alloc4;
+  camp::ResourceAllocator<int, Resource> alloc6 = alloc4;
+  CAMP_ALLOW_UNUSED_LOCAL(alloc5);
+  CAMP_ALLOW_UNUSED_LOCAL(alloc6);
 }
 
 //
@@ -79,6 +100,7 @@ TEST(CampResourceAllocator, Copy)
 template <typename Res>
 void test_copy_assignment()
 {
+  // Specific resource
   camp::ResourceAllocator<int, Res> src{Res()};
   camp::ResourceAllocator<int, Res> dst;
 
@@ -87,6 +109,16 @@ void test_copy_assignment()
   ASSERT_EQ(src, dst);
   ASSERT_EQ(src.get_resource(), dst.get_resource());
   ASSERT_EQ(src.get_mem_access(), dst.get_mem_access());
+
+  // Generic resource
+  camp::ResourceAllocator<int, Resource> src1{Res()};
+  camp::ResourceAllocator<int, Resource> dst1;
+
+  dst1 = src1;
+
+  ASSERT_EQ(src1, dst1);
+  ASSERT_EQ(src1.get_resource(), dst1.get_resource());
+  ASSERT_EQ(src1.get_mem_access(), dst1.get_mem_access());
 }
 
 TEST(CampResourceAllocator, CopyAssignment)
@@ -109,10 +141,17 @@ TEST(CampResourceAllocator, CopyAssignment)
 template <typename Res>
 void test_move_assignment()
 {
+  // Specific resource
   camp::ResourceAllocator<int, Res> src{Res()};
   camp::ResourceAllocator<int, Res> dst;
 
   dst = std::move(src);
+
+  // Generic resource
+  camp::ResourceAllocator<int, Resource> src1{Res()};
+  camp::ResourceAllocator<int, Resource> dst1;
+
+  dst1 = std::move(src1);
 }
 
 TEST(CampResourceAllocator, MoveAssignment)
@@ -135,12 +174,24 @@ TEST(CampResourceAllocator, MoveAssignment)
 template <typename Res>
 void test_get_resource(Res res)
 {
+  // Specific
   camp::ResourceAllocator<int, Res> alloc1{res};
   const camp::ResourceAllocator<int, Res> const_alloc1{res};
 
   ASSERT_EQ(alloc1.get_resource(), res);
   ASSERT_EQ(const_alloc1.get_resource(), res);
   ASSERT_EQ(alloc1.get_resource(), const_alloc1.get_resource());
+
+  // Generic resource
+  camp::ResourceAllocator<int, Resource> alloc2{res};
+  const camp::ResourceAllocator<int, Resource> const_alloc2{res};
+
+  ASSERT_EQ(alloc2.get_resource(), res);
+  ASSERT_EQ(const_alloc2.get_resource(), res);
+  ASSERT_EQ(alloc2.get_resource(), const_alloc2.get_resource());
+
+  ASSERT_EQ(alloc1.get_resource(), alloc2.get_resource());
+  ASSERT_EQ(const_alloc1.get_resource(), const_alloc2.get_resource());
 }
 
 TEST(CampResourceAllocator, GetResource)
@@ -163,6 +214,7 @@ TEST(CampResourceAllocator, GetResource)
 template <typename Res>
 void test_get_mem_access()
 {
+  // Specific resource
   camp::ResourceAllocator<int, Res> alloc1{Res(), MemoryAccess::Pinned};
   camp::ResourceAllocator<int, Res> alloc2{Res(), MemoryAccess::Device};
   camp::ResourceAllocator<int, Res> alloc3{Res(), MemoryAccess::Managed};
@@ -175,6 +227,20 @@ void test_get_mem_access()
   ASSERT_NE(alloc2.get_mem_access(), alloc3.get_mem_access());
 
   ASSERT_EQ(alloc3.get_mem_access(), alloc3.get_mem_access());
+
+  // Generic resource
+  camp::ResourceAllocator<int, Resource> alloc4{Res(), MemoryAccess::Pinned};
+  camp::ResourceAllocator<int, Resource> alloc5{Res(), MemoryAccess::Device};
+  camp::ResourceAllocator<int, Resource> alloc6{Res(), MemoryAccess::Managed};
+
+  ASSERT_EQ(alloc4.get_mem_access(), alloc4.get_mem_access());
+  ASSERT_NE(alloc4.get_mem_access(), alloc5.get_mem_access());
+  ASSERT_NE(alloc4.get_mem_access(), alloc6.get_mem_access());
+
+  ASSERT_EQ(alloc5.get_mem_access(), alloc5.get_mem_access());
+  ASSERT_NE(alloc5.get_mem_access(), alloc6.get_mem_access());
+
+  ASSERT_EQ(alloc6.get_mem_access(), alloc6.get_mem_access());
 }
 
 TEST(CampResourceAllocator, GetMemAccess)
@@ -197,6 +263,7 @@ TEST(CampResourceAllocator, GetMemAccess)
 template <typename Res>
 void test_compare()
 {
+  // Specific resource
   camp::ResourceAllocator<int, Res> alloc1{Res(), MemoryAccess::Pinned};
   camp::ResourceAllocator<int, Res> alloc2{Res(), MemoryAccess::Device};
   camp::ResourceAllocator<int, Res> alloc3{Res(), MemoryAccess::Managed};
@@ -204,6 +271,15 @@ void test_compare()
   ASSERT_EQ(alloc1, alloc1);
   ASSERT_NE(alloc1, alloc2);
   ASSERT_NE(alloc1, alloc3);
+
+  // Generic resource
+  camp::ResourceAllocator<int, Resrouce> alloc4{Res(), MemoryAccess::Pinned};
+  camp::ResourceAllocator<int, Resource> alloc5{Res(), MemoryAccess::Device};
+  camp::ResourceAllocator<int, Resource> alloc6{Res(), MemoryAccess::Managed};
+
+  ASSERT_EQ(alloc4, alloc4);
+  ASSERT_NE(alloc4, alloc5);
+  ASSERT_NE(alloc4, alloc6);
 }
 
 //
@@ -227,12 +303,21 @@ TEST(CampResourceAllocator, Compare)
 template <typename Res>
 void test_rebind()
 {
+  // Specific resource
   camp::ResourceAllocator<int, Res> alloc1{Res()};
   camp::ResourceAllocator<double, Res> alloc2{alloc1};
 
   ASSERT_EQ(alloc1, alloc2);
   ASSERT_EQ(alloc1.get_resource(), alloc2.get_resource());
   ASSERT_EQ(alloc1.get_mem_access(), alloc2.get_mem_access());
+
+  // Generic resource
+  camp::ResourceAllocator<int, Resource> alloc3{Res()};
+  camp::ResourceAllocator<double, Resource> alloc4{alloc3};
+
+  ASSERT_EQ(alloc3, alloc4);
+  ASSERT_EQ(alloc3.get_resource(), alloc4.get_resource());
+  ASSERT_EQ(alloc3.get_mem_access(), alloc4.get_mem_access());
 }
 
 //
@@ -257,13 +342,20 @@ template <typename Res>
 void test_allocate()
 {
   static constexpr std::size_t num = 5;
+
+  // Specific resource
   camp::ResourceAllocator<int, Res> alloc1{Res()};
 
   int* ptr = alloc1.allocate(num);
-
   EXPECT_TRUE(ptr != nullptr);
-
   alloc1.deallocate(ptr, num);
+
+  // Generic resource
+  camp::ResourceAllocator<int, Resource> alloc2{Res()};
+
+  int* ptr = alloc2.allocate(num);
+  EXPECT_TRUE(ptr != nullptr);
+  alloc2.deallocate(ptr, num);
 }
 
 //
@@ -288,17 +380,54 @@ template <typename Res>
 void test_vector()
 {
   static constexpr std::size_t num = 5;
+
+  auto check_vec = [=](const auto& vec) {
+    EXPECT_TRUE(vec.data() != nullptr);
+    EXPECT_TRUE(vec.size() == num);
+
+    for (std::size_t i = 0; i < vec.size(); ++i) {
+      EXPECT_TRUE(vec[i] == static_cast<int>(i));
+    }
+  });
+
   camp::ResourceAllocator<int, Res> alloc{Res(), MemoryAccess::Pinned};
 
-  std::vector vec(num, alloc);
-  std::iota(vec.begin(), vec.end(), num);
+  std::vector vec1(num, alloc);
+  std::iota(vec1.begin(), vec1.end(), num);
+  check_vec(vec1);
 
-  EXPECT_TRUE(vec.data() != nullptr);
-  EXPECT_TRUE(vec.size() == num);
+  // Copy ctor
+  auto vec2 = vec1;
+  check_vec(vec1);
+  check_vec(vec2);
 
-  for (std::size_t i = 0; i < vec.size(); ++i) {
-    EXPECT_TRUE(vec[i] == static_cast<int>(i));
-  }
+  // Move ctor
+  auto vec3 = std::move(vec2);
+  check_vec(vec3);
+  
+  // Move assignment
+  vec2 = std::move(vec3);
+  check_vec(vec2);
+
+  // Generic resource
+  camp::ResourceAllocator<int, Resource> alloc{Res(), MemoryAccess::Pinned};
+
+  std::vector vec4(num, alloc);
+  std::iota(vec4.begin(), vec4.end(), num);
+  check_vec(vec4);
+
+  // Copy ctor
+  auto vec5 = vec4;
+  check_vec(vec4);
+  check_vec(vec5);
+
+  // Move ctor
+  auto vec6 = std::move(vec5);
+  check_vec(vec6);
+  
+  // Move assignment
+  vec5 = std::move(vec6);
+  check_vec(vec5);
 }
 
 //

--- a/test/resource_allocator.cpp
+++ b/test/resource_allocator.cpp
@@ -84,8 +84,6 @@ void test_copy_assignment()
 
   dst = src;
 
-  ASSERT_TRUE(src);
-  ASSERT_TRUE(dst);
   ASSERT_EQ(src, dst);
   ASSERT_EQ(src.get_resource(), dst.get_resource());
   ASSERT_EQ(src.get_mem_access(), dst.get_mem_access());
@@ -115,9 +113,6 @@ void test_move_assignment()
   camp::ResourceAllocator<int, Res> dst;
 
   dst = std::move(src);
-
-  ASSERT_FALSE(src);
-  ASSERT_TRUE(dst);
 }
 
 TEST(CampResourceAllocator, MoveAssignment)
@@ -258,13 +253,14 @@ TEST(CampResourceAllocator, Rebind)
 template <typename Res>
 void test_allocate()
 {
+  static constexpr std::size_t num = 5;
   camp::ResourceAllocator<int, Res> alloc1{Res()};
 
-  int* ptr = alloc1.allocate(5);
+  int* ptr = alloc1.allocate(num);
 
   EXPECT_TRUE(ptr != nullptr);
 
-  alloc1.deallocate(ptr);
+  alloc1.deallocate(ptr, num);
 }
 
 //

--- a/test/resource_allocator.cpp
+++ b/test/resource_allocator.cpp
@@ -272,14 +272,24 @@ void test_compare()
   ASSERT_NE(alloc1, alloc2);
   ASSERT_NE(alloc1, alloc3);
 
+  ASSERT_EQ(alloc2, alloc2);
+  ASSERT_NE(alloc2, alloc3);
+
+  ASSERT_EQ(alloc3, alloc3);
+
   // Generic resource
-  camp::ResourceAllocator<int, Resrouce> alloc4{Res(), MemoryAccess::Pinned};
+  camp::ResourceAllocator<int, Resource> alloc4{Res(), MemoryAccess::Pinned};
   camp::ResourceAllocator<int, Resource> alloc5{Res(), MemoryAccess::Device};
   camp::ResourceAllocator<int, Resource> alloc6{Res(), MemoryAccess::Managed};
 
   ASSERT_EQ(alloc4, alloc4);
   ASSERT_NE(alloc4, alloc5);
   ASSERT_NE(alloc4, alloc6);
+
+  ASSERT_EQ(alloc5, alloc5);
+  ASSERT_NE(alloc5, alloc6);
+
+  ASSERT_EQ(alloc6, alloc6);
 }
 
 //
@@ -346,16 +356,16 @@ void test_allocate()
   // Specific resource
   camp::ResourceAllocator<int, Res> alloc1{Res()};
 
-  int* ptr = alloc1.allocate(num);
-  EXPECT_TRUE(ptr != nullptr);
-  alloc1.deallocate(ptr, num);
+  int* ptr1 = alloc1.allocate(num);
+  EXPECT_TRUE(ptr1 != nullptr);
+  alloc1.deallocate(ptr1, num);
 
   // Generic resource
   camp::ResourceAllocator<int, Resource> alloc2{Res()};
 
-  int* ptr = alloc2.allocate(num);
-  EXPECT_TRUE(ptr != nullptr);
-  alloc2.deallocate(ptr, num);
+  int* ptr2 = alloc2.allocate(num);
+  EXPECT_TRUE(ptr2 != nullptr);
+  alloc2.deallocate(ptr2, num);
 }
 
 //
@@ -388,11 +398,11 @@ void test_vector()
     for (std::size_t i = 0; i < vec.size(); ++i) {
       EXPECT_TRUE(vec[i] == static_cast<int>(i));
     }
-  });
+  };
 
-  camp::ResourceAllocator<int, Res> alloc{Res(), MemoryAccess::Pinned};
+  camp::ResourceAllocator<int, Res> alloc1{Res(), MemoryAccess::Pinned};
 
-  std::vector vec1(num, alloc);
+  std::vector vec1(num, alloc1);
   std::iota(vec1.begin(), vec1.end(), num);
   check_vec(vec1);
 
@@ -410,9 +420,9 @@ void test_vector()
   check_vec(vec2);
 
   // Generic resource
-  camp::ResourceAllocator<int, Resource> alloc{Res(), MemoryAccess::Pinned};
+  camp::ResourceAllocator<int, Resource> alloc2{Res(), MemoryAccess::Pinned};
 
-  std::vector vec4(num, alloc);
+  std::vector vec4(num, alloc2);
   std::iota(vec4.begin(), vec4.end(), num);
   check_vec(vec4);
 


### PR DESCRIPTION
Moves the resource allocator implementation from https://github.com/llnl/RAJA/pull/1832 to camp. The goal of this is to support a C++ `std::allocator`-like allocator for resources.