### PR TITLE
Fix "get" function call in tuple header to prevent include ordering issues

### DIFF
--- a/include/camp/camp.hpp
+++ b/include/camp/camp.hpp
@@ -21,6 +21,7 @@
 #include "camp/map.hpp"
 #include "camp/number.hpp"
 #include "camp/size.hpp"
+#include "camp/array.hpp"
 #include "camp/tuple.hpp"
 #include "camp/value.hpp"
 

--- a/include/camp/tuple.hpp
+++ b/include/camp/tuple.hpp
@@ -701,7 +701,8 @@ CAMP_HOST_DEVICE constexpr auto invoke_with_order(TupleLike&& tup,
                                                   Fn&& f,
                                                   camp::idx_seq<Sequence...>)
 {
-  return f(::camp::get<Sequence>(std::forward<TupleLike>(tup))...);
+  using ::camp::get;
+  return f(get<Sequence>(std::forward<TupleLike>(tup))...);
 }
 
 CAMP_SUPPRESS_HD_WARN


### PR DESCRIPTION
The current PR makes get<>(...) unqualified in tuple.hpp invoke_with_order to allow ADL to find the right overload for camp::array, regardless of include ordering.  This PR also adds the array header into camp.hpp.