### PR TITLE
Add Constant Type and Operators

### DIFF
--- a/include/camp/list/list.hpp
+++ b/include/camp/list/list.hpp
@@ -34,7 +34,7 @@ namespace detail
 
   template <typename T, T... Args>
   struct _as_list<int_seq<T, Args...>> {
-    using type = list<integral_constant<T, Args>...>;
+    using type = list<constant<Args>...>;
   };
 }  // namespace detail
 

--- a/include/camp/number.hpp
+++ b/include/camp/number.hpp
@@ -32,43 +32,46 @@ using idx_seq = int_seq<idx_t, vs...>;
 
 namespace detail
 {
-  template <typename T, typename N>
-  struct gen_seq;
-#if CAMP_USE_MAKE_INTEGER_SEQ
   template <typename T, T N>
-  struct gen_seq<T, integral_constant<T, N>> {
+  struct gen_seq;
+
+#if CAMP_USE_MAKE_INTEGER_SEQ
+
+  template <typename T, T N>
+  struct gen_seq {
     using type = __make_integer_seq<int_seq, T, N>;
   };
+
 #elif CAMP_USE_INTEGER_PACK
+
   template <typename T, T N>
-  struct gen_seq<T, integral_constant<T, N>> {
+  struct gen_seq {
     using type = int_seq<T, __integer_pack(N)...>;
   };
+
 #else
+
   template <typename T, typename S1, typename S2>
-  struct concat;
-
+  struct gen_seq_concat;
   template <typename T, T... I1, T... I2>
-  struct concat<T, int_seq<T, I1...>, int_seq<T, I2...>> {
-    using type = typename int_seq<T, I1..., (sizeof...(I1) + I2)...>::type;
+  struct gen_seq_concat<T, int_seq<T, I1...>, int_seq<T, I2...>> {
+    using type = int_seq<T, I1..., (sizeof...(I1) + I2)...>;
   };
 
-  template <typename T, typename N_t>
+  template <typename T>
+  struct gen_seq<T, 0> : int_seq<T> {
+  };
+
+  template <typename T>
+  struct gen_seq<T, 1> : int_seq<T, 0> {
+  };
+
+  template <typename T, T N_t>
   struct gen_seq
-      : concat<T,
-               typename gen_seq<T, integral_constant<T, N_t::value / 2>>::type,
-               typename gen_seq<
-                   T,
-                   integral_constant<T, N_t::value - N_t::value / 2>>::type>::
-            type {
-  };
-
-  template <typename T>
-  struct gen_seq<T, integral_constant<T, 0>> : int_seq<T> {
-  };
-
-  template <typename T>
-  struct gen_seq<T, integral_constant<T, 1>> : int_seq<T, 0> {
+      : gen_seq_concat<T,
+            typename gen_seq<T, N_t / 2>::type,
+            typename gen_seq<T, N_t - N_t / 2>::type
+            >::type {
   };
 #endif
 }  // namespace detail
@@ -77,7 +80,7 @@ namespace detail
 template <idx_t Upper>
 struct make_idx_seq {
   using type =
-      typename detail::gen_seq<idx_t, integral_constant<idx_t, Upper>>::type;
+      typename detail::gen_seq<idx_t, Upper>::type;
 };
 
 // TODO: document
@@ -108,7 +111,7 @@ using idx_seq_from_t = typename idx_seq_from<camp::decay<T>>::type;
 
 // TODO: document
 template <typename T, T Upper>
-struct make_int_seq : detail::gen_seq<T, integral_constant<T, Upper>>::type {
+struct make_int_seq : detail::gen_seq<T, Upper>::type {
 };
 
 // TODO: document

--- a/include/camp/number/number.hpp
+++ b/include/camp/number/number.hpp
@@ -28,6 +28,248 @@ struct integral_constant {
 };
 
 /**
+ * @brief class that represents a compile time constant value.
+ *
+ * Some arithmetic operators are supported for this class so compile-time
+ * arithmetic may be done transparently. In addition, this class is implicitly
+ * convertible to its value type so it is usable in arithmetic with other types.
+ */
+template < auto t_value >
+struct constant
+{
+  using type = constant;
+  using value_type = decltype(t_value);
+  static constexpr value_type value = t_value;
+
+  CAMP_HOST_DEVICE
+  constexpr operator value_type() const noexcept { return value; }
+
+  CAMP_HOST_DEVICE
+  constexpr value_type operator()() const noexcept { return value; }
+};
+
+/**
+ * @brief constant yielding unary plus for a constant value
+ */
+template < auto value >
+CAMP_HOST_DEVICE
+constexpr auto operator+(constant<value>)
+{
+  return constant<+value>{};
+}
+
+/**
+ * @brief constant yielding unary minus for a constant value
+ */
+template < auto value >
+CAMP_HOST_DEVICE
+constexpr auto operator-(constant<value>)
+{
+  return constant<-value>{};
+}
+
+/**
+ * @brief constant yielding bitwise not for a constant value
+ */
+template < auto value >
+CAMP_HOST_DEVICE
+constexpr auto operator~(constant<value>)
+{
+  return constant<~value>{};
+}
+
+/**
+ * @brief constant yielding logical not for a constant value
+ */
+template < auto value >
+CAMP_HOST_DEVICE
+constexpr auto operator!(constant<value>)
+{
+  return constant<!value>{};
+}
+
+/**
+ * @brief constant yielding plus for constant values
+ */
+template < auto lhs_value, auto rhs_value >
+CAMP_HOST_DEVICE
+constexpr auto operator+(constant<lhs_value>, constant<rhs_value>)
+{
+  return constant<lhs_value+rhs_value>{};
+}
+
+/**
+ * @brief constant yielding minus for constant values
+ */
+template < auto lhs_value, auto rhs_value >
+CAMP_HOST_DEVICE
+constexpr auto operator-(constant<lhs_value>, constant<rhs_value>)
+{
+  return constant<lhs_value-rhs_value>{};
+}
+
+/**
+ * @brief constant yielding times for constant values
+ */
+template < auto lhs_value, auto rhs_value >
+CAMP_HOST_DEVICE
+constexpr auto operator*(constant<lhs_value>, constant<rhs_value>)
+{
+  return constant<lhs_value*rhs_value>{};
+}
+
+/**
+ * @brief constant yielding divide for constant values
+ */
+template < auto lhs_value, auto rhs_value >
+CAMP_HOST_DEVICE
+constexpr auto operator/(constant<lhs_value>, constant<rhs_value>)
+{
+  return constant<lhs_value/rhs_value>{};
+}
+
+/**
+ * @brief constant yielding remainder for constant values
+ */
+template < auto lhs_value, auto rhs_value >
+CAMP_HOST_DEVICE
+constexpr auto operator%(constant<lhs_value>, constant<rhs_value>)
+{
+  return constant<lhs_value%rhs_value>{};
+}
+
+/**
+ * @brief constant yielding bitwise and for constant values
+ */
+template < auto lhs_value, auto rhs_value >
+CAMP_HOST_DEVICE
+constexpr auto operator&(constant<lhs_value>, constant<rhs_value>)
+{
+  return constant<lhs_value&rhs_value>{};
+}
+
+/**
+ * @brief constant yielding bitwise or for constant values
+ */
+template < auto lhs_value, auto rhs_value >
+CAMP_HOST_DEVICE
+constexpr auto operator|(constant<lhs_value>, constant<rhs_value>)
+{
+  return constant<lhs_value|rhs_value>{};
+}
+
+/**
+ * @brief constant yielding bitwise xor for constant values
+ */
+template < auto lhs_value, auto rhs_value >
+CAMP_HOST_DEVICE
+constexpr auto operator^(constant<lhs_value>, constant<rhs_value>)
+{
+  return constant<lhs_value^rhs_value>{};
+}
+
+/**
+ * @brief constant yielding left shift for constant values
+ */
+template < auto lhs_value, auto rhs_value >
+CAMP_HOST_DEVICE
+constexpr auto operator<<(constant<lhs_value>, constant<rhs_value>)
+{
+  return constant<(lhs_value<<rhs_value)>{};
+}
+
+/**
+ * @brief constant yielding right shift for constant values
+ */
+template < auto lhs_value, auto rhs_value >
+CAMP_HOST_DEVICE
+constexpr auto operator>>(constant<lhs_value>, constant<rhs_value>)
+{
+  return constant<(lhs_value>>rhs_value)>{};
+}
+
+/**
+ * @brief constant yielding logical and for constant values
+ */
+template < auto lhs_value, auto rhs_value >
+CAMP_HOST_DEVICE
+constexpr auto operator&&(constant<lhs_value>, constant<rhs_value>)
+{
+  return constant<lhs_value&&rhs_value>{};
+}
+
+/**
+ * @brief constant yielding logical or for constant values
+ */
+template < auto lhs_value, auto rhs_value >
+CAMP_HOST_DEVICE
+constexpr auto operator||(constant<lhs_value>, constant<rhs_value>)
+{
+  return constant<lhs_value||rhs_value>{};
+}
+
+/**
+ * @brief constant yielding equals for constant values
+ */
+template < auto lhs_value, auto rhs_value >
+CAMP_HOST_DEVICE
+constexpr auto operator==(constant<lhs_value>, constant<rhs_value>)
+{
+  return constant<lhs_value==rhs_value>{};
+}
+
+/**
+ * @brief constant yielding not equals for constant values
+ */
+template < auto lhs_value, auto rhs_value >
+CAMP_HOST_DEVICE
+constexpr auto operator!=(constant<lhs_value>, constant<rhs_value>)
+{
+  return constant<lhs_value!=rhs_value>{};
+}
+
+/**
+ * @brief constant yielding less than for constant values
+ */
+template < auto lhs_value, auto rhs_value >
+CAMP_HOST_DEVICE
+constexpr auto operator<(constant<lhs_value>, constant<rhs_value>)
+{
+  return constant<(lhs_value<rhs_value)>{};
+}
+
+/**
+ * @brief constant yielding less than equals for constant values
+ */
+template < auto lhs_value, auto rhs_value >
+CAMP_HOST_DEVICE
+constexpr auto operator<=(constant<lhs_value>, constant<rhs_value>)
+{
+  return constant<(lhs_value<=rhs_value)>{};
+}
+
+/**
+ * @brief constant yielding greater than for constant values
+ */
+template < auto lhs_value, auto rhs_value >
+CAMP_HOST_DEVICE
+constexpr auto operator>(constant<lhs_value>, constant<rhs_value>)
+{
+  return constant<(lhs_value>rhs_value)>{};
+}
+
+/**
+ * @brief constant yielding greater than equals for constant values
+ */
+template < auto lhs_value, auto rhs_value >
+CAMP_HOST_DEVICE
+constexpr auto operator>=(constant<lhs_value>, constant<rhs_value>)
+{
+  return constant<(lhs_value>=rhs_value)>{};
+}
+
+
+/**
  * @brief Short-form for a whole number
  *
  * @tparam N The integral value

--- a/include/camp/number/number.hpp
+++ b/include/camp/number/number.hpp
@@ -15,15 +15,24 @@
 namespace camp
 {
 
-// TODO: document, consider making use/match std::integral_constant
+//
+
+/**
+ * @brief class that represents a compile time constant value
+ *
+ * TODO: consider making use/match std::integral_constant
+ */
 template <class NumT, NumT v>
-struct integral_constant {
+struct [[deprecated("use constant<val> instead of integral_constant<T, val>")]]
+       integral_constant {
   static constexpr NumT value = v;
   using value_type = NumT;
   using type = integral_constant;
 
+  CAMP_HOST_DEVICE
   constexpr operator value_type() const noexcept { return value; }
 
+  CAMP_HOST_DEVICE
   constexpr value_type operator()() const noexcept { return value; }
 };
 
@@ -275,7 +284,7 @@ constexpr auto operator>=(constant<lhs_value>, constant<rhs_value>)
  * @tparam N The integral value
  */
 template <idx_t N>
-using num = integral_constant<idx_t, N>;
+using num = constant<N>;
 
 using true_type = num<true>;
 using false_type = num<false>;


### PR DESCRIPTION
Add a constant type that takes a compile-time value as a template parameter. Support arithmetic between constants that produces a constant.

Deprecate integral_constant in favor of constant.

```cpp
constant<0> zero;
constant<1> one;
auto two = one + one;
static_assert(two == 2);
static_assert(std::same_as<decltype(two), constant<2>>);
```

The ultimate goal with this is use it as part of a `RAJA::transparent_range` class that I'm thinking about adding that stores the input begin, end, and stride exactly as they were given. My hope is to improve some cases in RAJAPerf and beyond where the BASE and RAJA differ by knowledge of such exact values. For example we often assume that ranges start at 0 but RAJA ranges always have a runtime begin value, knowledge of which does not cross the host device barrier. This is responsible for some differences between kernel which takes its ranges on the host and launch which takes ranges on the device.