### PR TITLE
Remove macro layer in concepts.hpp

### DIFF
--- a/docs/sphinx/user_guide/feature/concepts.rst
+++ b/docs/sphinx/user_guide/feature/concepts.rst
@@ -1,0 +1,186 @@
+.. ##
+.. ## Copyright (c) Lawrence Livermore National Security, LLC and other
+.. ## Camp Project Developers. See top-level LICENSE and COPYRIGHT
+.. ## files for dates and other details. No copyright assignment is required
+.. ## to contribute to Camp.
+.. ##
+.. ## SPDX-License-Identifier: (BSD-3-Clause)
+.. ##
+
+.. _concepts-label:
+
+=======================
+Concepts and Type Traits
+=======================
+
+Camp provides a small set of C++20 concepts and companion type traits in
+``camp/concepts.hpp``. The concepts are useful in ``requires`` clauses and
+constrained templates, while the traits provide the same checks in
+``std::bool_constant`` form for code that still prefers the traditional
+type-trait style.
+
+All concepts live in ``camp::concepts``. All trait wrappers live in
+``camp::type_traits``.
+
+------------
+Introduction
+------------
+
+The API in ``camp/concepts.hpp`` is organized into a few groups:
+
+* comparison concepts such as ``Comparable`` and ``ComparableTo``
+* numeric concepts such as ``Integral`` and ``FloatingPoint``
+* iterator and range concepts such as ``Iterator`` and ``RandomAccessRange``
+* resource concepts such as ``ConcreteResource`` and ``ConcreteEvent``
+* trait wrappers such as ``is_iterator_v`` and ``is_comparable_to_v``
+
+In general, use the concept form when constraining templates:
+
+.. code-block:: cpp
+
+   template <camp::concepts::RandomAccessRange R>
+   void sort_in_place(R&& range);
+
+Use the trait form when a boolean constant is more convenient:
+
+.. code-block:: cpp
+
+   static_assert(camp::type_traits::is_random_access_range_v<std::vector<int>>);
+
+-------------------
+Comparison Concepts
+-------------------
+
+Camp provides concepts for common comparison operations:
+
+* ``LessThanComparable``
+* ``GreaterThanComparable``
+* ``LessEqualComparable``
+* ``GreaterEqualComparable``
+* ``EqualityComparable``
+* ``ComparableTo<T, U>``
+* ``Comparable<T>``
+
+``ComparableTo<T, U>`` is the most complete comparison check. It requires the
+two types to support all of the standard ordering and equality operators in
+both directions, with results convertible to ``bool``.
+
+.. code-block:: cpp
+
+   struct index_t {
+     int value;
+   };
+
+   inline bool operator<(index_t lhs, index_t rhs) { return lhs.value < rhs.value; }
+   inline bool operator<=(index_t lhs, index_t rhs) { return lhs.value <= rhs.value; }
+   inline bool operator>(index_t lhs, index_t rhs) { return lhs.value > rhs.value; }
+   inline bool operator>=(index_t lhs, index_t rhs) { return lhs.value >= rhs.value; }
+   inline bool operator==(index_t lhs, index_t rhs) { return lhs.value == rhs.value; }
+   inline bool operator!=(index_t lhs, index_t rhs) { return lhs.value != rhs.value; }
+
+   static_assert(camp::concepts::Comparable<index_t>);
+   static_assert(camp::type_traits::is_comparable_v<index_t>);
+
+----------------
+Numeric Concepts
+----------------
+
+Camp forwards a few common numeric classifications into concept form:
+
+* ``FloatingPoint``
+* ``Integral``
+* ``Arithmetic``
+* ``Signed``
+* ``Unsigned``
+
+These are convenient when a template should only accept a narrow category of
+scalar types.
+
+.. code-block:: cpp
+
+   template <camp::concepts::Integral T>
+   constexpr T midpoint(T a, T b)
+   {
+     return a + (b - a) / 2;
+   }
+
+   static_assert(camp::type_traits::is_integral_v<int>);
+   static_assert(!camp::type_traits::is_integral_v<double>);
+
+---------------------------
+Iterator and Range Concepts
+---------------------------
+
+Camp provides iterator and range concepts that are intended to work with the
+project's tuple, array, and resource utilities as well as standard-library
+types.
+
+Iterator concepts:
+
+* ``Iterator``
+* ``ForwardIterator``
+* ``BidirectionalIterator``
+* ``RandomAccessIterator``
+
+Range concepts:
+
+* ``HasBeginEnd``
+* ``Range``
+* ``ForwardRange``
+* ``BidirectionalRange``
+* ``RandomAccessRange``
+
+These are available both as concepts and type traits:
+
+.. code-block:: cpp
+
+   static_assert(camp::concepts::RandomAccessIterator<int*>);
+   static_assert(camp::concepts::RandomAccessRange<std::array<int, 4>>);
+
+   static_assert(camp::type_traits::is_iterator_v<int*>);
+   static_assert(camp::type_traits::is_random_access_range_v<std::array<int, 4>>);
+
+``IterableValue<T>`` and ``IteratorValue<T>`` are helper aliases that recover
+the dereferenced type from a range-like or iterator-like type.
+
+.. code-block:: cpp
+
+   using range_value = camp::type_traits::IterableValue<std::vector<double>>;
+   using iter_value = camp::type_traits::IteratorValue<double*>;
+
+------------------------------------
+Concepts and Type Traits for Camp Resources
+------------------------------------
+
+Camp also exposes concepts and traits for concrete resource and event types:
+
+* ``camp::concepts::ConcreteResource``
+* ``camp::concepts::ConcreteEvent``
+* ``camp::resources::is_concrete_resource<T>``
+* ``camp::resources::is_concrete_resource_v<T>``
+* ``camp::resources::is_concrete_event<T>``
+* ``camp::resources::is_concrete_event_v<T>``
+
+These are primarily used by Camp's resource API to distinguish typed backend
+objects from the generic type-erased wrappers.
+
+.. code-block:: cpp
+
+   template <camp::concepts::ConcreteResource Res>
+   void submit_work(Res&& res);
+
+---------------------------------
+Template Specialization Utilities
+---------------------------------
+
+``camp::type_traits::IsSpecialized`` and ``camp::type_traits::SpecializationOf``
+help with template-pattern matching at compile time.
+
+.. code-block:: cpp
+
+   static_assert(camp::type_traits::IsSpecialized<std::tuple, int, double>::value);
+   static_assert(camp::type_traits::SpecializationOf<std::tuple,
+                                                     std::tuple<int, double>>::value);
+
+These utilities are useful when a template should accept "any specialization of
+template X" rather than a single concrete instantiation.

