### PR TITLE
Format code with clang format

### DIFF
--- a/include/camp/concepts.hpp
+++ b/include/camp/concepts.hpp
@@ -256,7 +256,7 @@ namespace concepts
         {arg - increment} -> std::same_as<T>;
         // random access index operator
         arg[increment];
-  };
+    };
 
   template <typename T>
   concept HasBeginEnd = std::ranges::range<T>;

--- a/include/camp/concepts.hpp
+++ b/include/camp/concepts.hpp
@@ -136,7 +136,7 @@ namespace concepts
 
 
     template <typename Ret, typename T>
-    Ret returns(T const&) noexcept;
+    Ret returns(T const &) noexcept;
 
   }  // end namespace detail
 
@@ -146,13 +146,13 @@ namespace concepts
   /// metafunction for use within decltype expression to validate return type is
   /// convertible to given type
   template <typename T, typename U>
-  constexpr auto convertible_to(U&& u) noexcept
-      -> decltype(detail::returns<camp::true_type>(static_cast<T>((U&&)u)));
+  constexpr auto convertible_to(U &&u) noexcept
+      -> decltype(detail::returns<camp::true_type>(static_cast<T>((U &&)u)));
 
   /// metafunction for use within decltype expression to validate type of
   /// expression
   template <typename T, typename U>
-  constexpr auto has_type(U&&) noexcept -> metalib::is_same<T, U>;
+  constexpr auto has_type(U &&) noexcept -> metalib::is_same<T, U>;
 
   template <typename BoolLike>
   constexpr auto is(BoolLike) noexcept
@@ -189,99 +189,87 @@ namespace concepts
   struct requires_ : detail::detected<Op, detail::TL<Args...>> {
   };
 
-  DefineConceptFromSTL(Swappable, std::swappable<T>) DefineConceptRequires(
-      LessThanComparable, {arg < arg}->std::convertible_to<bool>;)
-      DefineConceptRequires(GreaterThanComparable,
-                            {arg > arg}->std::convertible_to<bool>;)
-          DefineConceptRequires(LessEqualComparable,
-                                {arg <= arg}->std::convertible_to<bool>;)
-              DefineConceptRequires(GreaterEqualComparable,
-                                    {arg >= arg}->std::convertible_to<bool>;)
-                  DefineConceptRequires(
-                      EqualityComparable,
-                      {arg == arg}->std::convertible_to<bool>;)
+  // clang-format off
 
-                      template <typename T, typename U>
-                      concept ComparableTo = requires(T lhs, U rhs) {
-                        { lhs < rhs } -> std::convertible_to<bool>;
-                        { rhs < lhs } -> std::convertible_to<bool>;
-                        { lhs <= rhs } -> std::convertible_to<bool>;
-                        { rhs <= lhs } -> std::convertible_to<bool>;
-                        { lhs > rhs } -> std::convertible_to<bool>;
-                        { rhs > lhs } -> std::convertible_to<bool>;
-                        { lhs >= rhs } -> std::convertible_to<bool>;
-                        { rhs >= lhs } -> std::convertible_to<bool>;
-                        { lhs == rhs } -> std::convertible_to<bool>;
-                        { rhs == lhs } -> std::convertible_to<bool>;
-                        { lhs != rhs } -> std::convertible_to<bool>;
-                        { rhs != lhs } -> std::convertible_to<bool>;
-                      };
+  DefineConceptFromSTL(Swappable, std::swappable<T>)
+  DefineConceptRequires(LessThanComparable, {arg < arg} -> std::convertible_to<bool>; )
+  DefineConceptRequires(GreaterThanComparable, {arg > arg} -> std::convertible_to<bool>; )
+  DefineConceptRequires(LessEqualComparable,  {arg <= arg} -> std::convertible_to<bool>; )
+  DefineConceptRequires(GreaterEqualComparable,  {arg >= arg} -> std::convertible_to<bool>; )
+  DefineConceptRequires(EqualityComparable,  {arg == arg} -> std::convertible_to<bool>; )
+
+  template <typename T, typename U>
+  concept ComparableTo = requires(T lhs, U rhs) {
+    { lhs < rhs } -> std::convertible_to<bool>;
+    { rhs < lhs } -> std::convertible_to<bool>;
+    { lhs <= rhs } -> std::convertible_to<bool>;
+    { rhs <= lhs } -> std::convertible_to<bool>;
+    { lhs > rhs } -> std::convertible_to<bool>;
+    { rhs > lhs } -> std::convertible_to<bool>;
+    { lhs >= rhs } -> std::convertible_to<bool>;
+    { rhs >= lhs } -> std::convertible_to<bool>;
+    { lhs == rhs } -> std::convertible_to<bool>;
+    { rhs == lhs } -> std::convertible_to<bool>;
+    { lhs != rhs } -> std::convertible_to<bool>;
+    { rhs != lhs } -> std::convertible_to<bool>;
+  };
 
   template <typename T>
   concept Comparable = ComparableTo<T, T>;
 
   DefineConceptFromSTL(FloatingPoint, std::floating_point<T>)
-      DefineConceptFromSTL(Integral, std::integral<T>)
-          DefineConceptFromSTL(Arithmetic, std::is_arithmetic_v<T>)
-              DefineConceptFromSTL(Signed, std::signed_integral<T>)
-                  DefineConceptFromSTL(Unsigned, std::unsigned_integral<T>)
+  DefineConceptFromSTL(Integral, std::integral<T>)
+  DefineConceptFromSTL(Arithmetic, std::is_arithmetic_v<T>)
+  DefineConceptFromSTL(Signed, std::signed_integral<T>)
+  DefineConceptFromSTL(Unsigned, std::unsigned_integral<T>)
 
-      // Note: std::weakly_incrementable is the closest C++ concept to Iterator,
-      // but differs in two important ways.  (1) std::weakly_incrementable
-      // requires and iterator be post-incrementable (arg_ref++) (2)
-      // std::weakly_incrementable does not requires not Integral
-      DefineConceptBinaryAnd(
-          Iterator,
-          !Integral<T>,
-          requires(T arg, T& arg_ref) {
-            *arg;
-            { ++arg_ref } -> std::same_as<T&>;
-          })
-          DefineConceptBinaryAnd(
-              ForwardIterator,
-              Iterator<T>,
-              requires(T& arg) {
-                arg++;
-                *arg++;
-              })
+  // Note: std::weakly_incrementable is the closest C++ concept to Iterator, but differs
+  // in two important ways.  (1) std::weakly_incrementable requires and iterator be
+  // post-incrementable (arg_ref++) (2) std::weakly_incrementable does not requires
+  // not Integral
+  DefineConceptBinaryAnd(Iterator, !Integral<T>, requires(T arg, T& arg_ref) {
+    *arg;
+    { ++arg_ref } -> std::same_as<T&>;
+  })
+  DefineConceptBinaryAnd(ForwardIterator, Iterator<T>, requires(T& arg) {
+    arg++;
+    *arg++;
+  })
 
-              DefineConceptBinaryAnd(
-                  BidirectionalIterator,
-                  ForwardIterator<T>,
-                  requires(T& arg) {
-                    { --arg } -> std::same_as<T&>;
-                    { arg-- } -> std::convertible_to<T const&>;
-                    *arg--;
-                  })
+  DefineConceptBinaryAnd(BidirectionalIterator, ForwardIterator<T>, requires(T& arg) {
+    { --arg } -> std::same_as<T&>;
+    { arg-- } -> std::convertible_to<T const &>;
+    *arg--;
+  })
 
-                  template <typename T>
-                  concept RandomAccessIterator =
-                      BidirectionalIterator<T> && Comparable<T>
-                      && requires(T arg, T& arg_ref, diff_from<T> increment) {
-                           // Reference increment requirements
-                           { arg_ref += increment } -> std::same_as<T&>;
-                           { arg_ref -= increment } -> std::same_as<T&>;
-                           // Value increment requirements
-                           { arg + increment } -> std::same_as<T>;
-                           { increment + arg } -> std::same_as<T>;
-                           { arg - increment } -> std::same_as<T>;
-                           // random access index operator
-                           arg[increment];
-                         };
+  template<typename T>
+  concept RandomAccessIterator =
+    BidirectionalIterator<T> &&
+    Comparable<T> &&
+    requires(T arg, T& arg_ref, diff_from<T> increment) {
+        // Reference increment requirements
+        {arg_ref += increment} -> std::same_as<T&>;
+        {arg_ref -= increment} ->std::same_as<T&>;
+        // Value increment requirements
+        {arg + increment} -> std::same_as<T>;
+        {increment + arg} -> std::same_as<T>;
+        {arg - increment} -> std::same_as<T>;
+        // random access index operator
+        arg[increment];
+  };
 
   template <typename T>
   concept HasBeginEnd = std::ranges::range<T>;
 
-  DefineConceptBinaryAnd(Range, HasBeginEnd<T>, Iterator<iterator_from<T>>)
-      DefineConceptBinaryAnd(ForwardRange,
-                             HasBeginEnd<T>,
-                             ForwardIterator<iterator_from<T>>)
-          DefineConceptBinaryAnd(BidirectionalRange,
-                                 HasBeginEnd<T>,
-                                 BidirectionalIterator<iterator_from<T>>)
-              DefineConceptBinaryAnd(RandomAccessRange,
-                                     HasBeginEnd<T>,
-                                     RandomAccessIterator<iterator_from<T>>)
+  DefineConceptBinaryAnd(Range,  HasBeginEnd<T>, Iterator<iterator_from<T>>)
+  DefineConceptBinaryAnd(ForwardRange,  HasBeginEnd<T>,
+    ForwardIterator<iterator_from<T>>)
+  DefineConceptBinaryAnd(BidirectionalRange,  HasBeginEnd<T>,
+    BidirectionalIterator<iterator_from<T>>)
+  DefineConceptBinaryAnd(RandomAccessRange, HasBeginEnd<T>,
+    RandomAccessIterator<iterator_from<T>>)
+
+  // clang-format on
 
 }  // end namespace concepts
 

--- a/include/camp/concepts.hpp
+++ b/include/camp/concepts.hpp
@@ -10,9 +10,9 @@
 #ifndef CAMP_CONCEPTS_HPP
 #define CAMP_CONCEPTS_HPP
 
+#include <concepts>
 #include <iterator>
 #include <type_traits>
-#include <concepts>
 
 #include "camp/helpers.hpp"
 #include "camp/list.hpp"
@@ -71,25 +71,26 @@ namespace concepts
 }  // end namespace camp
 
 #define DefineConceptRequires(CONCEPT_NAME, expr) \
-template<typename T> \
-concept CONCEPT_NAME = requires(T arg) { expr };
+  template <typename T>                           \
+  concept CONCEPT_NAME = requires(T arg) { expr };
 
 #define DefineConceptFromSTL(CONCEPT_NAME, stl_concept) \
-template<typename T> \
-concept CONCEPT_NAME = stl_concept;
+  template <typename T>                                 \
+  concept CONCEPT_NAME = stl_concept;
 
 #define DefineConceptBinaryAnd(CONCEPT_NAME, expr1, expr2) \
-template<typename T> \
-concept CONCEPT_NAME = expr1 && expr2;
+  template <typename T>                                    \
+  concept CONCEPT_NAME = expr1 && expr2;
 
 #define DefineConceptVar(CONCEPT_NAME, ...) \
-template<typename T> \
-concept CONCEPT_NAME = EXPAND_AND(__VA_ARGS__);
+  template <typename T>                     \
+  concept CONCEPT_NAME = EXPAND_AND(__VA_ARGS__);
 
-#define DefineTypeTraitFromConcept(TTName, ConceptName)             \
-  template<class T>                                                 \
-  struct TTName : std::bool_constant<ConceptName<T>> {};            \
-  template<class T>                                                 \
+#define DefineTypeTraitFromConcept(TTName, ConceptName) \
+  template <class T>                                    \
+  struct TTName : std::bool_constant<ConceptName<T>> {  \
+  };                                                    \
+  template <class T>                                    \
   inline constexpr bool TTName##_v = TTName<T>::value;
 
 namespace camp
@@ -135,7 +136,7 @@ namespace concepts
 
 
     template <typename Ret, typename T>
-    Ret returns(T const &) noexcept;
+    Ret returns(T const&) noexcept;
 
   }  // end namespace detail
 
@@ -145,13 +146,13 @@ namespace concepts
   /// metafunction for use within decltype expression to validate return type is
   /// convertible to given type
   template <typename T, typename U>
