### PR TITLE
Modify GHA builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,16 +28,22 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: recursive
+
+## Back off to version of cmake not on "bleeding edge"
+      - name: Install CMake 3.29
+        uses: lukka/get-cmake@e6906078ebd1ccb8ce51ab4626ac46a1b5a517e3  # v4.4.0
+        with:
+          cmakeVersion: "~3.29.0"
+
       - uses: threeal/cmake-action@v1.3.0
         with:
-          cmake-version: '3.29.x'  # Back off version of cmake with known issue
           build-dir: build
           options:
             CMAKE_CXX_STANDARD=20
             ENABLE_OPENMP=Off
             CMAKE_BUILD_TYPE=Release
           run-build: true
-          build-args: '--parallel 16'
+          build-args: '--parallel 4'
       - uses: threeal/ctest-action@v1.1.0
   build_windows:
     strategy:
@@ -55,9 +61,15 @@ jobs:
           submodules: recursive
 ## ====================================
 ## Config and build action
+
+## Back off to version of cmake not on "bleeding edge"
+      - name: Install CMake 3.29
+        uses: lukka/get-cmake@e6906078ebd1ccb8ce51ab4626ac46a1b5a517e3  # v4.4.0
+        with:
+          cmakeVersion: "~3.29.0"
+
       - uses: threeal/cmake-action@v1.3.0
         with:
-          cmake-version: '3.29.x'  # Back off version of cmake with known issue
           build-dir: build
           options:
             ENABLE_WARNINGS_AS_ERRORS=Off
@@ -66,11 +78,11 @@ jobs:
             CMAKE_BUILD_TYPE=Release
             ${{ matrix.shared.args }}
           run-build: true
-          build-args: '--config Release --parallel 16'
+          build-args: '--config Release --parallel 4'
 ## ====================================
 ## Print the contents of the test directory in the build space (debugging)
 ##    - run: |
-##        dir -r D:\a\RAJA\RAJA\build\test
+##        dir -r D:\a\camp\camp\build\test
 ## ====================================
 ## Run tests action
       - uses: threeal/ctest-action@v1.1.0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,7 +54,12 @@ jobs:
             CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS=On
         - args: BUILD_SHARED_LIBS=Off
 
-    runs-on: windows-latest
+# Notes on Windows CI
+# The windows-2025 runner has converted to Visual Studio (VS) 2026.
+# cmake added VS 2026 support in cmake v4.2, we had issues with cmake 4.4 related to JSON parsing.
+# Testing is currently done on the windows-2022 runner with VS 2022 until the issue can
+# be resolved.
+    runs-on: windows-2022
     steps:
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
- Use proper method to set CMake version for Windows and Mac
- Match parallel build to number of avail cores on GH runners