--- a/docs/sphinx/user_guide/features.rst
+++ b/docs/sphinx/user_guide/features.rst
@@ -27,6 +27,7 @@ For more information about specific Camp features, visit the pages below.
   :maxdepth: 3
 
   feature/array
+  feature/concepts
   feature/list
   feature/resource
   feature/number

--- a/include/camp/concepts.hpp
+++ b/include/camp/concepts.hpp
@@ -312,6 +312,7 @@ namespace type_traits
   template <class T>
   struct is_iterator : std::bool_constant<camp::concepts::Iterator<T>> {
   };
+
   /// Convenience variable template for `is_iterator<T>::value`.
   template <class T>
   inline constexpr bool is_iterator_v = is_iterator<T>::value;
@@ -321,6 +322,7 @@ namespace type_traits
   struct is_forward_iterator
       : std::bool_constant<camp::concepts::ForwardIterator<T>> {
   };
+
   /// Convenience variable template for `is_forward_iterator<T>::value`.
   template <class T>
   inline constexpr bool is_forward_iterator_v = is_forward_iterator<T>::value;
@@ -330,6 +332,7 @@ namespace type_traits
   struct is_bidirectional_iterator
       : std::bool_constant<camp::concepts::BidirectionalIterator<T>> {
   };
+
   /// Convenience variable template for `is_bidirectional_iterator<T>::value`.
   template <class T>
   inline constexpr bool is_bidirectional_iterator_v =
@@ -340,6 +343,7 @@ namespace type_traits
   struct is_random_access_iterator
       : std::bool_constant<camp::concepts::RandomAccessIterator<T>> {
   };
+
   /// Convenience variable template for `is_random_access_iterator<T>::value`.
   template <class T>
   inline constexpr bool is_random_access_iterator_v =
@@ -349,6 +353,7 @@ namespace type_traits
   template <class T>
   struct is_range : std::bool_constant<camp::concepts::Range<T>> {
   };
+
   /// Convenience variable template for `is_range<T>::value`.
   template <class T>
   inline constexpr bool is_range_v = is_range<T>::value;
@@ -358,6 +363,7 @@ namespace type_traits
   struct is_forward_range
       : std::bool_constant<camp::concepts::ForwardRange<T>> {
   };
+
   /// Convenience variable template for `is_forward_range<T>::value`.
   template <class T>
   inline constexpr bool is_forward_range_v = is_forward_range<T>::value;
@@ -367,6 +373,7 @@ namespace type_traits
   struct is_bidirectional_range
       : std::bool_constant<camp::concepts::BidirectionalRange<T>> {
   };
+
   /// Convenience variable template for `is_bidirectional_range<T>::value`.
   template <class T>
   inline constexpr bool is_bidirectional_range_v =
@@ -377,6 +384,7 @@ namespace type_traits
   struct is_random_access_range
       : std::bool_constant<camp::concepts::RandomAccessRange<T>> {
   };
+
   /// Convenience variable template for `is_random_access_range<T>::value`.
   template <class T>
   inline constexpr bool is_random_access_range_v =
@@ -386,6 +394,7 @@ namespace type_traits
   template <class T>
   struct is_comparable : std::bool_constant<camp::concepts::Comparable<T>> {
   };