-  constexpr auto convertible_to(U &&u) noexcept
-      -> decltype(detail::returns<camp::true_type>(static_cast<T>((U &&)u)));
+  constexpr auto convertible_to(U&& u) noexcept
+      -> decltype(detail::returns<camp::true_type>(static_cast<T>((U&&)u)));
 
   /// metafunction for use within decltype expression to validate type of
   /// expression
   template <typename T, typename U>
-  constexpr auto has_type(U &&) noexcept -> metalib::is_same<T, U>;
+  constexpr auto has_type(U&&) noexcept -> metalib::is_same<T, U>;
 
   template <typename BoolLike>
   constexpr auto is(BoolLike) noexcept
@@ -188,83 +189,99 @@ namespace concepts
   struct requires_ : detail::detected<Op, detail::TL<Args...>> {
   };
 
-  DefineConceptFromSTL(Swappable, std::swappable<T>)
-  DefineConceptRequires(LessThanComparable, {arg < arg} -> std::convertible_to<bool>; )
-  DefineConceptRequires(GreaterThanComparable, {arg > arg} -> std::convertible_to<bool>; )
-  DefineConceptRequires(LessEqualComparable,  {arg <= arg} -> std::convertible_to<bool>; )
-  DefineConceptRequires(GreaterEqualComparable,  {arg >= arg} -> std::convertible_to<bool>; )
-  DefineConceptRequires(EqualityComparable,  {arg == arg} -> std::convertible_to<bool>; )
+  DefineConceptFromSTL(Swappable, std::swappable<T>) DefineConceptRequires(
+      LessThanComparable, {arg < arg}->std::convertible_to<bool>;)
+      DefineConceptRequires(GreaterThanComparable,
+                            {arg > arg}->std::convertible_to<bool>;)
+          DefineConceptRequires(LessEqualComparable,
+                                {arg <= arg}->std::convertible_to<bool>;)
+              DefineConceptRequires(GreaterEqualComparable,
+                                    {arg >= arg}->std::convertible_to<bool>;)
+                  DefineConceptRequires(
+                      EqualityComparable,
+                      {arg == arg}->std::convertible_to<bool>;)
 
-  template <typename T, typename U>
-  concept ComparableTo = requires (T lhs, U rhs) {
-        {lhs < rhs} -> std::convertible_to<bool>;
-        {rhs < lhs} -> std::convertible_to<bool>;
-        {lhs <= rhs} -> std::convertible_to<bool>;
-        {rhs <= lhs} -> std::convertible_to<bool>;
-        {lhs > rhs} -> std::convertible_to<bool>;
-        {rhs > lhs} -> std::convertible_to<bool>;
-        {lhs >= rhs} -> std::convertible_to<bool>;
-        {rhs >= lhs} -> std::convertible_to<bool>;
-        {lhs == rhs} -> std::convertible_to<bool>;
-        {rhs == lhs} -> std::convertible_to<bool>;
-        {lhs != rhs} -> std::convertible_to<bool>;
-        {rhs != lhs} -> std::convertible_to<bool>;
-  };
+                      template <typename T, typename U>
+                      concept ComparableTo = requires(T lhs, U rhs) {
+                        { lhs < rhs } -> std::convertible_to<bool>;
+                        { rhs < lhs } -> std::convertible_to<bool>;
+                        { lhs <= rhs } -> std::convertible_to<bool>;
+                        { rhs <= lhs } -> std::convertible_to<bool>;
+                        { lhs > rhs } -> std::convertible_to<bool>;
+                        { rhs > lhs } -> std::convertible_to<bool>;
+                        { lhs >= rhs } -> std::convertible_to<bool>;
+                        { rhs >= lhs } -> std::convertible_to<bool>;
+                        { lhs == rhs } -> std::convertible_to<bool>;
+                        { rhs == lhs } -> std::convertible_to<bool>;
+                        { lhs != rhs } -> std::convertible_to<bool>;
+                        { rhs != lhs } -> std::convertible_to<bool>;
+                      };
 
   template <typename T>
   concept Comparable = ComparableTo<T, T>;
 
   DefineConceptFromSTL(FloatingPoint, std::floating_point<T>)
-  DefineConceptFromSTL(Integral, std::integral<T>)
-  DefineConceptFromSTL(Arithmetic, std::is_arithmetic_v<T>)
-  DefineConceptFromSTL(Signed, std::signed_integral<T>)
-  DefineConceptFromSTL(Unsigned, std::unsigned_integral<T>)
+      DefineConceptFromSTL(Integral, std::integral<T>)
+          DefineConceptFromSTL(Arithmetic, std::is_arithmetic_v<T>)
+              DefineConceptFromSTL(Signed, std::signed_integral<T>)
+                  DefineConceptFromSTL(Unsigned, std::unsigned_integral<T>)
 
-  // Note: std::weakly_incrementable is the closest C++ concept to Iterator, but differs
-  // in two important ways.  (1) std::weakly_incrementable requires and iterator be
-  // post-incrementable (arg_ref++) (2) std::weakly_incrementable does not requires
-  // not Integral
-  DefineConceptBinaryAnd(Iterator, !Integral<T>, requires(T arg, T& arg_ref) {
-    *arg;
-    { ++arg_ref } -> std::same_as<T&>;
-  })
-  DefineConceptBinaryAnd(ForwardIterator, Iterator<T>, requires(T& arg) {
-    arg++;
-    *arg++;
-  })
+      // Note: std::weakly_incrementable is the closest C++ concept to Iterator,
+      // but differs in two important ways.  (1) std::weakly_incrementable
+      // requires and iterator be post-incrementable (arg_ref++) (2)
+      // std::weakly_incrementable does not requires not Integral
+      DefineConceptBinaryAnd(
+          Iterator,
+          !Integral<T>,
+          requires(T arg, T& arg_ref) {
+            *arg;
+            { ++arg_ref } -> std::same_as<T&>;
+          })
+          DefineConceptBinaryAnd(
+              ForwardIterator,
+              Iterator<T>,
+              requires(T& arg) {
+                arg++;
+                *arg++;
+              })
 
-  DefineConceptBinaryAnd(BidirectionalIterator, ForwardIterator<T>, requires(T& arg) {
-    { --arg } -> std::same_as<T&>;
-    { arg-- } -> std::convertible_to<T const &>;
-    *arg--;
-  })
+              DefineConceptBinaryAnd(
+                  BidirectionalIterator,
+                  ForwardIterator<T>,
+                  requires(T& arg) {
+                    { --arg } -> std::same_as<T&>;
+                    { arg-- } -> std::convertible_to<T const&>;
+                    *arg--;
+                  })
 
-  template<typename T>
-  concept RandomAccessIterator =
-    BidirectionalIterator<T> &&
-    Comparable<T> &&
-    requires(T arg, T& arg_ref, diff_from<T> increment) {
-        // Reference increment requirements
-        {arg_ref += increment} -> std::same_as<T&>;
-        {arg_ref -= increment} ->std::same_as<T&>;
-        // Value increment requirements
-        {arg + increment} -> std::same_as<T>;
-        {increment + arg} -> std::same_as<T>;
-        {arg - increment} -> std::same_as<T>;
-        // random access index operator
-        arg[increment];
-    };
+                  template <typename T>
+                  concept RandomAccessIterator =
+                      BidirectionalIterator<T> && Comparable<T>
+                      && requires(T arg, T& arg_ref, diff_from<T> increment) {
+                           // Reference increment requirements
+                           { arg_ref += increment } -> std::same_as<T&>;
+                           { arg_ref -= increment } -> std::same_as<T&>;
+                           // Value increment requirements
+                           { arg + increment } -> std::same_as<T>;
+                           { increment + arg } -> std::same_as<T>;
+                           { arg - increment } -> std::same_as<T>;
+                           // random access index operator
+                           arg[increment];
+                         };
 
   template <typename T>
   concept HasBeginEnd = std::ranges::range<T>;
 
-  DefineConceptBinaryAnd(Range,  HasBeginEnd<T>, Iterator<iterator_from<T>>)
-  DefineConceptBinaryAnd(ForwardRange,  HasBeginEnd<T>,
-    ForwardIterator<iterator_from<T>>)
-  DefineConceptBinaryAnd(BidirectionalRange,  HasBeginEnd<T>,
-    BidirectionalIterator<iterator_from<T>>)
-  DefineConceptBinaryAnd(RandomAccessRange, HasBeginEnd<T>,
-    RandomAccessIterator<iterator_from<T>>)
+  DefineConceptBinaryAnd(Range, HasBeginEnd<T>, Iterator<iterator_from<T>>)
+      DefineConceptBinaryAnd(ForwardRange,
+                             HasBeginEnd<T>,
+                             ForwardIterator<iterator_from<T>>)
+          DefineConceptBinaryAnd(BidirectionalRange,
+                                 HasBeginEnd<T>,
+                                 BidirectionalIterator<iterator_from<T>>)
+              DefineConceptBinaryAnd(RandomAccessRange,
+                                     HasBeginEnd<T>,
+                                     RandomAccessIterator<iterator_from<T>>)
 
 }  // end namespace concepts
 
@@ -293,9 +310,11 @@ namespace type_traits
   DefineTypeTraitFromConcept(is_signed, camp::concepts::Signed);
   DefineTypeTraitFromConcept(is_unsigned, camp::concepts::Unsigned);
 
-  template<class T, class U>
-  struct is_comparable_to : std::bool_constant<camp::concepts::ComparableTo<T, U>> {};
-  template<class T, class U>
+  template <class T, class U>
+  struct is_comparable_to
+      : std::bool_constant<camp::concepts::ComparableTo<T, U>> {
+  };
+  template <class T, class U>
   inline constexpr bool is_comparable_to_v = is_comparable_to<T, U>::value;
 
   template <typename T>
@@ -374,7 +393,6 @@ namespace resources
     template <typename T>
     inline constexpr bool is_concrete_event_v = is_concrete_event<T>::value;
 
-
     template <typename T>
     struct is_concrete_resource_impl : std::false_type {
     };
@@ -385,7 +403,8 @@ namespace resources
     };
 
     template <typename T>
-    inline constexpr bool is_concrete_resource_v = is_concrete_resource<T>::value;
+    inline constexpr bool is_concrete_resource_v =
+        is_concrete_resource<T>::value;
 
   }  // namespace v1
 }  // namespace resources
@@ -393,10 +412,10 @@ namespace resources
 namespace concepts
 {
 
-  template < typename T >
+  template <typename T>
   concept ConcreteEvent = ::camp::resources::is_concrete_event_v<T>;
 
-  template < typename T >
+  template <typename T>
   concept ConcreteResource = ::camp::resources::is_concrete_resource_v<T>;
 
 }  // namespace concepts

--- a/include/camp/config.in.hpp
+++ b/include/camp/config.in.hpp
@@ -20,9 +20,9 @@
 #cmakedefine CAMP_WIN_STATIC_BUILD
 #endif
 
-#define CAMP_VERSION_MAJOR @camp_VERSION_MAJOR @
-#define CAMP_VERSION_MINOR @camp_VERSION_MINOR @
-#define CAMP_VERSION_PATCH @camp_VERSION_PATCH @
+#define CAMP_VERSION_MAJOR @camp_VERSION_MAJOR@
+#define CAMP_VERSION_MINOR @camp_VERSION_MINOR@
+#define CAMP_VERSION_PATCH @camp_VERSION_PATCH@
 
 #define CAMP_VERSION                                           \
   (CAMP_VERSION_MAJOR * 1000000) + (CAMP_VERSION_MINOR * 1000) \

--- a/include/camp/config.in.hpp
+++ b/include/camp/config.in.hpp
@@ -20,9 +20,9 @@
 #cmakedefine CAMP_WIN_STATIC_BUILD
 #endif
 
-#define CAMP_VERSION_MAJOR @camp_VERSION_MAJOR@
-#define CAMP_VERSION_MINOR @camp_VERSION_MINOR@
-#define CAMP_VERSION_PATCH @camp_VERSION_PATCH@
+#define CAMP_VERSION_MAJOR @camp_VERSION_MAJOR @
+#define CAMP_VERSION_MINOR @camp_VERSION_MINOR @
+#define CAMP_VERSION_PATCH @camp_VERSION_PATCH @
 
 #define CAMP_VERSION                                           \
   (CAMP_VERSION_MAJOR * 1000000) + (CAMP_VERSION_MINOR * 1000) \
@@ -39,7 +39,8 @@
 #endif
 
 #if defined(CAMP_USE_PLATFORM_DEFAULT_STREAM)
