### PR TITLE
Use allocated value for deallocate test

### DIFF
--- a/test/resource.cpp
+++ b/test/resource.cpp
@@ -274,6 +274,8 @@ TEST(CampResource, EmptyBehavior)
   Resource full{Host()};
   Resource sink{std::move(full)};
   int value = 7;
+  Host host;
+  int* allocated_value = host.allocate<int>(1);
 
   CAMP_ALLOW_UNUSED_LOCAL(sink);
 
@@ -294,7 +296,7 @@ TEST(CampResource, EmptyBehavior)
   ASSERT_FALSE(empty.try_get<Host>());
   ASSERT_THROW((void)empty.allocate<int>(1), std::runtime_error);
   ASSERT_THROW((void)empty.calloc(1), std::runtime_error);
-  ASSERT_THROW(empty.deallocate(&value), std::runtime_error);
+  ASSERT_THROW(empty.deallocate(&allocated_value), std::runtime_error);
   ASSERT_THROW(empty.memcpy(&value, &value, 1), std::runtime_error);
   ASSERT_THROW(empty.memset(&value, 0, 1), std::runtime_error);
 
@@ -307,6 +309,8 @@ TEST(CampResource, EmptyBehavior)
   Event host_event = Host().get_event_erased();
   empty.wait_for(empty_event);
   empty.wait_for(host_event);
+
+  host.deallocate(allocated_value);
 }
 
 TEST(CampEvent, EmptyBehavior)

--- a/test/resource.cpp
+++ b/test/resource.cpp
@@ -296,7 +296,7 @@ TEST(CampResource, EmptyBehavior)
   ASSERT_FALSE(empty.try_get<Host>());
   ASSERT_THROW((void)empty.allocate<int>(1), std::runtime_error);
   ASSERT_THROW((void)empty.calloc(1), std::runtime_error);
-  ASSERT_THROW(empty.deallocate(&allocated_value), std::runtime_error);
+  ASSERT_THROW(empty.deallocate(allocated_value), std::runtime_error);
   ASSERT_THROW(empty.memcpy(&value, &value, 1), std::runtime_error);
   ASSERT_THROW(empty.memset(&value, 0, 1), std::runtime_error);
 


### PR DESCRIPTION
Use allocated memory in the empty resource deallocation test.   A non-heap memory ptr (e.g. value) in the deallocation can flag compilation errors on a free of non-heap memory even though in this case the empty allocator will cause an error to be thrown before the free.

Fixes #225 