+
   /// Convenience variable template for `is_comparable<T>::value`.
   template <class T>
   inline constexpr bool is_comparable_v = is_comparable<T>::value;
@@ -394,6 +403,7 @@ namespace type_traits
   template <class T>
   struct is_arithmetic : std::bool_constant<camp::concepts::Arithmetic<T>> {
   };
+
   /// Convenience variable template for `is_arithmetic<T>::value`.
   template <class T>
   inline constexpr bool is_arithmetic_v = is_arithmetic<T>::value;
@@ -403,6 +413,7 @@ namespace type_traits
   struct is_floating_point
       : std::bool_constant<camp::concepts::FloatingPoint<T>> {
   };
+
   /// Convenience variable template for `is_floating_point<T>::value`.
   template <class T>
   inline constexpr bool is_floating_point_v = is_floating_point<T>::value;
@@ -411,6 +422,7 @@ namespace type_traits
   template <class T>
   struct is_integral : std::bool_constant<camp::concepts::Integral<T>> {
   };
+
   /// Convenience variable template for `is_integral<T>::value`.
   template <class T>
   inline constexpr bool is_integral_v = is_integral<T>::value;
@@ -419,6 +431,7 @@ namespace type_traits
   template <class T>
   struct is_signed : std::bool_constant<camp::concepts::Signed<T>> {
   };
+
   /// Convenience variable template for `is_signed<T>::value`.
   template <class T>
   inline constexpr bool is_signed_v = is_signed<T>::value;
@@ -427,6 +440,7 @@ namespace type_traits
   template <class T>
   struct is_unsigned : std::bool_constant<camp::concepts::Unsigned<T>> {
   };
+
   /// Convenience variable template for `is_unsigned<T>::value`.
   template <class T>
   inline constexpr bool is_unsigned_v = is_unsigned<T>::value;
@@ -436,6 +450,7 @@ namespace type_traits
   struct is_comparable_to
       : std::bool_constant<camp::concepts::ComparableTo<T, U>> {
   };
+
   /// Convenience variable template for `is_comparable_to<T, U>::value`.
   template <class T, class U>
   inline constexpr bool is_comparable_to_v = is_comparable_to<T, U>::value;

--- a/include/camp/concepts.hpp
+++ b/include/camp/concepts.hpp
@@ -166,34 +166,41 @@ namespace concepts
   struct requires_ : detail::detected<Op, detail::TL<Args...>> {
   };
 
+  /// Matches types that satisfy `std::swappable`.
   template <typename T>
   concept Swappable = std::swappable<T>;
 
+  /// Matches types that support `lhs < rhs`.
   template <typename T>
   concept LessThanComparable = requires(T arg) {
     { arg < arg } -> std::convertible_to<bool>;
   };
 
+  /// Matches types that support `lhs > rhs`.
   template <typename T>
   concept GreaterThanComparable = requires(T arg) {
     { arg > arg } -> std::convertible_to<bool>;
   };
 
+  /// Matches types that support `lhs <= rhs`.
   template <typename T>
   concept LessEqualComparable = requires(T arg) {
     { arg <= arg } -> std::convertible_to<bool>;
   };
 
+  /// Matches types that support `lhs >= rhs`.
   template <typename T>
   concept GreaterEqualComparable = requires(T arg) {
     { arg >= arg } -> std::convertible_to<bool>;
   };
 
+  /// Matches types that support `lhs == rhs`.
   template <typename T>
   concept EqualityComparable = requires(T arg) {
     { arg == arg } -> std::convertible_to<bool>;
   };
 
+  /// Matches two types that can be ordered and equality-compared with each other.
   template <typename T, typename U>
   concept ComparableTo = requires(T lhs, U rhs) {
     { lhs < rhs } -> std::convertible_to<bool>;
@@ -210,21 +217,27 @@ namespace concepts
     { rhs != lhs } -> std::convertible_to<bool>;
   };
 
+  /// Matches a type that is comparable with itself.
   template <typename T>
   concept Comparable = ComparableTo<T, T>;
 
+  /// Matches floating-point types.
   template <typename T>
   concept FloatingPoint = std::floating_point<T>;
 
+  /// Matches integral types.
   template <typename T>
   concept Integral = std::integral<T>;
 
+  /// Matches arithmetic types.
   template <typename T>
   concept Arithmetic = std::is_arithmetic_v<T>;
 
+  /// Matches signed integral types.
   template <typename T>
   concept Signed = std::signed_integral<T>;
 
+  /// Matches unsigned integral types.
   template <typename T>
   concept Unsigned = std::unsigned_integral<T>;
 
@@ -232,18 +245,21 @@ namespace concepts
   // differs in two important ways.  (1) std::weakly_incrementable requires and
   // iterator be post-incrementable (arg_ref++) (2) std::weakly_incrementable
   // does not requires not Integral