-#error "Manually defining CAMP_USE_PLATFORM_DEFAULT_STREAM is not allowed because of the potential for ODR violations. CAMP supports a CMake configuration option that should be used instead."
+#error \
+    "Manually defining CAMP_USE_PLATFORM_DEFAULT_STREAM is not allowed because of the potential for ODR violations. CAMP supports a CMake configuration option that should be used instead."
 #endif
 
 #cmakedefine01 CAMP_USE_PLATFORM_DEFAULT_STREAM

--- a/include/camp/defines.hpp
+++ b/include/camp/defines.hpp
@@ -176,10 +176,10 @@ using nullptr_t = decltype(nullptr);
 
 /// Throw a runtime_error, avoid including exception everywhere
 [[noreturn]]
-CAMP_DLL_EXPORT void throw_re(const char *s);
+CAMP_DLL_EXPORT void throw_re(const char* s);
 ///
 [[noreturn]]
-CAMP_DLL_EXPORT void throw_re(std::string const &s);
+CAMP_DLL_EXPORT void throw_re(std::string const& s);
 
 #ifdef CAMP_ENABLE_CUDA
 
@@ -190,7 +190,7 @@ CAMP_DLL_EXPORT void throw_re(std::string const &s);
 
 [[deprecated]]
 CAMP_DLL_EXPORT cudaError_t
-cudaAssert(cudaError_t code, const char *call, const char *file, int line);
+cudaAssert(cudaError_t code, const char* call, const char* file, int line);
 
 /// Invoke the given CUDA API function and report CUDA error codes.
 ///
@@ -237,7 +237,7 @@ cudaAssert(cudaError_t code, const char *call, const char *file, int line);
 
 [[deprecated]]
 CAMP_DLL_EXPORT hipError_t
-hipAssert(hipError_t code, const char *call, const char *file, int line);
+hipAssert(hipError_t code, const char* call, const char* file, int line);
 
 
 /// Invoke the given HIP API function and report HIP error codes.

--- a/include/camp/helpers.hpp
+++ b/include/camp/helpers.hpp
@@ -290,9 +290,8 @@ namespace experimental
   }
 
 
-
 #ifdef CAMP_ENABLE_CUDA
-  
+
 #if CUDART_VERSION >= 13000
   // Specialization of camp I/O for CUDA 13 cudaMemLocation.
   //
@@ -306,23 +305,23 @@ namespace experimental
   {
     switch (t) {
       case cudaMemLocationTypeInvalid:
-	return "cudaMemLocationTypeInvalid";
+        return "cudaMemLocationTypeInvalid";
       case cudaMemLocationTypeDevice:
-	return "cudaMemLocationTypeDevice";
+        return "cudaMemLocationTypeDevice";
       case cudaMemLocationTypeHost:
-	return "cudaMemLocationTypeHost";
+        return "cudaMemLocationTypeHost";
       case cudaMemLocationTypeHostNuma:
-	return "cudaMemLocationTypeHostNuma";
+        return "cudaMemLocationTypeHostNuma";
       default:
-	return "Unknown";
+        return "Unknown";
     }
   }
 
   //! Print helper for cudaMemLocation
   inline std::ostream& print_cudaMemLocation(std::ostream& os,
-					     const cudaMemLocation& loc)
+                                             const cudaMemLocation& loc)
   {
-    os << "{" <<  to_string(loc.type) << ", " << loc.id << "}";
+    os << "{" << to_string(loc.type) << ", " << loc.id << "}";
     return os;
   }
 
@@ -337,7 +336,8 @@ namespace experimental
   struct StreamInsertHelper<cudaMemLocation&> {
     const cudaMemLocation& m_val;
 
-    std::ostream& operator()(std::ostream& str) const {
+    std::ostream& operator()(std::ostream& str) const
+    {
       return print_cudaMemLocation(str, m_val);
     }
   };
@@ -353,11 +353,12 @@ namespace experimental
   struct StreamInsertHelper<const cudaMemLocation&> {
     const cudaMemLocation& m_val;
 
-    std::ostream& operator()(std::ostream& str) const {
+    std::ostream& operator()(std::ostream& str) const
+    {
       return print_cudaMemLocation(str, m_val);
     }
   };
-#endif // CUDART_VERSION >= 13000
+#endif  // CUDART_VERSION >= 13000
 
   //! Get the argument names for the given cuda API function name.
   //

--- a/include/camp/resource.hpp
+++ b/include/camp/resource.hpp
@@ -19,7 +19,6 @@
 #include "camp/config.hpp"
 #include "camp/defines.hpp"
 #include "camp/helpers.hpp"
-
 #include "camp/resource/event.hpp"
 
 // last to ensure we don't hide breakage in the others
@@ -37,13 +36,13 @@ namespace resources
       using event_type = Event;
 
       Resource() = default;
-      Resource(Resource &&) = default;
-      Resource(Resource const &) = default;
-      Resource &operator=(Resource &&) = default;
-      Resource &operator=(Resource const &) = default;
+      Resource(Resource&&) = default;
+      Resource(Resource const&) = default;
+      Resource& operator=(Resource&&) = default;
+      Resource& operator=(Resource const&) = default;
 
       template <camp::concepts::ConcreteResource T>
-      Resource(T &&value)
+      Resource(T&& value)
       {
         m_value.reset(new ContextModel<camp::decay<T>>(forward<T>(value)));
       }
@@ -54,7 +53,7 @@ namespace resources
         if (!m_value) {
           return nullptr;
         }
-        auto result = dynamic_cast<ContextModel<T> *>(m_value.get());
+        auto result = dynamic_cast<ContextModel<T>*>(m_value.get());
         if (!result) {
           return nullptr;
         }
@@ -67,7 +66,7 @@ namespace resources
         if (!m_value) {
           return nullptr;
         }
-        auto result = dynamic_cast<ContextModel<T> *>(m_value.get());
+        auto result = dynamic_cast<ContextModel<T>*>(m_value.get());
         if (!result) {
           return nullptr;
         }
@@ -110,7 +109,7 @@ namespace resources
       }
 
       template <typename T>
-      T *allocate(size_t size, MemoryAccess ma = MemoryAccess::Device)
+      T* allocate(size_t size, MemoryAccess ma = MemoryAccess::Device)
       {
         if (size == 0) {
           return nullptr;
@@ -118,10 +117,10 @@ namespace resources
         if (!m_value) {
           ::camp::throw_re("Empty Resource type allocate call.");
         }
-        return (T *)m_value->allocate(size * sizeof(T), ma);
+        return (T*)m_value->allocate(size * sizeof(T), ma);
       }
 
-      void *calloc(size_t size, MemoryAccess ma = MemoryAccess::Device)
+      void* calloc(size_t size, MemoryAccess ma = MemoryAccess::Device)
       {
         if (size == 0) {
           return nullptr;
@@ -132,7 +131,7 @@ namespace resources
         return m_value->calloc(size, ma);
       }
 
-      void deallocate(void *p, MemoryAccess ma = MemoryAccess::Device)
+      void deallocate(void* p, MemoryAccess ma = MemoryAccess::Device)
       {
         if (p == nullptr) {
           return;
@@ -143,7 +142,7 @@ namespace resources
         m_value->deallocate(p, ma);
       }
 
-      void memcpy(void *dst, const void *src, size_t size)
+      void memcpy(void* dst, const void* src, size_t size)
       {
         if (size == 0) {
           return;
@@ -154,7 +153,7 @@ namespace resources
         m_value->memcpy(dst, src, size);
       }
 
-      void memset(void *p, int val, size_t size)
+      void memset(void* p, int val, size_t size)
       {
         if (size == 0) {
           return;
@@ -184,7 +183,7 @@ namespace resources
       void wait_for(Event const& e)
       {
         if (!m_value) {
-            e.wait();
+          e.wait();
           return;
         }
         m_value->wait_for(e);
@@ -207,13 +206,12 @@ namespace resources
        * \return True if they have the same platform and stream/queue, false
        * otherwise.
        */
-      friend inline bool operator==(Resource const &lhs, Resource const &rhs)
+      friend inline bool operator==(Resource const& lhs, Resource const& rhs)
       {
         if (!lhs.m_value && !rhs.m_value) {
           return true;
         }
-        if ((!lhs.m_value && rhs.m_value) ||
-            (lhs.m_value && !rhs.m_value)) {
+        if ((!lhs.m_value && rhs.m_value) || (lhs.m_value && !rhs.m_value)) {
           return false;
         }
         if (lhs.get_platform() == rhs.get_platform()) {
@@ -222,8 +220,8 @@ namespace resources
         return false;
       }
 
-      template < camp::concepts::ConcreteResource Res >
-      friend inline bool operator==(Resource const &lhs, Res const &rhs)
+      template <camp::concepts::ConcreteResource Res>
+      friend inline bool operator==(Resource const& lhs, Res const& rhs)
       {
         if (!lhs.m_value) {
           return false;
@@ -257,17 +255,17 @@ namespace resources
 
         virtual Platform get_platform() const = 0;
 
-        virtual bool compare(Resource const &r) const = 0;
+        virtual bool compare(Resource const& r) const = 0;
         virtual size_t get_hash() const = 0;
 
-        virtual void *allocate(size_t size,
+        virtual void* allocate(size_t size,
                                MemoryAccess ma = MemoryAccess::Device) = 0;
-        virtual void *calloc(size_t size,
+        virtual void* calloc(size_t size,
                              MemoryAccess ma = MemoryAccess::Device) = 0;
-        virtual void deallocate(void *p,
+        virtual void deallocate(void* p,
                                 MemoryAccess ma = MemoryAccess::Device) = 0;
-        virtual void memcpy(void *dst, const void *src, size_t size) = 0;
-        virtual void memset(void *p, int val, size_t size) = 0;
+        virtual void memcpy(void* dst, const void* src, size_t size) = 0;
+        virtual void memset(void* p, int val, size_t size) = 0;
 
         virtual Event get_event() = 0;
         virtual Event get_event_erased() = 0;
@@ -279,44 +277,44 @@ namespace resources
       class ContextModel final : public ContextInterface
       {
       public:
-        explicit ContextModel(T const &modelVal) : m_modelVal(modelVal) {}
+        explicit ContextModel(T const& modelVal) : m_modelVal(modelVal) {}
 
         Platform get_platform() const override
         {
           return m_modelVal.get_platform();
         }
 
-        bool compare(Resource const &r) const override
+        bool compare(Resource const& r) const override
         {
           return m_modelVal == r.get<T>();
         }
 
         size_t get_hash() const override { return m_modelVal.get_hash(); }
 
-        void *allocate(size_t size,
+        void* allocate(size_t size,
                        MemoryAccess ma = MemoryAccess::Device) override
         {
           return m_modelVal.template allocate<char>(size, ma);
         }
 
-        void *calloc(size_t size,
+        void* calloc(size_t size,
                      MemoryAccess ma = MemoryAccess::Device) override
         {
           return m_modelVal.calloc(size, ma);
         }
 
-        void deallocate(void *p,
+        void deallocate(void* p,
                         MemoryAccess ma = MemoryAccess::Device) override
         {
           m_modelVal.deallocate(p, ma);
         }
 
-        void memcpy(void *dst, const void *src, size_t size) override
+        void memcpy(void* dst, const void* src, size_t size) override
         {
           m_modelVal.memcpy(dst, src, size);
         }
 
-        void memset(void *p, int val, size_t size) override
+        void memset(void* p, int val, size_t size) override
         {
           m_modelVal.memset(p, val, size);
         }
@@ -344,39 +342,35 @@ namespace resources
     };
 
     template <typename Res>
-    struct EventProxy : ::camp::resources::detail::EventProxyBase
-    {
+    struct EventProxy : ::camp::resources::detail::EventProxyBase {
       using native_event = typename Res::event_type;
 
-      EventProxy(EventProxy &&) = default;
-      EventProxy(EventProxy const &) = delete;
-      EventProxy &operator=(EventProxy &&) = default;
-      EventProxy &operator=(EventProxy const &) = delete;
+      EventProxy(EventProxy&&) = default;
+      EventProxy(EventProxy const&) = delete;
+      EventProxy& operator=(EventProxy&&) = default;
+      EventProxy& operator=(EventProxy const&) = delete;
 
       EventProxy(Res r) : resource_{move(r)} {}
 
       native_event get()
-      requires (!std::same_as<native_event, Event>)
+        requires(!std::same_as<native_event, Event>)
       {
         return resource_.get_event();
       }
 
       Event get()
-      requires (std::same_as<native_event, Event>)
+        requires(std::same_as<native_event, Event>)
       {
         return resource_.get_event_erased();
       }
 
       operator native_event()
-      requires (!std::same_as<native_event, Event>)
+        requires(!std::same_as<native_event, Event>)
       {
         return resource_.get_event();
       }
 
-      operator Event()
-      {
-        return resource_.get_event_erased();
-      }
+      operator Event() { return resource_.get_event_erased(); }
 
       Res resource_;
     };
@@ -399,7 +393,7 @@ namespace std
  */
 template <>
 struct hash<camp::resources::Resource> {
-  std::size_t operator()(const camp::resources::Resource &r) const
+  std::size_t operator()(const camp::resources::Resource& r) const
   {
     return r.get_hash();
   }

--- a/include/camp/resource/cuda.hpp
+++ b/include/camp/resource/cuda.hpp
@@ -16,8 +16,8 @@
 
 #include <cuda_runtime.h>
 
-#include <cstddef>
 #include <array>
+#include <cstddef>
 #include <mutex>
 #include <utility>
 
@@ -76,15 +76,14 @@ namespace resources
     class CudaEvent
     {
     public:
-      explicit CudaEvent(cudaStream_t stream)
-        : m_event(init(stream))
-      {}
+      explicit CudaEvent(cudaStream_t stream) : m_event(init(stream)) {}
 
       CudaEvent(CudaEvent const&) = delete;
 
       CudaEvent(CudaEvent&& rhs) noexcept
-        : m_event(std::exchange(rhs.m_event, nullptr))
-      {}
+          : m_event(std::exchange(rhs.m_event, nullptr))
+      {
+      }
 
       CudaEvent& operator=(CudaEvent const&) = delete;
 
@@ -95,10 +94,7 @@ namespace resources
         return *this;
       }
 
-      ~CudaEvent()
-      {
-        finalize(m_event);
-      }
+      ~CudaEvent() { finalize(m_event); }
 
       Platform get_platform() const { return Platform::cuda; }
 
@@ -121,7 +117,8 @@ namespace resources
        *
        * \return True if both refer to the same cuda event, false otherwise.
        */
-      friend inline bool operator==(CudaEvent const& lhs, CudaEvent const& rhs) = default;
+      friend inline bool operator==(CudaEvent const& lhs,
+                                    CudaEvent const& rhs) = default;
 
       size_t get_hash() const
       {
@@ -160,7 +157,7 @@ namespace resources
         static constexpr int num_streams = 16;
         static std::array<cudaStream_t, num_streams> s_streams = [] {
           std::array<cudaStream_t, num_streams> streams;
-          for (auto &s : streams) {
+          for (auto& s : streams) {
             CAMP_CUDA_API_INVOKE_AND_CHECK(cudaStreamCreate, &s);
           }
           return streams;
@@ -181,7 +178,7 @@ namespace resources
       // Private from-stream constructor
       Cuda(cudaStream_t s, int dev = 0) : stream(s), device(dev) {}
 
-      MemoryAccess get_access_type(void *p)
+      MemoryAccess get_access_type(void* p)
       {
         cudaPointerAttributes a;
         cudaError_t status = cudaPointerGetAttributes(&a, p);
@@ -275,28 +272,28 @@ namespace resources
 
       // Memory
       template <typename T>
-      T *allocate(size_t size, MemoryAccess ma = MemoryAccess::Device)
+      T* allocate(size_t size, MemoryAccess ma = MemoryAccess::Device)
       {
-        T *ret = nullptr;
+        T* ret = nullptr;
         if (size > 0) {
           auto d{device_guard(device)};
           switch (ma) {
             case MemoryAccess::Unknown:
             case MemoryAccess::Device:
               CAMP_CUDA_API_INVOKE_AND_CHECK(cudaMalloc,
-                                             (void **)&ret,
+                                             (void**)&ret,
                                              sizeof(T) * size);
               break;
             case MemoryAccess::Pinned:
               // TODO: do a test here for whether managed is *actually* shared
               // so we can use the better performing memory
               CAMP_CUDA_API_INVOKE_AND_CHECK(cudaMallocHost,
-                                             (void **)&ret,
+                                             (void**)&ret,
                                              sizeof(T) * size);
               break;
             case MemoryAccess::Managed:
               CAMP_CUDA_API_INVOKE_AND_CHECK(cudaMallocManaged,
-                                             (void **)&ret,
+                                             (void**)&ret,
                                              sizeof(T) * size);
               break;
           }
@@ -304,14 +301,14 @@ namespace resources
         return ret;
       }
 
-      void *calloc(size_t size, MemoryAccess ma = MemoryAccess::Device)
+      void* calloc(size_t size, MemoryAccess ma = MemoryAccess::Device)
       {
-        void *p = allocate<char>(size, ma);
+        void* p = allocate<char>(size, ma);
         this->memset(p, 0, size);
         return p;
       }
 
-      void deallocate(void *p, MemoryAccess ma = MemoryAccess::Unknown)
+      void deallocate(void* p, MemoryAccess ma = MemoryAccess::Unknown)
       {
         auto d{device_guard(device)};
         if (ma == MemoryAccess::Unknown) {
@@ -335,7 +332,7 @@ namespace resources
         }
       }
 
-      void memcpy(void *dst, const void *src, size_t size)
+      void memcpy(void* dst, const void* src, size_t size)
       {
         if (size > 0) {
           auto d{device_guard(device)};
@@ -344,7 +341,7 @@ namespace resources
         }
       }
 
-      void memset(void *p, int val, size_t size)
+      void memset(void* p, int val, size_t size)
       {
         if (size > 0) {
           auto d{device_guard(device)};
@@ -366,7 +363,7 @@ namespace resources
       size_t get_hash() const
       {
         const size_t cuda_type = size_t(get_platform()) << 32;
-        size_t stream_hash = std::hash<void *>{}(static_cast<void *>(stream));
+        size_t stream_hash = std::hash<void*>{}(static_cast<void*>(stream));
         return cuda_type | (stream_hash & 0xFFFFFFFF);
       }
 
@@ -394,7 +391,7 @@ namespace std
  */
 template <>
 struct hash<camp::resources::CudaEvent> {
-  std::size_t operator()(const camp::resources::CudaEvent &e) const
+  std::size_t operator()(const camp::resources::CudaEvent& e) const
   {
     return e.get_hash();
   }
@@ -411,7 +408,7 @@ struct hash<camp::resources::CudaEvent> {
  */
 template <>
 struct hash<camp::resources::Cuda> {
-  std::size_t operator()(const camp::resources::Cuda &c) const
+  std::size_t operator()(const camp::resources::Cuda& c) const
   {
     return c.get_hash();
   }

--- a/include/camp/resource/event.hpp
+++ b/include/camp/resource/event.hpp
@@ -37,15 +37,16 @@ namespace resources
     {
     public:
       Event() = default;
-      Event(Event const &e) = default;
-      Event(Event &&e) = default;
-      Event &operator=(Event const &e) = default;
-      Event &operator=(Event &&e) = default;
+      Event(Event const& e) = default;
+      Event(Event&& e) = default;
+      Event& operator=(Event const& e) = default;
+      Event& operator=(Event&& e) = default;
 
       template <camp::concepts::ConcreteEvent T>
-      Event(T &&value)
+      Event(T&& value)
       {
-        m_value.reset(new EventModel<type::ref::rem<T>>(std::forward<T>(value)));
+        m_value.reset(
+            new EventModel<type::ref::rem<T>>(std::forward<T>(value)));
       }
 
       template <typename T>
@@ -54,7 +55,7 @@ namespace resources
         if (!m_value) {
           return nullptr;
         }
-        auto result = dynamic_cast<EventModel<T> *>(m_value.get());
+        auto result = dynamic_cast<EventModel<T>*>(m_value.get());
         if (!result) {
           return nullptr;
         }
@@ -67,7 +68,7 @@ namespace resources
         if (!m_value) {
           return nullptr;
         }
-        auto result = dynamic_cast<EventModel<T> *>(m_value.get());
+        auto result = dynamic_cast<EventModel<T>*>(m_value.get());
         if (!result) {
           return nullptr;
         }
@@ -111,7 +112,12 @@ namespace resources
 
       bool check() const { return m_value ? m_value->check() : true; }
 
-      void wait() const { if (m_value) { m_value->wait(); } }
+      void wait() const
+      {
+        if (m_value) {
+          m_value->wait();
+        }
+      }
 
       explicit operator bool() const { return static_cast<bool>(m_value); }
 
@@ -123,13 +129,12 @@ namespace resources
        * \return True if they have the same platform and equivalent underlying
        *         typed events, false otherwise.
        */
-      friend inline bool operator==(Event const &lhs, Event const &rhs)
+      friend inline bool operator==(Event const& lhs, Event const& rhs)
       {
         if (!lhs.m_value && !rhs.m_value) {
           return true;
         }
-        if ((!lhs.m_value && rhs.m_value) ||
-            (lhs.m_value && !rhs.m_value)) {
+        if ((!lhs.m_value && rhs.m_value) || (lhs.m_value && !rhs.m_value)) {
           return false;
         }
         if (lhs.get_platform() == rhs.get_platform()) {
@@ -138,8 +143,8 @@ namespace resources
         return false;
       }
 
-      template < camp::concepts::ConcreteEvent Evt >
-      friend inline bool operator==(Event const &lhs, Evt const &rhs)
+      template <camp::concepts::ConcreteEvent Evt>
+      friend inline bool operator==(Event const& lhs, Evt const& rhs)
       {
         if (!lhs.m_value) {
           return false;
@@ -173,7 +178,7 @@ namespace resources
 
         virtual Platform get_platform() const = 0;
 
-        virtual bool compare(Event const &e) const = 0;
+        virtual bool compare(Event const& e) const = 0;
         virtual size_t get_hash() const = 0;
 
         virtual bool check() const = 0;
@@ -184,31 +189,23 @@ namespace resources
       class EventModel final : public EventInterface
       {
       public:
-        explicit EventModel(T modelVal)
-          : m_modelVal(std::move(modelVal))
-        {}
+        explicit EventModel(T modelVal) : m_modelVal(std::move(modelVal)) {}
 
         Platform get_platform() const override
         {
           return m_modelVal.get_platform();
         }
 
-        bool compare(Event const &e) const override
+        bool compare(Event const& e) const override
         {
           return m_modelVal == e.get<T>();
         }
 
         size_t get_hash() const override { return m_modelVal.get_hash(); }
 
-        bool check() const override
-        {
-          return m_modelVal.check();
-        }
+        bool check() const override { return m_modelVal.check(); }
 
-        void wait() const override
-        {
-          m_modelVal.wait();
-        }
+        void wait() const override { m_modelVal.wait(); }
 
         T const* get() const { return &m_modelVal; }
 
@@ -239,7 +236,7 @@ namespace std
  */
 template <>
 struct hash<camp::resources::Event> {
-  std::size_t operator()(const camp::resources::Event &e) const
+  std::size_t operator()(const camp::resources::Event& e) const
   {
     return e.get_hash();
   }

--- a/include/camp/resource/hip.hpp
+++ b/include/camp/resource/hip.hpp
@@ -16,8 +16,8 @@
 
 #include <hip/hip_runtime.h>
 
-#include <cstddef>
 #include <array>
+#include <cstddef>
 #include <mutex>
 #include <utility>
 
@@ -81,11 +81,11 @@ namespace resources
       HipEvent(HipEvent const&) = delete;
 
       HipEvent(HipEvent&& rhs) noexcept
-        : m_event(std::exchange(rhs.m_event, nullptr))
-      {}
+          : m_event(std::exchange(rhs.m_event, nullptr))
+      {
+      }
 
       HipEvent& operator=(HipEvent const&) = delete;
-
 
       HipEvent& operator=(HipEvent&& rhs) noexcept
       {
@@ -94,10 +94,7 @@ namespace resources
         return *this;
       }
 
-      ~HipEvent()
-      {
-        finalize(m_event);
-      }
+      ~HipEvent() { finalize(m_event); }
 
       Platform get_platform() const { return Platform::hip; }
 
@@ -120,7 +117,8 @@ namespace resources
        *
        * \return True if both refer to the same hip event, false otherwise.
        */
-      friend inline bool operator==(HipEvent const& lhs, HipEvent const& rhs) = default;
+      friend inline bool operator==(HipEvent const& lhs,
+                                    HipEvent const& rhs) = default;
 
       size_t get_hash() const
       {
@@ -160,7 +158,7 @@ namespace resources
         static constexpr int num_streams = 16;
         static std::array<hipStream_t, num_streams> s_streams = [] {
           std::array<hipStream_t, num_streams> streams;
-          for (auto &s : streams) {
+          for (auto& s : streams) {
             CAMP_HIP_API_INVOKE_AND_CHECK(hipStreamCreate, &s);
           }
           return streams;
@@ -181,7 +179,7 @@ namespace resources
       // Private from-stream constructor
       Hip(hipStream_t s, int dev = 0) : stream(s), device(dev) {}
 
-      MemoryAccess get_access_type(void *p)
+      MemoryAccess get_access_type(void* p)
       {
         hipPointerAttribute_t a;
         hipError_t status = hipPointerGetAttributes(&a, p);
@@ -276,28 +274,28 @@ namespace resources
 
       // Memory
       template <typename T>
-      T *allocate(size_t size, MemoryAccess ma = MemoryAccess::Device)
+      T* allocate(size_t size, MemoryAccess ma = MemoryAccess::Device)
       {
-        T *ret = nullptr;
+        T* ret = nullptr;
         if (size > 0) {
           auto d{device_guard(device)};
           switch (ma) {
             case MemoryAccess::Unknown:
             case MemoryAccess::Device:
               CAMP_HIP_API_INVOKE_AND_CHECK(hipMalloc,
-                                            (void **)&ret,
+                                            (void**)&ret,
                                             sizeof(T) * size);
               break;
             case MemoryAccess::Pinned:
               // TODO: do a test here for whether managed is *actually* shared
               // so we can use the better performing memory
               CAMP_HIP_API_INVOKE_AND_CHECK(hipHostMalloc,
-                                            (void **)&ret,
+                                            (void**)&ret,
                                             sizeof(T) * size);
               break;
             case MemoryAccess::Managed:
               CAMP_HIP_API_INVOKE_AND_CHECK(hipMallocManaged,
-                                            (void **)&ret,
+                                            (void**)&ret,
                                             sizeof(T) * size);
               break;
           }
@@ -305,14 +303,14 @@ namespace resources
         return ret;
       }
 
-      void *calloc(size_t size, MemoryAccess ma)
+      void* calloc(size_t size, MemoryAccess ma)
       {
-        void *p = allocate<char>(size, ma);
+        void* p = allocate<char>(size, ma);
         this->memset(p, 0, size);
         return p;
       }
 
-      void deallocate(void *p, MemoryAccess ma = MemoryAccess::Unknown)
+      void deallocate(void* p, MemoryAccess ma = MemoryAccess::Unknown)
       {
         auto d{device_guard(device)};
         if (ma == MemoryAccess::Unknown) {
@@ -336,7 +334,7 @@ namespace resources
         }
       }
 
-      void memcpy(void *dst, const void *src, size_t size)
+      void memcpy(void* dst, const void* src, size_t size)
       {
         if (size > 0) {
           auto d{device_guard(device)};
@@ -345,7 +343,7 @@ namespace resources
         }
       }
 
-      void memset(void *p, int val, size_t size)
+      void memset(void* p, int val, size_t size)
       {
         if (size > 0) {
           auto d{device_guard(device)};
@@ -367,7 +365,7 @@ namespace resources
       size_t get_hash() const
       {
         const size_t hip_type = size_t(get_platform()) << 32;
-        size_t stream_hash = std::hash<void *>{}(static_cast<void *>(stream));
+        size_t stream_hash = std::hash<void*>{}(static_cast<void*>(stream));
         return hip_type | (stream_hash & 0xFFFFFFFF);
       }
 
@@ -395,7 +393,7 @@ namespace std
  */
 template <>
 struct hash<camp::resources::HipEvent> {
-  std::size_t operator()(const camp::resources::HipEvent &e) const
+  std::size_t operator()(const camp::resources::HipEvent& e) const
   {
     return e.get_hash();
   }
@@ -412,7 +410,7 @@ struct hash<camp::resources::HipEvent> {
  */
 template <>
 struct hash<camp::resources::Hip> {
-  std::size_t operator()(const camp::resources::Hip &h) const
+  std::size_t operator()(const camp::resources::Hip& h) const
   {
     return h.get_hash();
   }

--- a/include/camp/resource/host.hpp
+++ b/include/camp/resource/host.hpp
@@ -67,7 +67,8 @@ namespace resources
        *
        * \return True (Host is always synchronous so host events are trivial)
        */
-      friend inline bool operator==(HostEvent const& lhs, HostEvent const& rhs) = default;
+      friend inline bool operator==(HostEvent const& lhs,
+                                    HostEvent const& rhs) = default;
 
       size_t get_hash() const
       {
@@ -98,10 +99,7 @@ namespace resources
 
       void wait() {}
 
-      void wait_for(HostEvent const& e)
-      {
-        e.wait();
-      }
+      void wait_for(HostEvent const& e) { e.wait(); }
 
       void wait_for(Event const& e)
       {
@@ -114,36 +112,37 @@ namespace resources
 
       // Memory
       template <typename T>
-      T *allocate(size_t n, MemoryAccess = MemoryAccess::Device)
+      T* allocate(size_t n, MemoryAccess = MemoryAccess::Device)
       {
-        return (T *)std::malloc(sizeof(T) * n);
+        return (T*)std::malloc(sizeof(T) * n);
       }
 
-      void *calloc(size_t size, MemoryAccess = MemoryAccess::Device)
+      void* calloc(size_t size, MemoryAccess = MemoryAccess::Device)
       {
-        void *p = allocate<char>(size);
+        void* p = allocate<char>(size);
         this->memset(p, 0, size);
         return p;
       }
 
-      void deallocate(void *p, MemoryAccess = MemoryAccess::Device)
+      void deallocate(void* p, MemoryAccess = MemoryAccess::Device)
       {
         std::free(p);
       }
 
-      void memcpy(void *dst, const void *src, size_t size)
+      void memcpy(void* dst, const void* src, size_t size)
       {
         std::memcpy(dst, src, size);
       }
 
-      void memset(void *p, int val, size_t size) { std::memset(p, val, size); }
+      void memset(void* p, int val, size_t size) { std::memset(p, val, size); }
 
       /*
        * \brief Compares two (Host) resources to see if they are equal
        *
        * \return Always return true since Host resources are always the same
        */
-      friend inline bool operator==(Host const& CAMP_UNUSED_ARG(lhs), Host const& CAMP_UNUSED_ARG(rhs))
+      friend inline bool operator==(Host const& CAMP_UNUSED_ARG(lhs),
+                                    Host const& CAMP_UNUSED_ARG(rhs))
       {
         return true;
       }
@@ -173,7 +172,7 @@ namespace std
  */
 template <>
 struct hash<camp::resources::HostEvent> {
-  std::size_t operator()(const camp::resources::HostEvent &e) const
+  std::size_t operator()(const camp::resources::HostEvent& e) const
   {
     return e.get_hash();
   }
@@ -190,7 +189,7 @@ struct hash<camp::resources::HostEvent> {
  */
 template <>
 struct hash<camp::resources::Host> {
-  std::size_t operator()(const camp::resources::Host &h) const
+  std::size_t operator()(const camp::resources::Host& h) const
   {
     return h.get_hash();
   }

--- a/include/camp/resource/omp_target.hpp
+++ b/include/camp/resource/omp_target.hpp
@@ -50,7 +50,7 @@ namespace resources
     class OmpEvent
     {
     public:
-      explicit OmpEvent(char *addr_in, int device = omp_get_default_device())
+      explicit OmpEvent(char* addr_in, int device = omp_get_default_device())
           : addr(addr_in), dev(device)
       {
 #pragma omp target device(dev) depend(inout : addr_in[0]) nowait
@@ -61,9 +61,10 @@ namespace resources
       OmpEvent(OmpEvent const&) = delete;
 
       OmpEvent(OmpEvent&& rhs) noexcept
-        : addr(std::exchange(rhs.addr, nullptr))
-        , dev(std::exchange(rhs.dev, -1))
-      {}
+          : addr(std::exchange(rhs.addr, nullptr)),
+            dev(std::exchange(rhs.dev, -1))
+      {
+      }
 
       OmpEvent& operator=(OmpEvent const&) = delete;
 
@@ -86,7 +87,7 @@ namespace resources
 
       void wait() const
       {
-        char *local_addr = addr;
+        char* local_addr = addr;
         CAMP_ALLOW_UNUSED_LOCAL(local_addr);
         // if only we could use taskwait depend portably...
 #pragma omp task if (0) depend(inout : local_addr[0])
@@ -94,7 +95,7 @@ namespace resources
         }
       }
 
-      void *getEventAddr() const { return addr; }
+      void* getEventAddr() const { return addr; }
 
       /*
        * \brief Compares two events to see if they represent the same underlying
@@ -103,24 +104,25 @@ namespace resources
        * \return True if both refer to the same address and device, false
        *         otherwise.
        */
-      friend inline bool operator==(OmpEvent const& lhs, OmpEvent const& rhs) = default;
+      friend inline bool operator==(OmpEvent const& lhs,
+                                    OmpEvent const& rhs) = default;
 
       size_t get_hash() const
       {
         const size_t platform_type = size_t(get_platform()) << 32;
-        size_t hash = std::hash<char *>{}(addr);
+        size_t hash = std::hash<char*>{}(addr);
         hash ^= std::hash<int>{}(dev) + 0x9E3779B9 + (hash << 6) + (hash >> 2);
         return platform_type | (hash & 0xFFFFFFFF);
       }
 
     private:
-      char *addr;
+      char* addr;
       int dev;
     };
 
     class Omp
     {
-      static char *get_addr(int num)
+      static char* get_addr(int num)
       {
         static constexpr int num_addrs = 16;
         static char s_addrs[num_addrs] = {};
@@ -138,7 +140,7 @@ namespace resources
       }
 
       // Private from-address constructor
-      Omp(char *a, int device = omp_get_default_device()) : addr(a), dev(device)
+      Omp(char* a, int device = omp_get_default_device()) : addr(a), dev(device)
       {
       }
 
@@ -162,7 +164,7 @@ namespace resources
       /// Create a resource from a custom address
       /// The device specified must match the address, if none is specified the
       /// currently selected device is used.
-      static Omp OmpFromAddr(char *a, int device = -1)
+      static Omp OmpFromAddr(char* a, int device = -1)
       {
         if (device < 0) {
           device = omp_get_default_device();
@@ -185,7 +187,7 @@ namespace resources
 
       void wait()
       {
-        char *local_addr = addr;
+        char* local_addr = addr;
         CAMP_ALLOW_UNUSED_LOCAL(local_addr);
 #pragma omp target device(dev) depend(inout : local_addr[0])
         {
@@ -194,12 +196,12 @@ namespace resources
 
       void wait_for(OmpEvent const& e)
       {
-        char *local_addr = addr;
-        char *other_addr = (char *)e.getEventAddr();
+        char* local_addr = addr;
+        char* other_addr = (char*)e.getEventAddr();
         CAMP_ALLOW_UNUSED_LOCAL(local_addr);
         CAMP_ALLOW_UNUSED_LOCAL(other_addr);
 #pragma omp target depend(inout : local_addr[0]) depend(in : other_addr[0]) \
-  nowait
+    nowait
         {
         }
       }
@@ -215,43 +217,43 @@ namespace resources
 
       // Memory
       template <typename T>
-      T *allocate(size_t size, MemoryAccess ma = MemoryAccess::Device)
+      T* allocate(size_t size, MemoryAccess ma = MemoryAccess::Device)
       {
         check_ma(ma);
-        T *ret = static_cast<T *>(omp_target_alloc(sizeof(T) * size, dev));
+        T* ret = static_cast<T*>(omp_target_alloc(sizeof(T) * size, dev));
         register_ptr_dev(ret, dev);
         return ret;
       }
 
-      void *calloc(size_t size, MemoryAccess ma = MemoryAccess::Device)
+      void* calloc(size_t size, MemoryAccess ma = MemoryAccess::Device)
       {
         check_ma(ma);
-        void *p = allocate<char>(size);
+        void* p = allocate<char>(size);
         this->memset(p, 0, size);
         return p;
       }
 
-      void deallocate(void *p, MemoryAccess ma = MemoryAccess::Device)
+      void deallocate(void* p, MemoryAccess ma = MemoryAccess::Device)
       {
         check_ma(ma);
         deregister_ptr_dev(p);
         omp_target_free(p, dev);
       }
 
-      void memcpy(void *dst, const void *src, size_t size)
+      void memcpy(void* dst, const void* src, size_t size)
       {
         // this is truly, insanely awful, need to think of something better
         int dd = get_ptr_dev(dst);
         int sd = get_ptr_dev(src);
         // extra cast due to GCC openmp header bug
-        omp_target_memcpy(dst, (void *)src, size, 0, 0, dd, sd);
+        omp_target_memcpy(dst, (void*)src, size, 0, 0, dd, sd);
       }
 
-      void memset(void *p, int val, size_t size)
+      void memset(void* p, int val, size_t size)
       {
-        char *local_addr = addr;
+        char* local_addr = addr;
         CAMP_ALLOW_UNUSED_LOCAL(local_addr);
-        char *pc = (char *)p;
+        char* pc = (char*)p;
 #pragma omp target teams distribute parallel for device(dev) \
     depend(inout : local_addr[0]) is_device_ptr(pc) nowait
         for (size_t i = 0; i < size; ++i) {
@@ -259,7 +261,7 @@ namespace resources
         }
       }
 
-      void register_ptr_dev(void *p, int device)
+      void register_ptr_dev(void* p, int device)
       {
 #pragma omp critical(camp_register_ptr)
         {
@@ -267,7 +269,7 @@ namespace resources
         }
       }
 
-      void deregister_ptr_dev(void const *p)
+      void deregister_ptr_dev(void const* p)
       {
 #pragma omp critical(camp_register_ptr)
         {
@@ -275,7 +277,7 @@ namespace resources
         }
       }
 
-      int get_ptr_dev(void const *p)
+      int get_ptr_dev(void const* p)
       {
         int ret = omp_get_initial_device();
 #pragma omp critical(camp_register_ptr)
@@ -311,7 +313,7 @@ namespace resources
        *
        * \return The depend address of this Omp resource.
        */
-      char *get_depend_location() const { return addr; }
+      char* get_depend_location() const { return addr; }
 
       /*
        * \brief Compares two (Omp) resources to see if they are equal
@@ -323,18 +325,18 @@ namespace resources
       size_t get_hash() const
       {
         const size_t omp_type = size_t(get_platform()) << 32;
-        size_t stream_hash = std::hash<void *>{}(static_cast<void *>(addr));
+        size_t stream_hash = std::hash<void*>{}(static_cast<void*>(addr));
         return omp_type | (stream_hash & 0xFFFFFFFF);
       }
 
     private:
-      char *addr;
+      char* addr;
       int dev;
 
       template <typename always_void_odr_helper = void>
-      std::map<const void *, int> &get_dev_register()
+      std::map<const void*, int>& get_dev_register()
       {
-        static std::map<const void *, int> dev_register;
+        static std::map<const void*, int> dev_register;
         return dev_register;
       }
     };
@@ -376,7 +378,7 @@ struct hash<camp::resources::OmpEvent> {
  */
 template <>
 struct hash<camp::resources::Omp> {
-  std::size_t operator()(const camp::resources::Omp &o) const
+  std::size_t operator()(const camp::resources::Omp& o) const
   {
     return o.get_hash();
   }

--- a/include/camp/resource/sycl.hpp
+++ b/include/camp/resource/sycl.hpp
@@ -14,8 +14,8 @@
 
 #ifdef CAMP_ENABLE_SYCL
 
-#include <cstddef>
 #include <array>
+#include <cstddef>
 #include <map>
 #include <mutex>
 #include <sycl/sycl.hpp>
@@ -49,9 +49,7 @@ namespace resources
     class SyclEvent
     {
     public:
-      explicit SyclEvent(sycl::event e)
-        : m_event(std::move(e))
-      {}
+      explicit SyclEvent(sycl::event e) : m_event(std::move(e)) {}
 
       // TODO: see what overhead an empty submit has
       explicit SyclEvent(sycl::queue& qu)
@@ -77,10 +75,10 @@ namespace resources
       bool check() const
       {
         return m_event.get_info<sycl::info::event::command_execution_status>()
-            == sycl::info::event_command_status::complete;
+               == sycl::info::event_command_status::complete;
       }
 
-      void wait() const { m_event.wait(); } // sycl::event::wait is non-const
+      void wait() const { m_event.wait(); }  // sycl::event::wait is non-const
 
       sycl::event& getSyclEvent_t() { return m_event; }
 
@@ -92,7 +90,8 @@ namespace resources
        *
        * \return True if both refer to equivalent sycl events, false otherwise.
        */
-      friend inline bool operator==(SyclEvent const& lhs, SyclEvent const& rhs) = default;
+      friend inline bool operator==(SyclEvent const& lhs,
+                                    SyclEvent const& rhs) = default;
 
       size_t get_hash() const
       {
@@ -102,7 +101,7 @@ namespace resources
       }
 
     private:
-      mutable sycl::event m_event; // mutable as use non-const member function
+      mutable sycl::event m_event;  // mutable as use non-const member function
     };
 
     class Sycl
@@ -321,9 +320,8 @@ namespace resources
 
       void wait_for(SyclEvent const& e)
       {
-        qu.submit([&](::sycl::handler& h) {
-          h.depends_on(e.getSyclEvent_t());
-        });
+        qu.submit(
+            [&](::sycl::handler& h) { h.depends_on(e.getSyclEvent_t()); });
       }
 
       void wait_for(Event const& e)

--- a/include/camp/tuple.hpp
+++ b/include/camp/tuple.hpp
@@ -789,7 +789,8 @@ struct tuple_size<camp::tagged_tuple<TagList, Elements...>> {
 
 template <size_t i, typename TagList, typename... Elements>
 struct tuple_element<i, camp::tagged_tuple<TagList, Elements...>> {
-  using type = camp::at_v<typename camp::tagged_tuple<TagList, Elements...>::TList, i>;
+  using type =
+      camp::at_v<typename camp::tagged_tuple<TagList, Elements...>::TList, i>;
 };
 }  // namespace std
 

--- a/src/errors.cpp
+++ b/src/errors.cpp
@@ -15,15 +15,15 @@
 namespace camp
 {
 
-void throw_re(const char *s) { throw std::runtime_error(s); }
+void throw_re(const char* s) { throw std::runtime_error(s); }
 
-void throw_re(std::string const &s) { throw std::runtime_error(s); }
+void throw_re(std::string const& s) { throw std::runtime_error(s); }
 
 #ifdef CAMP_ENABLE_CUDA
 
 cudaError_t cudaAssert(cudaError_t code,
-                       const char *call,
-                       const char *file,
+                       const char* call,
+                       const char* file,
                        int line)
 {
   if (code != cudaSuccess && code != cudaErrorNotReady) {
@@ -46,8 +46,8 @@ cudaError_t cudaAssert(cudaError_t code,
 #ifdef CAMP_ENABLE_HIP
 
 hipError_t hipAssert(hipError_t code,
-                     const char *call,
-                     const char *file,
+                     const char* call,
+                     const char* file,
                      int line)
 {
   if (code != hipSuccess && code != hipErrorNotReady) {

--- a/test/append.cpp
+++ b/test/append.cpp
@@ -14,8 +14,10 @@ using namespace camp;
 using list1 = list<float, double, double>;
 using list2 = list<int, int, char>;
 
-CAMP_CHECK_TSAME((append<list1, list2>), (list<float, double, double, list<int, int, char>>));
-CAMP_CHECK_TSAME((append<list2, list1>), (list<int, int, char, list<float, double, double>>));
+CAMP_CHECK_TSAME((append<list1, list2>),
+                 (list<float, double, double, list<int, int, char>>));
+CAMP_CHECK_TSAME((append<list2, list1>),
+                 (list<int, int, char, list<float, double, double>>));
 
 CAMP_CHECK_TSAME((append<list<int>, int>), (list<int, int>));
 CAMP_CHECK_TSAME((append<list1, int>), (list<float, double, double, int>));

--- a/test/array.cpp
+++ b/test/array.cpp
@@ -8,9 +8,9 @@
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 
 #include "camp/array.hpp"
-#include "camp/tuple.hpp"
 
 #include "Test.hpp"
+#include "camp/tuple.hpp"
 #include "gtest/gtest.h"
 
 CAMP_TEST_BEGIN(array, initialize)
@@ -370,10 +370,12 @@ CAMP_TEST_BEGIN(array, apply)
   camp::array<int, 2> a{-1, 1};
   int a0 = 0;
   int a1 = 0;
-  camp::apply([&](int i0, int i1){
-    a0 = i0;
-    a1 = i1;
-  }, a);
+  camp::apply(
+      [&](int i0, int i1) {
+        a0 = i0;
+        a1 = i1;
+      },
+      a);
 
   return a0 == -1 && a1 == 1 && a[0] == -1 && a[1] == 1;
 }

--- a/test/extend.cpp
+++ b/test/extend.cpp
@@ -14,8 +14,10 @@ using namespace camp;
 using list1 = list<float, double, double>;
 using list2 = list<int, int, char>;
 
-CAMP_CHECK_TSAME((extend<list1, list2>), (list<float, double, double, int, int, char>));
-CAMP_CHECK_TSAME((extend<list2, list1>), (list<int, int, char, float, double, double>));
+CAMP_CHECK_TSAME((extend<list1, list2>),
+                 (list<float, double, double, int, int, char>));
+CAMP_CHECK_TSAME((extend<list2, list1>),
+                 (list<int, int, char, float, double, double>));
 CAMP_CHECK_TSAME((extend<list<int>, list<int>>), (list<int, int>));
 CAMP_CHECK_TSAME((extend<list<char, float>, list<>>), (list<char, float>));
 CAMP_CHECK_TSAME((extend<list<>, list<char, float>>), (list<char, float>));

--- a/test/prepend.cpp
+++ b/test/prepend.cpp
@@ -14,8 +14,10 @@ using namespace camp;
 using list1 = list<float, double, double>;
 using list2 = list<int, int, char>;
 
-CAMP_CHECK_TSAME((prepend<list1, list2>), (list<list<int, int, char>, float, double, double>));
-CAMP_CHECK_TSAME((prepend<list2, list1>), (list<list<float, double, double>, int, int, char>));
+CAMP_CHECK_TSAME((prepend<list1, list2>),
+                 (list<list<int, int, char>, float, double, double>));
+CAMP_CHECK_TSAME((prepend<list2, list1>),
+                 (list<list<float, double, double>, int, int, char>));
 
 CAMP_CHECK_TSAME((prepend<list<int>, int>), (list<int, int>));
 CAMP_CHECK_TSAME((prepend<list1, int>), (list<int, float, double, double>));

--- a/test/resource.cpp
+++ b/test/resource.cpp
@@ -20,6 +20,7 @@ using namespace camp::resources;
 // compatible but different resource for conversion test
 struct Host2 : Host {
 };
+
 struct HostEvent2 : HostEvent {
 };
 #ifdef CAMP_HAVE_CUDA
@@ -46,15 +47,18 @@ namespace resources
   template <>
   struct is_concrete_resource_impl<Host2> : std::true_type {
   };
+
   template <>
   struct is_concrete_event_impl<HostEvent2> : std::true_type {
   };
 }  // namespace resources
 }  // namespace camp
 
-struct NotAResource { };
+struct NotAResource {
+};
 
-struct NotAnEvent { };
+struct NotAnEvent {
+};
 
 template <typename Res>
 void test_construct()
@@ -394,23 +398,23 @@ TEST(CampEvent, MoveAssignment)
 
 TEST(CampPlatform, ResourceFromPlatform)
 {
-  ASSERT_TRUE((std::is_same_v<resource_from_platform<Platform::host>::type,
-                              Host>));
+  ASSERT_TRUE(
+      (std::is_same_v<resource_from_platform<Platform::host>::type, Host>));
 #ifdef CAMP_HAVE_CUDA
-  ASSERT_TRUE((std::is_same_v<resource_from_platform<Platform::cuda>::type,
-                              Cuda>));
+  ASSERT_TRUE(
+      (std::is_same_v<resource_from_platform<Platform::cuda>::type, Cuda>));
 #endif
 #ifdef CAMP_HAVE_HIP
-  ASSERT_TRUE((std::is_same_v<resource_from_platform<Platform::hip>::type,
-                              Hip>));
+  ASSERT_TRUE(
+      (std::is_same_v<resource_from_platform<Platform::hip>::type, Hip>));
 #endif
 #ifdef CAMP_HAVE_OMP_OFFLOAD
-  ASSERT_TRUE(
-      (std::is_same_v<resource_from_platform<Platform::omp_target>::type, Omp>));
+  ASSERT_TRUE((
+      std::is_same_v<resource_from_platform<Platform::omp_target>::type, Omp>));
 #endif
 #ifdef CAMP_HAVE_SYCL
-  ASSERT_TRUE((std::is_same_v<resource_from_platform<Platform::sycl>::type,
-                              Sycl>));
+  ASSERT_TRUE(
+      (std::is_same_v<resource_from_platform<Platform::sycl>::type, Sycl>));
 #endif
 }
 
@@ -704,7 +708,8 @@ TEST(CampResource, UnorderedMapKey)
 
 struct ref_hash {
   template <typename T>
-  std::size_t operator()(std::reference_wrapper<T> const& ref) const {
+  std::size_t operator()(std::reference_wrapper<T> const& ref) const
+  {
     return std::hash<T>()(ref.get());
   }
 };
@@ -712,7 +717,8 @@ struct ref_hash {
 struct ref_equal {
   template <typename T>
   bool operator()(std::reference_wrapper<T> const& lhs,
-                  std::reference_wrapper<T> const& rhs) const {
+                  std::reference_wrapper<T> const& rhs) const
+  {
     return lhs.get() == rhs.get();
   }
 };
@@ -731,7 +737,8 @@ void test_map_key(Event& he)
   erased_event_ref d1(d1_);
   erased_event_ref d2(d2_);
   std::unordered_map<erased_event_ref, size_t, ref_hash, ref_equal> map;
-  std::unordered_multimap<erased_event_ref, size_t, ref_hash, ref_equal> multimap;
+  std::unordered_multimap<erased_event_ref, size_t, ref_hash, ref_equal>
+      multimap;
 
   // Typed
   typed_event e1_ = Res().get_event();
@@ -739,7 +746,8 @@ void test_map_key(Event& he)
   typed_event_ref e1(e1_);
   typed_event_ref e2(e2_);
   std::unordered_map<typed_event_ref, size_t, ref_hash, ref_equal> rmap;
-  std::unordered_multimap<typed_event_ref, size_t, ref_hash, ref_equal> rmultimap;
+  std::unordered_multimap<typed_event_ref, size_t, ref_hash, ref_equal>
+      rmultimap;
 
   // Generic
   map.emplace(he, 10);
@@ -974,7 +982,6 @@ TEST(CampResource, GetDefault)
 #endif
 }
 
-
 template <typename Res>
 void test_id_compare(Event& he)
 {
@@ -1164,8 +1171,8 @@ template <typename Res>
 void test_get()
 {
   const Resource dev_res{Res()};
-  static_assert(std::is_same_v<decltype(dev_res.template get<Res>()),
-                               const Res&>);
+  static_assert(
+      std::is_same_v<decltype(dev_res.template get<Res>()), const Res&>);
   const auto& erased_res = dev_res.get<Res>();
   Res pure_res;
   ASSERT_EQ(typeid(erased_res), typeid(pure_res));
@@ -1320,9 +1327,8 @@ void test_get_const_typed_event(EventArgs&&... eventArgs)
   static_assert(
       std::is_same_v<decltype(erased_event.template try_get<ResEvent>()),
                      const ResEvent*>);
-  static_assert(
-      std::is_same_v<decltype(erased_event.template get<ResEvent>()),
-                     const ResEvent&>);
+  static_assert(std::is_same_v<decltype(erased_event.template get<ResEvent>()),
+                               const ResEvent&>);
 
   const ResEvent* typed_event_ptr = erased_event.template try_get<ResEvent>();
   ASSERT_NE(typed_event_ptr, nullptr);
@@ -1531,8 +1537,10 @@ void test_event_check()
   const auto typed_event = r.get_event();
   const Event event = r.get_event_erased();
   // checking in a loop should always eventually return true
-  while (!typed_event.check()) {}
-  while (!event.check()) {}
+  while (!typed_event.check()) {
+  }
+  while (!event.check()) {
+  }
 }
 
 //
@@ -1562,6 +1570,7 @@ void test_concrete_resource_trait()
   ASSERT_TRUE(is_concrete_resource<const Res&>::value);
   ASSERT_TRUE(is_concrete_resource<Res&&>::value);
 }
+
 //
 TEST(CampResource, ConcreteResourceTypeTrait)
 {
@@ -1605,6 +1614,7 @@ void test_concrete_event_trait()
   ASSERT_TRUE(is_concrete_event<const Evt&>::value);
   ASSERT_TRUE(is_concrete_event<Evt&&>::value);
 }
+
 //
 TEST(CampEvent, ConcreteEventTypeTrait)
 {
@@ -1714,10 +1724,7 @@ void test_inferred_deallocate(MemoryAccess access)
   r.deallocate(ptr);
 }
 
-TEST(CampResource, MemoryHost)
-{
-  test_memory_ops<Host>(MemoryAccess::Device);
-}
+TEST(CampResource, MemoryHost) { test_memory_ops<Host>(MemoryAccess::Device); }
 
 #ifdef CAMP_HAVE_CUDA
 TEST(CampResource, MemoryCuda)
@@ -1748,10 +1755,7 @@ TEST(CampResource, MemoryHip)
 #endif
 
 #ifdef CAMP_HAVE_OMP_OFFLOAD
-TEST(CampResource, MemoryOmp)
-{
-  test_memory_ops<Omp>(MemoryAccess::Device);
-}
+TEST(CampResource, MemoryOmp) { test_memory_ops<Omp>(MemoryAccess::Device); }
 #endif
 
 #ifdef CAMP_HAVE_SYCL

--- a/test/tuple.cpp
+++ b/test/tuple.cpp
@@ -13,27 +13,26 @@
 #include "gtest/gtest.h"
 
 static_assert(
-    std::is_same<camp::tuple<int &, int const &, int>,
+    std::is_same<camp::tuple<int&, int const&, int>,
                  decltype(camp::tuple_cat_pair(
-                     camp::val<camp::tuple<int &>>(),
-                     camp::val<camp::tuple<int const &, int>>()))>::value,
+                     camp::val<camp::tuple<int&>>(),
+                     camp::val<camp::tuple<int const&, int>>()))>::value,
     "tuple_cat pair nuking refs");
 
 static_assert(
-    std::is_same<camp::tuple<int &&, int const &&, int>,
+    std::is_same<camp::tuple<int&&, int const&&, int>,
                  decltype(camp::tuple_cat_pair(
-                     camp::val<camp::tuple<int &&>>(),
-                     camp::val<camp::tuple<int const &&, int>>()))>::value,
+                     camp::val<camp::tuple<int&&>>(),
+                     camp::val<camp::tuple<int const&&, int>>()))>::value,
     "tuple_cat pair nuking rvalue refs");
 
-static_assert(
-    std::is_same<
-        camp::tuple<int &, int const &, int &&, int const &&>,
-        decltype(camp::forward_as_tuple(camp::val<int &>(),
-                                        camp::val<int const &>(),
-                                        camp::val<int &&>(),
-                                        camp::val<int const &&>()))>::value,
-    "forward_as_tuple nuking refs");
+static_assert(std::is_same<camp::tuple<int&, int const&, int&&, int const&&>,
+                           decltype(camp::forward_as_tuple(
+                               camp::val<int&>(),
+                               camp::val<int const&>(),
+                               camp::val<int&&>(),
+                               camp::val<int const&&>()))>::value,
+              "forward_as_tuple nuking refs");
 
 #define CAMP_TEST_TUPLE_GET_REFS(GET_REF, TYPE_REF, TUPLE_REF)            \
   static_assert(                                                          \
@@ -71,106 +70,106 @@ static_assert(
 
 CAMP_TEST_TUPLE_GET_REFS(&, , &)
 CAMP_TEST_TUPLE_GET_REFS(&&, , &&)
-CAMP_TEST_TUPLE_GET_REFS(const &, , const &)
-CAMP_TEST_TUPLE_GET_REFS(const &&, , const &&)
+CAMP_TEST_TUPLE_GET_REFS(const&, , const&)
+CAMP_TEST_TUPLE_GET_REFS(const&&, , const&&)
 
 CAMP_TEST_TUPLE_GET_REFS(&, &, &)
 CAMP_TEST_TUPLE_GET_REFS(&, &, &&)
-CAMP_TEST_TUPLE_GET_REFS(&, &, const &)
-CAMP_TEST_TUPLE_GET_REFS(&, &, const &&)
+CAMP_TEST_TUPLE_GET_REFS(&, &, const&)
+CAMP_TEST_TUPLE_GET_REFS(&, &, const&&)
 
-CAMP_TEST_TUPLE_GET_REFS(const &, const &, &)
-CAMP_TEST_TUPLE_GET_REFS(const &, const &, &&)
-CAMP_TEST_TUPLE_GET_REFS(const &, const &, const &)
-CAMP_TEST_TUPLE_GET_REFS(const &, const &, const &&)
+CAMP_TEST_TUPLE_GET_REFS(const&, const&, &)
+CAMP_TEST_TUPLE_GET_REFS(const&, const&, &&)
+CAMP_TEST_TUPLE_GET_REFS(const&, const&, const&)
+CAMP_TEST_TUPLE_GET_REFS(const&, const&, const&&)
 
 CAMP_TEST_TUPLE_GET_REFS(&, &&, &)
 CAMP_TEST_TUPLE_GET_REFS(&&, &&, &&)
-CAMP_TEST_TUPLE_GET_REFS(&, &&, const &)
-CAMP_TEST_TUPLE_GET_REFS(&&, &&, const &&)
+CAMP_TEST_TUPLE_GET_REFS(&, &&, const&)
+CAMP_TEST_TUPLE_GET_REFS(&&, &&, const&&)
 
-CAMP_TEST_TUPLE_GET_REFS(const &, const &&, &)
-CAMP_TEST_TUPLE_GET_REFS(const &&, const &&, &&)
-CAMP_TEST_TUPLE_GET_REFS(const &, const &&, const &)
-CAMP_TEST_TUPLE_GET_REFS(const &&, const &&, const &&)
+CAMP_TEST_TUPLE_GET_REFS(const&, const&&, &)
+CAMP_TEST_TUPLE_GET_REFS(const&&, const&&, &&)
+CAMP_TEST_TUPLE_GET_REFS(const&, const&&, const&)
+CAMP_TEST_TUPLE_GET_REFS(const&&, const&&, const&&)
 
 
 CAMP_TEST_TUPLE_GET_T_REFS(&, , &)
 CAMP_TEST_TUPLE_GET_T_REFS(&&, , &&)
-CAMP_TEST_TUPLE_GET_T_REFS(const &, , const &)
-CAMP_TEST_TUPLE_GET_T_REFS(const &&, , const &&)
+CAMP_TEST_TUPLE_GET_T_REFS(const&, , const&)
+CAMP_TEST_TUPLE_GET_T_REFS(const&&, , const&&)
 
 CAMP_TEST_TUPLE_GET_T_REFS(&, &, &)
 CAMP_TEST_TUPLE_GET_T_REFS(&, &, &&)
-CAMP_TEST_TUPLE_GET_T_REFS(&, &, const &)
-CAMP_TEST_TUPLE_GET_T_REFS(&, &, const &&)
+CAMP_TEST_TUPLE_GET_T_REFS(&, &, const&)
+CAMP_TEST_TUPLE_GET_T_REFS(&, &, const&&)
 
-CAMP_TEST_TUPLE_GET_T_REFS(const &, const &, &)
-CAMP_TEST_TUPLE_GET_T_REFS(const &, const &, &&)
-CAMP_TEST_TUPLE_GET_T_REFS(const &, const &, const &)
-CAMP_TEST_TUPLE_GET_T_REFS(const &, const &, const &&)
+CAMP_TEST_TUPLE_GET_T_REFS(const&, const&, &)
+CAMP_TEST_TUPLE_GET_T_REFS(const&, const&, &&)
+CAMP_TEST_TUPLE_GET_T_REFS(const&, const&, const&)
+CAMP_TEST_TUPLE_GET_T_REFS(const&, const&, const&&)
 
 CAMP_TEST_TUPLE_GET_T_REFS(&, &&, &)
 CAMP_TEST_TUPLE_GET_T_REFS(&&, &&, &&)
-CAMP_TEST_TUPLE_GET_T_REFS(&, &&, const &)
-CAMP_TEST_TUPLE_GET_T_REFS(&&, &&, const &&)
+CAMP_TEST_TUPLE_GET_T_REFS(&, &&, const&)
+CAMP_TEST_TUPLE_GET_T_REFS(&&, &&, const&&)
 
-CAMP_TEST_TUPLE_GET_T_REFS(const &, const &&, &)
-CAMP_TEST_TUPLE_GET_T_REFS(const &&, const &&, &&)
-CAMP_TEST_TUPLE_GET_T_REFS(const &, const &&, const &)
-CAMP_TEST_TUPLE_GET_T_REFS(const &&, const &&, const &&)
+CAMP_TEST_TUPLE_GET_T_REFS(const&, const&&, &)
+CAMP_TEST_TUPLE_GET_T_REFS(const&&, const&&, &&)
+CAMP_TEST_TUPLE_GET_T_REFS(const&, const&&, const&)
+CAMP_TEST_TUPLE_GET_T_REFS(const&&, const&&, const&&)
 
 
 CAMP_TEST_TAGGED_TUPLE_GET_REFS(&, , &)
 CAMP_TEST_TAGGED_TUPLE_GET_REFS(&&, , &&)
-CAMP_TEST_TAGGED_TUPLE_GET_REFS(const &, , const &)
-CAMP_TEST_TAGGED_TUPLE_GET_REFS(const &&, , const &&)
+CAMP_TEST_TAGGED_TUPLE_GET_REFS(const&, , const&)
+CAMP_TEST_TAGGED_TUPLE_GET_REFS(const&&, , const&&)
 
 CAMP_TEST_TAGGED_TUPLE_GET_REFS(&, &, &)
 CAMP_TEST_TAGGED_TUPLE_GET_REFS(&, &, &&)
-CAMP_TEST_TAGGED_TUPLE_GET_REFS(&, &, const &)
-CAMP_TEST_TAGGED_TUPLE_GET_REFS(&, &, const &&)
+CAMP_TEST_TAGGED_TUPLE_GET_REFS(&, &, const&)
+CAMP_TEST_TAGGED_TUPLE_GET_REFS(&, &, const&&)
 
-CAMP_TEST_TAGGED_TUPLE_GET_REFS(const &, const &, &)
-CAMP_TEST_TAGGED_TUPLE_GET_REFS(const &, const &, &&)
-CAMP_TEST_TAGGED_TUPLE_GET_REFS(const &, const &, const &)
-CAMP_TEST_TAGGED_TUPLE_GET_REFS(const &, const &, const &&)
+CAMP_TEST_TAGGED_TUPLE_GET_REFS(const&, const&, &)
+CAMP_TEST_TAGGED_TUPLE_GET_REFS(const&, const&, &&)
+CAMP_TEST_TAGGED_TUPLE_GET_REFS(const&, const&, const&)
+CAMP_TEST_TAGGED_TUPLE_GET_REFS(const&, const&, const&&)
 
 CAMP_TEST_TAGGED_TUPLE_GET_REFS(&, &&, &)
 CAMP_TEST_TAGGED_TUPLE_GET_REFS(&&, &&, &&)
-CAMP_TEST_TAGGED_TUPLE_GET_REFS(&, &&, const &)
-CAMP_TEST_TAGGED_TUPLE_GET_REFS(&&, &&, const &&)
+CAMP_TEST_TAGGED_TUPLE_GET_REFS(&, &&, const&)
+CAMP_TEST_TAGGED_TUPLE_GET_REFS(&&, &&, const&&)
 
-CAMP_TEST_TAGGED_TUPLE_GET_REFS(const &, const &&, &)
-CAMP_TEST_TAGGED_TUPLE_GET_REFS(const &&, const &&, &&)
-CAMP_TEST_TAGGED_TUPLE_GET_REFS(const &, const &&, const &)
-CAMP_TEST_TAGGED_TUPLE_GET_REFS(const &&, const &&, const &&)
+CAMP_TEST_TAGGED_TUPLE_GET_REFS(const&, const&&, &)
+CAMP_TEST_TAGGED_TUPLE_GET_REFS(const&&, const&&, &&)
+CAMP_TEST_TAGGED_TUPLE_GET_REFS(const&, const&&, const&)
+CAMP_TEST_TAGGED_TUPLE_GET_REFS(const&&, const&&, const&&)
 
 
 CAMP_TEST_TAGGED_TUPLE_GET_T_REFS(&, , &)
 CAMP_TEST_TAGGED_TUPLE_GET_T_REFS(&&, , &&)
-CAMP_TEST_TAGGED_TUPLE_GET_T_REFS(const &, , const &)
-CAMP_TEST_TAGGED_TUPLE_GET_T_REFS(const &&, , const &&)
+CAMP_TEST_TAGGED_TUPLE_GET_T_REFS(const&, , const&)
+CAMP_TEST_TAGGED_TUPLE_GET_T_REFS(const&&, , const&&)
 
 CAMP_TEST_TAGGED_TUPLE_GET_T_REFS(&, &, &)
 CAMP_TEST_TAGGED_TUPLE_GET_T_REFS(&, &, &&)
-CAMP_TEST_TAGGED_TUPLE_GET_T_REFS(&, &, const &)
-CAMP_TEST_TAGGED_TUPLE_GET_T_REFS(&, &, const &&)
+CAMP_TEST_TAGGED_TUPLE_GET_T_REFS(&, &, const&)
+CAMP_TEST_TAGGED_TUPLE_GET_T_REFS(&, &, const&&)
 
-CAMP_TEST_TAGGED_TUPLE_GET_T_REFS(const &, const &, &)
-CAMP_TEST_TAGGED_TUPLE_GET_T_REFS(const &, const &, &&)
-CAMP_TEST_TAGGED_TUPLE_GET_T_REFS(const &, const &, const &)
-CAMP_TEST_TAGGED_TUPLE_GET_T_REFS(const &, const &, const &&)
+CAMP_TEST_TAGGED_TUPLE_GET_T_REFS(const&, const&, &)
+CAMP_TEST_TAGGED_TUPLE_GET_T_REFS(const&, const&, &&)
+CAMP_TEST_TAGGED_TUPLE_GET_T_REFS(const&, const&, const&)
+CAMP_TEST_TAGGED_TUPLE_GET_T_REFS(const&, const&, const&&)
 
 CAMP_TEST_TAGGED_TUPLE_GET_T_REFS(&, &&, &)
 CAMP_TEST_TAGGED_TUPLE_GET_T_REFS(&&, &&, &&)
-CAMP_TEST_TAGGED_TUPLE_GET_T_REFS(&, &&, const &)
-CAMP_TEST_TAGGED_TUPLE_GET_T_REFS(&&, &&, const &&)
+CAMP_TEST_TAGGED_TUPLE_GET_T_REFS(&, &&, const&)
+CAMP_TEST_TAGGED_TUPLE_GET_T_REFS(&&, &&, const&&)
 
-CAMP_TEST_TAGGED_TUPLE_GET_T_REFS(const &, const &&, &)
-CAMP_TEST_TAGGED_TUPLE_GET_T_REFS(const &&, const &&, &&)
-CAMP_TEST_TAGGED_TUPLE_GET_T_REFS(const &, const &&, const &)
-CAMP_TEST_TAGGED_TUPLE_GET_T_REFS(const &&, const &&, const &&)
+CAMP_TEST_TAGGED_TUPLE_GET_T_REFS(const&, const&&, &)
+CAMP_TEST_TAGGED_TUPLE_GET_T_REFS(const&&, const&&, &&)
+CAMP_TEST_TAGGED_TUPLE_GET_T_REFS(const&, const&&, const&)
+CAMP_TEST_TAGGED_TUPLE_GET_T_REFS(const&&, const&&, const&&)
 
 // Size tests, ensure that EBO is being applied
 struct A {
@@ -242,17 +241,17 @@ TEST(CampTuple, Assign)
 
 struct MoveOnly {
   MoveOnly() = default;
-  MoveOnly(MoveOnly const &) = delete;
-  MoveOnly(MoveOnly &&) = default;
-  MoveOnly &operator=(MoveOnly const &) = delete;
-  MoveOnly &operator=(MoveOnly &&) = default;
+  MoveOnly(MoveOnly const&) = delete;
+  MoveOnly(MoveOnly&&) = default;
+  MoveOnly& operator=(MoveOnly const&) = delete;
+  MoveOnly& operator=(MoveOnly&&) = default;
 };
 
 TEST(CampTuple, ForwardAsTuple)
 {
   int a, b;
   const int d{7};
-  [](camp::tuple<int &, int &, int &&, MoveOnly &&, int const &&> t) {
+  [](camp::tuple<int&, int&, int&&, MoveOnly&&, int const&&> t) {
     MoveOnly c{camp::get<3>(std::move(t))};
     ASSERT_NE(&c, nullptr);
     ASSERT_EQ(camp::get<2>(t), 5);
@@ -324,7 +323,7 @@ struct NoDefCon {
 
   NoDefCon(int i) : num{i} { (void)num; }
 
-  NoDefCon(NoDefCon const &) = default;
+  NoDefCon(NoDefCon const&) = default;
 
 private:
   int num;
@@ -383,7 +382,7 @@ TEST(CampTuple, StructuredBindingsConst)
 TEST(CampTuple, StructuredBindingsRef)
 {
   auto t = camp::make_tuple(3, 9.9);
-  auto &[a, b] = t;
+  auto& [a, b] = t;
   static_assert(std::is_same<decltype(a), int>::value);     // Not an int &
   static_assert(std::is_same<decltype(b), double>::value);  // Not a double &
   ASSERT_EQ(a, 3);
@@ -398,7 +397,7 @@ TEST(CampTuple, StructuredBindingsRef)
 TEST(CampTuple, StructuredBindingsRefConst)
 {
   auto t = camp::make_tuple(3, 9.9);
-  const auto &[a, b] = t;
+  const auto& [a, b] = t;
   static_assert(
       std::is_same<decltype(a), const int>::value);  // Not an const int &
   static_assert(
@@ -454,7 +453,7 @@ TEST(CampFilterByTypeTrait, MakeFilteredTuple)
                                     OtherType<int>,
                                     SearchType<int>,
                                     camp::tuple<double>>;
-  using ExpectedTupleType = camp::tuple<SearchType<int> &, SearchType<int> &>;
+  using ExpectedTupleType = camp::tuple<SearchType<int>&, SearchType<int>&>;
   auto base_tuple = BaseTupleType{};
   auto filtered_tuple =
       camp::get_refs_to_elements_by_type_trait<IsSearchType>(base_tuple);
@@ -469,7 +468,7 @@ TEST(CampFilterByTypeTrait, SearchTypeAtEnd)
                                     OtherType<int>,
                                     camp::tuple<SearchType<int>>,
                                     SearchType<int>>;
-  using ExpectedTupleType = camp::tuple<SearchType<int> &>;
+  using ExpectedTupleType = camp::tuple<SearchType<int>&>;
   auto base_tuple = BaseTupleType{};
   auto filtered_tuple =
       camp::get_refs_to_elements_by_type_trait<IsSearchType>(base_tuple);
@@ -484,7 +483,7 @@ TEST(CampFilterByTypeTrait, SearchTypeAtStart)
                                     OtherType<SearchType<int>>,
                                     OtherType<int>,
                                     camp::tuple<SearchType<int>>>;
-  using ExpectedTupleType = camp::tuple<SearchType<OtherType<double>> &>;
+  using ExpectedTupleType = camp::tuple<SearchType<OtherType<double>>&>;
   auto base_tuple = BaseTupleType{};
   auto filtered_tuple =
       camp::get_refs_to_elements_by_type_trait<IsSearchType>(base_tuple);
@@ -522,7 +521,7 @@ TEST(CampFilterByTypeTrait, SingletonTuple)
 TEST(CampFilterByTypeTrait, SingletonTupleTwo)
 {
   using BaseTupleType = camp::tuple<SearchType<int>>;
-  using ExpectedTupleType = camp::tuple<SearchType<int> &>;
+  using ExpectedTupleType = camp::tuple<SearchType<int>&>;
   auto base_tuple = BaseTupleType{};
   auto filtered_tuple =
       camp::get_refs_to_elements_by_type_trait<IsSearchType>(base_tuple);
@@ -533,10 +532,10 @@ TEST(CampFilterByTypeTrait, SingletonTupleTwo)
 
 TEST(CampFilterByTypeTrait, UndecayedSearchTypes)
 {
-  using BaseTupleType = camp::tuple<SearchType<OtherType<double>> *,
+  using BaseTupleType = camp::tuple<SearchType<OtherType<double>>*,
                                     SearchType<SearchType<double>>,
                                     OtherType<int>>;
-  using ExpectedTupleType = camp::tuple<SearchType<SearchType<double>> &>;
+  using ExpectedTupleType = camp::tuple<SearchType<SearchType<double>>&>;
   auto base_tuple = BaseTupleType{};
   auto filtered_tuple =
       camp::get_refs_to_elements_by_type_trait<IsSearchType>(base_tuple);


### PR DESCRIPTION
Runs clang-format on all headers and source files. This includes the following folders:
* include
* src
* test

This was using the `camp/.clang-format`