+  /// Matches dereferenceable, pre-incrementable non-integral iterator types.
   template <typename T>
   concept Iterator = !Integral<T> && requires(T arg, T &arg_ref) {
     *arg;
     { ++arg_ref } -> std::same_as<T &>;
   };
 
+  /// Matches iterators that satisfy `Iterator` and support post-increment.
   template <typename T>
   concept ForwardIterator = Iterator<T> && requires(T &arg) {
     arg++;
     *arg++;
   };
 
+  /// Matches iterators that satisfy `ForwardIterator` and support decrement.
   template <typename T>
   concept BidirectionalIterator = ForwardIterator<T> && requires(T &arg) {
     { --arg } -> std::same_as<T &>;
@@ -251,6 +267,7 @@ namespace concepts
     *arg--;
   };
 
+  /// Matches iterators that satisfy bidirectional traversal and random access.
   template <typename T>
   concept RandomAccessIterator =
       BidirectionalIterator<T> && Comparable<T>
@@ -269,16 +286,20 @@ namespace concepts
   template <typename T>
   concept HasBeginEnd = std::ranges::range<T>;
 
+  /// Matches ranges whose iterator type satisfies `Iterator`.
   template <typename T>
   concept Range = HasBeginEnd<T> && Iterator<iterator_from<T>>;
 
+  /// Matches ranges whose iterator type satisfies `ForwardIterator`.
   template <typename T>
   concept ForwardRange = HasBeginEnd<T> && ForwardIterator<iterator_from<T>>;
 
+  /// Matches ranges whose iterator type satisfies `BidirectionalIterator`.
   template <typename T>
   concept BidirectionalRange =
       HasBeginEnd<T> && BidirectionalIterator<iterator_from<T>>;
 
+  /// Matches ranges whose iterator type satisfies `RandomAccessIterator`.
   template <typename T>
   concept RandomAccessRange =
       HasBeginEnd<T> && RandomAccessIterator<iterator_from<T>>;
@@ -287,111 +308,143 @@ namespace concepts
 
 namespace type_traits
 {
+  /// Boolean type trait wrapper for `camp::concepts::Iterator`.
   template <class T>
   struct is_iterator : std::bool_constant<camp::concepts::Iterator<T>> {
   };
+  /// Convenience variable template for `is_iterator<T>::value`.
   template <class T>
   inline constexpr bool is_iterator_v = is_iterator<T>::value;
 
+  /// Boolean type trait wrapper for `camp::concepts::ForwardIterator`.
   template <class T>
   struct is_forward_iterator
       : std::bool_constant<camp::concepts::ForwardIterator<T>> {
   };
+  /// Convenience variable template for `is_forward_iterator<T>::value`.
   template <class T>
   inline constexpr bool is_forward_iterator_v = is_forward_iterator<T>::value;
 
+  /// Boolean type trait wrapper for `camp::concepts::BidirectionalIterator`.
   template <class T>
   struct is_bidirectional_iterator
       : std::bool_constant<camp::concepts::BidirectionalIterator<T>> {
   };
+  /// Convenience variable template for `is_bidirectional_iterator<T>::value`.
   template <class T>
   inline constexpr bool is_bidirectional_iterator_v =
       is_bidirectional_iterator<T>::value;
 
+  /// Boolean type trait wrapper for `camp::concepts::RandomAccessIterator`.
   template <class T>
   struct is_random_access_iterator
       : std::bool_constant<camp::concepts::RandomAccessIterator<T>> {
   };
+  /// Convenience variable template for `is_random_access_iterator<T>::value`.
   template <class T>
   inline constexpr bool is_random_access_iterator_v =
       is_random_access_iterator<T>::value;
 
+  /// Boolean type trait wrapper for `camp::concepts::Range`.
   template <class T>
   struct is_range : std::bool_constant<camp::concepts::Range<T>> {
   };
+  /// Convenience variable template for `is_range<T>::value`.
   template <class T>
   inline constexpr bool is_range_v = is_range<T>::value;
 
+  /// Boolean type trait wrapper for `camp::concepts::ForwardRange`.
   template <class T>
   struct is_forward_range
       : std::bool_constant<camp::concepts::ForwardRange<T>> {
   };
+  /// Convenience variable template for `is_forward_range<T>::value`.
   template <class T>
   inline constexpr bool is_forward_range_v = is_forward_range<T>::value;
 
+  /// Boolean type trait wrapper for `camp::concepts::BidirectionalRange`.
   template <class T>
   struct is_bidirectional_range
       : std::bool_constant<camp::concepts::BidirectionalRange<T>> {
   };
+  /// Convenience variable template for `is_bidirectional_range<T>::value`.
   template <class T>
   inline constexpr bool is_bidirectional_range_v =
       is_bidirectional_range<T>::value;
 
+  /// Boolean type trait wrapper for `camp::concepts::RandomAccessRange`.
   template <class T>
   struct is_random_access_range
       : std::bool_constant<camp::concepts::RandomAccessRange<T>> {
   };
+  /// Convenience variable template for `is_random_access_range<T>::value`.
   template <class T>
   inline constexpr bool is_random_access_range_v =
       is_random_access_range<T>::value;
 
+  /// Boolean type trait wrapper for `camp::concepts::Comparable`.
   template <class T>
   struct is_comparable : std::bool_constant<camp::concepts::Comparable<T>> {
   };
+  /// Convenience variable template for `is_comparable<T>::value`.
   template <class T>
   inline constexpr bool is_comparable_v = is_comparable<T>::value;
 
+  /// Boolean type trait wrapper for `camp::concepts::Arithmetic`.
   template <class T>
   struct is_arithmetic : std::bool_constant<camp::concepts::Arithmetic<T>> {
   };
+  /// Convenience variable template for `is_arithmetic<T>::value`.
   template <class T>
   inline constexpr bool is_arithmetic_v = is_arithmetic<T>::value;
 
+  /// Boolean type trait wrapper for `camp::concepts::FloatingPoint`.
   template <class T>
   struct is_floating_point
       : std::bool_constant<camp::concepts::FloatingPoint<T>> {
   };
+  /// Convenience variable template for `is_floating_point<T>::value`.
   template <class T>
   inline constexpr bool is_floating_point_v = is_floating_point<T>::value;
 
+  /// Boolean type trait wrapper for `camp::concepts::Integral`.
   template <class T>
   struct is_integral : std::bool_constant<camp::concepts::Integral<T>> {
   };
+  /// Convenience variable template for `is_integral<T>::value`.
   template <class T>
   inline constexpr bool is_integral_v = is_integral<T>::value;
 
+  /// Boolean type trait wrapper for `camp::concepts::Signed`.
   template <class T>
   struct is_signed : std::bool_constant<camp::concepts::Signed<T>> {
   };
+  /// Convenience variable template for `is_signed<T>::value`.
   template <class T>
   inline constexpr bool is_signed_v = is_signed<T>::value;
 
+  /// Boolean type trait wrapper for `camp::concepts::Unsigned`.
   template <class T>
   struct is_unsigned : std::bool_constant<camp::concepts::Unsigned<T>> {
   };
+  /// Convenience variable template for `is_unsigned<T>::value`.
   template <class T>
   inline constexpr bool is_unsigned_v = is_unsigned<T>::value;
 
+  /// Boolean type trait wrapper for `camp::concepts::ComparableTo`.
   template <class T, class U>
   struct is_comparable_to
       : std::bool_constant<camp::concepts::ComparableTo<T, U>> {
   };
+  /// Convenience variable template for `is_comparable_to<T, U>::value`.
   template <class T, class U>
   inline constexpr bool is_comparable_to_v = is_comparable_to<T, U>::value;
 
+  /// Dereferenced value type from `std::begin(T)`.
   template <typename T>
   using IterableValue = decltype(*std::begin(camp::val<T>()));
 
+  /// Dereferenced value type from an iterator-like type `T`.
   template <typename T>
   using IteratorValue = decltype(*camp::val<T>());
 
@@ -429,9 +482,11 @@ namespace type_traits
   }  // end namespace detail
 
 
+  /// Detects whether `Outer<Args...>` is a valid specialization.
   template <template <class...> class Outer, class... Args>
   using IsSpecialized = detail::IsSpecialized<void, Outer, Args...>;
 
+  /// Checks whether a type is a specialization of the given class template.
   template <template <class...> class, typename T>
   struct SpecializationOf : camp::false_type {
   };
@@ -462,6 +517,7 @@ namespace resources
         : is_concrete_event_impl<typename std::remove_cvref_t<T>> {
     };
 
+    /// Convenience variable template for `is_concrete_event<T>::value`.
     template <typename T>
     inline constexpr bool is_concrete_event_v = is_concrete_event<T>::value;
 
@@ -474,6 +530,7 @@ namespace resources
         : is_concrete_resource_impl<typename std::remove_cvref_t<T>> {
     };
 
+    /// Convenience variable template for `is_concrete_resource<T>::value`.
     template <typename T>
     inline constexpr bool is_concrete_resource_v =
         is_concrete_resource<T>::value;
@@ -484,9 +541,11 @@ namespace resources
 namespace concepts
 {
 
+  /// Matches concrete event types recognized by Camp's resource system.
   template <typename T>
   concept ConcreteEvent = ::camp::resources::is_concrete_event_v<T>;
 
+  /// Matches concrete resource types recognized by Camp's resource system.
   template <typename T>
   concept ConcreteResource = ::camp::resources::is_concrete_resource_v<T>;
 

--- a/include/camp/concepts.hpp
+++ b/include/camp/concepts.hpp
@@ -70,29 +70,6 @@ namespace concepts
 }  // end namespace concepts
 }  // end namespace camp
 
-#define DefineConceptRequires(CONCEPT_NAME, expr) \
-  template <typename T>                           \
-  concept CONCEPT_NAME = requires(T arg) { expr };
-
-#define DefineConceptFromSTL(CONCEPT_NAME, stl_concept) \
-  template <typename T>                                 \
-  concept CONCEPT_NAME = stl_concept;
-
-#define DefineConceptBinaryAnd(CONCEPT_NAME, expr1, expr2) \
-  template <typename T>                                    \
-  concept CONCEPT_NAME = expr1 && expr2;
-
-#define DefineConceptVar(CONCEPT_NAME, ...) \
-  template <typename T>                     \
-  concept CONCEPT_NAME = EXPAND_AND(__VA_ARGS__);
-
-#define DefineTypeTraitFromConcept(TTName, ConceptName) \
-  template <class T>                                    \
-  struct TTName : std::bool_constant<ConceptName<T>> {  \
-  };                                                    \
-  template <class T>                                    \
-  inline constexpr bool TTName##_v = TTName<T>::value;
-
 namespace camp
 {
 namespace concepts
@@ -191,12 +168,33 @@ namespace concepts
 
   // clang-format off
 
-  DefineConceptFromSTL(Swappable, std::swappable<T>)
-  DefineConceptRequires(LessThanComparable, {arg < arg} -> std::convertible_to<bool>; )
-  DefineConceptRequires(GreaterThanComparable, {arg > arg} -> std::convertible_to<bool>; )
-  DefineConceptRequires(LessEqualComparable,  {arg <= arg} -> std::convertible_to<bool>; )
-  DefineConceptRequires(GreaterEqualComparable,  {arg >= arg} -> std::convertible_to<bool>; )
-  DefineConceptRequires(EqualityComparable,  {arg == arg} -> std::convertible_to<bool>; )
+  template <typename T>
+  concept Swappable = std::swappable<T>;
+
+  template <typename T>
+  concept LessThanComparable = requires(T arg) {
+    { arg < arg } -> std::convertible_to<bool>;
+  };
+
+  template <typename T>
+  concept GreaterThanComparable = requires(T arg) {
+    { arg > arg } -> std::convertible_to<bool>;
+  };
+
+  template <typename T>
+  concept LessEqualComparable = requires(T arg) {
+    { arg <= arg } -> std::convertible_to<bool>;
+  };
+
+  template <typename T>
+  concept GreaterEqualComparable = requires(T arg) {
+    { arg >= arg } -> std::convertible_to<bool>;
+  };
+
+  template <typename T>
+  concept EqualityComparable = requires(T arg) {
+    { arg == arg } -> std::convertible_to<bool>;
+  };
 
   template <typename T, typename U>
   concept ComparableTo = requires(T lhs, U rhs) {
@@ -217,30 +215,44 @@ namespace concepts
   template <typename T>
   concept Comparable = ComparableTo<T, T>;
 
-  DefineConceptFromSTL(FloatingPoint, std::floating_point<T>)
-  DefineConceptFromSTL(Integral, std::integral<T>)
-  DefineConceptFromSTL(Arithmetic, std::is_arithmetic_v<T>)
-  DefineConceptFromSTL(Signed, std::signed_integral<T>)
-  DefineConceptFromSTL(Unsigned, std::unsigned_integral<T>)
+  template <typename T>
+  concept FloatingPoint = std::floating_point<T>;
+
+  template <typename T>
+  concept Integral = std::integral<T>;
+
+  template <typename T>
+  concept Arithmetic = std::is_arithmetic_v<T>;
+
+  template <typename T>
+  concept Signed = std::signed_integral<T>;
+
+  template <typename T>
+  concept Unsigned = std::unsigned_integral<T>;
 
   // Note: std::weakly_incrementable is the closest C++ concept to Iterator, but differs
   // in two important ways.  (1) std::weakly_incrementable requires and iterator be
   // post-incrementable (arg_ref++) (2) std::weakly_incrementable does not requires
   // not Integral
-  DefineConceptBinaryAnd(Iterator, !Integral<T>, requires(T arg, T& arg_ref) {
+  template <typename T>
+  concept Iterator = !Integral<T> && requires(T arg, T& arg_ref) {
     *arg;
     { ++arg_ref } -> std::same_as<T&>;
-  })
-  DefineConceptBinaryAnd(ForwardIterator, Iterator<T>, requires(T& arg) {
+  };
+
+  template <typename T>
+  concept ForwardIterator = Iterator<T> && requires(T& arg) {
     arg++;
     *arg++;
-  })
+  };
 
-  DefineConceptBinaryAnd(BidirectionalIterator, ForwardIterator<T>, requires(T& arg) {
+  template <typename T>
+  concept BidirectionalIterator =
+      ForwardIterator<T> && requires(T& arg) {
     { --arg } -> std::same_as<T&>;
     { arg-- } -> std::convertible_to<T const &>;
     *arg--;
-  })
+  };
 
   template<typename T>
   concept RandomAccessIterator =
@@ -261,13 +273,19 @@ namespace concepts
   template <typename T>
   concept HasBeginEnd = std::ranges::range<T>;
 
-  DefineConceptBinaryAnd(Range,  HasBeginEnd<T>, Iterator<iterator_from<T>>)
-  DefineConceptBinaryAnd(ForwardRange,  HasBeginEnd<T>,
-    ForwardIterator<iterator_from<T>>)
-  DefineConceptBinaryAnd(BidirectionalRange,  HasBeginEnd<T>,
-    BidirectionalIterator<iterator_from<T>>)
-  DefineConceptBinaryAnd(RandomAccessRange, HasBeginEnd<T>,
-    RandomAccessIterator<iterator_from<T>>)
+  template <typename T>
+  concept Range = HasBeginEnd<T> && Iterator<iterator_from<T>>;
+
+  template <typename T>
+  concept ForwardRange = HasBeginEnd<T> && ForwardIterator<iterator_from<T>>;
+
+  template <typename T>
+  concept BidirectionalRange =
+      HasBeginEnd<T> && BidirectionalIterator<iterator_from<T>>;
+
+  template <typename T>
+  concept RandomAccessRange =
+      HasBeginEnd<T> && RandomAccessIterator<iterator_from<T>>;
 
   // clang-format on
 
@@ -275,28 +293,100 @@ namespace concepts
 
 namespace type_traits
 {
-  DefineTypeTraitFromConcept(is_iterator, camp::concepts::Iterator);
-  DefineTypeTraitFromConcept(is_forward_iterator,
-                             camp::concepts::ForwardIterator);
-  DefineTypeTraitFromConcept(is_bidirectional_iterator,
-                             camp::concepts::BidirectionalIterator);
-  DefineTypeTraitFromConcept(is_random_access_iterator,
-                             camp::concepts::RandomAccessIterator);
+  template <class T>
+  struct is_iterator : std::bool_constant<camp::concepts::Iterator<T>> {
+  };
+  template <class T>
+  inline constexpr bool is_iterator_v = is_iterator<T>::value;
 
-  DefineTypeTraitFromConcept(is_range, camp::concepts::Range);
-  DefineTypeTraitFromConcept(is_forward_range, camp::concepts::ForwardRange);
-  DefineTypeTraitFromConcept(is_bidirectional_range,
-                             camp::concepts::BidirectionalRange);
-  DefineTypeTraitFromConcept(is_random_access_range,
-                             camp::concepts::RandomAccessRange);
+  template <class T>
+  struct is_forward_iterator
+      : std::bool_constant<camp::concepts::ForwardIterator<T>> {
+  };
+  template <class T>
+  inline constexpr bool is_forward_iterator_v = is_forward_iterator<T>::value;
 
-  DefineTypeTraitFromConcept(is_comparable, camp::concepts::Comparable);
+  template <class T>
+  struct is_bidirectional_iterator
+      : std::bool_constant<camp::concepts::BidirectionalIterator<T>> {
+  };
+  template <class T>
+  inline constexpr bool is_bidirectional_iterator_v =
+      is_bidirectional_iterator<T>::value;
 
-  DefineTypeTraitFromConcept(is_arithmetic, camp::concepts::Arithmetic);
-  DefineTypeTraitFromConcept(is_floating_point, camp::concepts::FloatingPoint);
-  DefineTypeTraitFromConcept(is_integral, camp::concepts::Integral);
-  DefineTypeTraitFromConcept(is_signed, camp::concepts::Signed);
-  DefineTypeTraitFromConcept(is_unsigned, camp::concepts::Unsigned);
+  template <class T>
+  struct is_random_access_iterator
+      : std::bool_constant<camp::concepts::RandomAccessIterator<T>> {
+  };
+  template <class T>
+  inline constexpr bool is_random_access_iterator_v =
+      is_random_access_iterator<T>::value;
+
+  template <class T>
+  struct is_range : std::bool_constant<camp::concepts::Range<T>> {
+  };
+  template <class T>
+  inline constexpr bool is_range_v = is_range<T>::value;
+
+  template <class T>
+  struct is_forward_range
+      : std::bool_constant<camp::concepts::ForwardRange<T>> {
+  };
+  template <class T>
+  inline constexpr bool is_forward_range_v = is_forward_range<T>::value;
+
+  template <class T>
+  struct is_bidirectional_range
+      : std::bool_constant<camp::concepts::BidirectionalRange<T>> {
+  };
+  template <class T>
+  inline constexpr bool is_bidirectional_range_v =
+      is_bidirectional_range<T>::value;
+
+  template <class T>
+  struct is_random_access_range
+      : std::bool_constant<camp::concepts::RandomAccessRange<T>> {
+  };
+  template <class T>
+  inline constexpr bool is_random_access_range_v =
+      is_random_access_range<T>::value;
+
+  template <class T>
+  struct is_comparable : std::bool_constant<camp::concepts::Comparable<T>> {
+  };
+  template <class T>
+  inline constexpr bool is_comparable_v = is_comparable<T>::value;
+
+  template <class T>
+  struct is_arithmetic : std::bool_constant<camp::concepts::Arithmetic<T>> {
+  };
+  template <class T>
+  inline constexpr bool is_arithmetic_v = is_arithmetic<T>::value;
+
+  template <class T>
+  struct is_floating_point
+      : std::bool_constant<camp::concepts::FloatingPoint<T>> {
+  };
+  template <class T>
+  inline constexpr bool is_floating_point_v = is_floating_point<T>::value;
+
+  template <class T>
+  struct is_integral : std::bool_constant<camp::concepts::Integral<T>> {
+  };
+  template <class T>
+  inline constexpr bool is_integral_v = is_integral<T>::value;
+
+  template <class T>
+  struct is_signed : std::bool_constant<camp::concepts::Signed<T>> {
+  };
+  template <class T>
+  inline constexpr bool is_signed_v = is_signed<T>::value;
+
+  template <class T>
+  struct is_unsigned : std::bool_constant<camp::concepts::Unsigned<T>> {
+  };
+  template <class T>
+  inline constexpr bool is_unsigned_v = is_unsigned<T>::value;
 
   template <class T, class U>
   struct is_comparable_to

--- a/include/camp/concepts.hpp
+++ b/include/camp/concepts.hpp
@@ -166,8 +166,6 @@ namespace concepts
   struct requires_ : detail::detected<Op, detail::TL<Args...>> {
   };
 
-  // clang-format off
-
   template <typename T>
   concept Swappable = std::swappable<T>;
 
@@ -230,45 +228,43 @@ namespace concepts
   template <typename T>
   concept Unsigned = std::unsigned_integral<T>;
 
-  // Note: std::weakly_incrementable is the closest C++ concept to Iterator, but differs
-  // in two important ways.  (1) std::weakly_incrementable requires and iterator be
-  // post-incrementable (arg_ref++) (2) std::weakly_incrementable does not requires
-  // not Integral
+  // Note: std::weakly_incrementable is the closest C++ concept to Iterator, but
+  // differs in two important ways.  (1) std::weakly_incrementable requires and
+  // iterator be post-incrementable (arg_ref++) (2) std::weakly_incrementable
+  // does not requires not Integral
   template <typename T>
-  concept Iterator = !Integral<T> && requires(T arg, T& arg_ref) {
+  concept Iterator = !Integral<T> && requires(T arg, T &arg_ref) {
     *arg;
-    { ++arg_ref } -> std::same_as<T&>;
+    { ++arg_ref } -> std::same_as<T &>;
   };
 
   template <typename T>
-  concept ForwardIterator = Iterator<T> && requires(T& arg) {
+  concept ForwardIterator = Iterator<T> && requires(T &arg) {
     arg++;
     *arg++;
   };
 
   template <typename T>
-  concept BidirectionalIterator =
-      ForwardIterator<T> && requires(T& arg) {
-    { --arg } -> std::same_as<T&>;
+  concept BidirectionalIterator = ForwardIterator<T> && requires(T &arg) {
+    { --arg } -> std::same_as<T &>;
     { arg-- } -> std::convertible_to<T const &>;
     *arg--;
   };
 
-  template<typename T>
+  template <typename T>
   concept RandomAccessIterator =
-    BidirectionalIterator<T> &&
-    Comparable<T> &&
-    requires(T arg, T& arg_ref, diff_from<T> increment) {
-        // Reference increment requirements
-        {arg_ref += increment} -> std::same_as<T&>;
-        {arg_ref -= increment} ->std::same_as<T&>;
-        // Value increment requirements
-        {arg + increment} -> std::same_as<T>;
-        {increment + arg} -> std::same_as<T>;
-        {arg - increment} -> std::same_as<T>;
-        // random access index operator
-        arg[increment];
-    };
+      BidirectionalIterator<T> && Comparable<T>
+      && requires(T arg, T &arg_ref, diff_from<T> increment) {
+           // Reference increment requirements
+           { arg_ref += increment } -> std::same_as<T &>;
+           { arg_ref -= increment } -> std::same_as<T &>;
+           // Value increment requirements
+           { arg + increment } -> std::same_as<T>;
+           { increment + arg } -> std::same_as<T>;
+           { arg - increment } -> std::same_as<T>;
+           // random access index operator
+           arg[increment];
+         };
 
   template <typename T>
   concept HasBeginEnd = std::ranges::range<T>;
@@ -286,8 +282,6 @@ namespace concepts
   template <typename T>
   concept RandomAccessRange =
       HasBeginEnd<T> && RandomAccessIterator<iterator_from<T>>;
-
-  // clang-format on
 
 }  // end namespace concepts
 


### PR DESCRIPTION
The macros added more obscurity than benefit and also were messing up clang-format. Also adds documentation for camp concepts and type traits.